### PR TITLE
Make agent events module docstring an actual docstring

### DIFF
--- a/src/mini_articraft/agent/events.py
+++ b/src/mini_articraft/agent/events.py
@@ -1,8 +1,3 @@
-from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import Any
-
 """Run events emitted by the agent harness.
 
 These are plain, stdlib-only dataclasses so the harness can report progress
@@ -10,6 +5,11 @@ without depending on any UI library. The CLI renderer consumes them; the agent
 core stays free of rich. A consumer dispatches on the event type with
 ``isinstance``.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

The module description in `agent/events.py` was placed *after* the imports, so
Python parsed it as a bare no-op string expression rather than the module
docstring — `events.__doc__` was `None`.

Moves the block above `from __future__ import annotations` (the only statement
allowed before a docstring) so it becomes the real module docstring. No code
behavior change.

## Validation (local)

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `python -c "import ...events"` — `events.__doc__` now populated
- `uv run pytest -q -k "not exec_command and not write_stdin"` — 95 passed
  (the exec/stdin tests are pre-existing flaky async on `main`, unrelated to
  this change — fix coming in a separate PR).

@mattzh72 — trivial docstring fix, would like your review/merge.
