### PR TITLE
Remove unused CompileError and LimitsExceeded

### DIFF
--- a/src/mini_articraft/errors.py
+++ b/src/mini_articraft/errors.py
@@ -15,11 +15,3 @@ class ValidationError(SDKError):
 
 class ModelError(MiniArticraftError):
     """Raised when the model response cannot be used."""
-
-
-class CompileError(MiniArticraftError):
-    """Raised when generated object code fails to compile."""
-
-
-class LimitsExceeded(MiniArticraftError):
-    """Raised when an agent run exceeds configured limits."""


### PR DESCRIPTION
## Summary

Deletes two exception classes from `errors.py` that are defined but never
raised or imported anywhere in the repo:

- `CompileError`
- `LimitsExceeded`

`SDKError`, `ValidationError`, and `ModelError` are all still in active use
and remain. Pure subtraction, no behavior change.

## Validation (local)

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run pytest -q` — all green except 3 pre-existing failures in
  `test_agent_tools.py` (exec/write_stdin "Event loop is closed") that also
  fail on `main` and are unrelated to this change.

@mattzh72 — small cleanup, would like your review/merge.
