### PR TITLE
Remove unused top-level Agent Protocol

### DIFF
--- a/src/mini_articraft/__init__.py
+++ b/src/mini_articraft/__init__.py
@@ -23,8 +23,4 @@ class Environment(Protocol):
     def compile_path(self, run_dir: Path | str) -> dict[str, Any]: ...
 
 
-class Agent(Protocol):
-    async def run(self, prompt: str, **kwargs: Any) -> dict[str, Any]: ...
-
-
-__all__ = ["Agent", "Environment", "Model", "__version__", "package_dir"]
+__all__ = ["Environment", "Model", "__version__", "package_dir"]


### PR DESCRIPTION
## Summary

Deletes the `Agent` `Protocol` from the package root (`__init__.py`). It was
never imported anywhere and shadowed the real `Agent` class (which lives in
`agent/harness.py` and is re-exported from `agent/__init__.py` — the import
every consumer actually uses).

Removes the class and drops `"Agent"` from `__all__`. `Protocol` and `Any`
stay imported (still used by the `Model` and `Environment` protocols).

## Validation (local)

- `import mini_articraft` works; `from mini_articraft.agent import Agent`
  (the real one) still resolves
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run pytest -q -k "not exec_command and not write_stdin"` — 95 passed
  (exec/stdin tests are pre-existing flaky async, unrelated; fix in a
  separate PR).

@mattzh72 — small cleanup, would like your review/merge.
