### PR TITLE
Drop unused Record.workspace and Record.entrypoint fields

### DIFF
--- a/src/mini_articraft/record.py
+++ b/src/mini_articraft/record.py
@@ -12,8 +12,6 @@ class Record:
     status: str = "created"
     attempts: int = 0
     error: str = ""
-    workspace: str = "workspace"
-    entrypoint: str = "workspace/main.py"
     result: str = ""
     cost: float = 0.0
     token_usage: dict[str, int] = field(default_factory=dict)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -61,8 +61,6 @@ def run_tests() -> TestReport:
         "status": "success",
         "attempts": 1,
         "error": "",
-        "workspace": "workspace",
-        "entrypoint": "workspace/main.py",
         "result": "result/model.usdz",
         "cost": 0.0,
         "token_usage": {},

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -17,8 +17,6 @@ def test_record_saves_slim_run_summary(tmp_path) -> None:
         "status": "success",
         "attempts": 0,
         "error": "",
-        "workspace": "workspace",
-        "entrypoint": "workspace/main.py",
         "result": "result/model.usdz",
         "cost": 0.0,
         "token_usage": {},


### PR DESCRIPTION
## Summary

Removes two dead fields from the `Record` dataclass:

- `Record.workspace` (constant `"workspace"`)
- `Record.entrypoint` (constant `"workspace/main.py"`)

Both were written into `record.json` via `asdict`, but nothing ever reads
them back. They held fixed defaults the harness never overrode.

Updates the two tests that asserted the full serialized record dict
(`test_record.py`, `test_compile.py`).

Note: the compile-result `entrypoint` key set by `LocalEnvironment`
(`test_compile.py:47`) is a different dict and is left unchanged.

## Validation (local)

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run pytest -q` — 98 passed (3 pre-existing exec/write_stdin failures on
  `main`, "Event loop is closed", unrelated to this change, deselected).

@mattzh72 — small cleanup, would like your review/merge.
