### PR TITLE
Run async tests on one session-scoped event loop (fix exec flakiness)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ include = ["mini_articraft*"]
 [tool.setuptools.package-data]
 mini_articraft = ["prompts/*.md", "sdk/docs/common/*.md", "sdk/docs/cadquery/*.md"]
 
+[tool.pytest.ini_options]
+addopts = "-m 'not volume'"
+markers = [
+    "volume: opt-in load/concurrency stress tests (run with `-m volume`)",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def _event_loop():
+    """One event loop for the whole test session.
+
+    The async tests drive coroutines through a small ``run`` helper. Creating
+    and tearing down a fresh loop per call (``asyncio.run``) churns the Unix
+    subprocess child watcher, which intermittently drops exec output or raises
+    "Event loop is closed" on a later test. A single long-lived loop, closed
+    once at the end, keeps that machinery stable.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield loop
+    finally:
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+@pytest.fixture(autouse=True)
+def _use_session_loop(_event_loop):
+    asyncio.set_event_loop(_event_loop)
+    return _event_loop

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -19,7 +19,7 @@ from mini_articraft.record import Record, append_conversation, read_conversation
 
 
 def run(awaitable):
-    return asyncio.run(awaitable)
+    return asyncio.get_event_loop().run_until_complete(awaitable)
 
 
 class FakeModel:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -13,7 +13,7 @@ from mini_articraft.environments.local import LocalEnvironment
 
 
 def run(awaitable):
-    return asyncio.run(awaitable)
+    return asyncio.get_event_loop().run_until_complete(awaitable)
 
 
 def context(tmp_path) -> ToolContext:

--- a/tests/test_exec_volume.py
+++ b/tests/test_exec_volume.py
@@ -1,0 +1,65 @@
+"""Opt-in load test for the exec reactor.
+
+This reproduces the flake that motivated the session-scoped event loop fix:
+under many concurrent/repeated exec calls the subprocess machinery would
+intermittently drop stdout or raise "Event loop is closed". It is a stress and
+regression guard, not part of the default suite.
+
+Run it explicitly:
+
+    uv run pytest -m volume
+
+It is skipped by default (see ``addopts`` in pyproject.toml).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mini_articraft.agent.tools import ToolContext, get
+from mini_articraft.environments.local import LocalEnvironment
+
+SEQUENTIAL_CALLS = 250
+CONCURRENT_BATCH = 60
+
+
+def _run(awaitable):
+    return asyncio.get_event_loop().run_until_complete(awaitable)
+
+
+def _context(tmp_path) -> ToolContext:
+    env = LocalEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("volume")
+    return ToolContext(env, run_dir, run_dir / "workspace")
+
+
+async def _exec(ctx: ToolContext, index: int) -> tuple[int, str]:
+    result = await get("exec_command").run(ctx, {"command": f"printf vol-{index}", "login": False})
+    return index, str(result["stdout"])
+
+
+@pytest.mark.volume
+def test_exec_command_survives_repeated_loop_entries(tmp_path) -> None:
+    """Many separate event-loop entries — the path the flake lived on."""
+    ctx = _context(tmp_path)
+    lost: list[tuple[int, str]] = []
+    for i in range(SEQUENTIAL_CALLS):
+        _, out = _run(_exec(ctx, i))
+        if out != f"vol-{i}":
+            lost.append((i, out))
+    assert not lost, f"{len(lost)}/{SEQUENTIAL_CALLS} exec calls lost output: {lost[:5]}"
+
+
+@pytest.mark.volume
+def test_exec_command_survives_concurrency(tmp_path) -> None:
+    """Many concurrent sessions sharing one loop."""
+    ctx = _context(tmp_path)
+
+    async def drive() -> list[tuple[int, str]]:
+        results = await asyncio.gather(*(_exec(ctx, i) for i in range(CONCURRENT_BATCH)))
+        return [(i, out) for i, out in results if out != f"vol-{i}"]
+
+    lost = _run(drive())
+    assert not lost, f"{len(lost)}/{CONCURRENT_BATCH} exec calls lost output: {lost[:5]}"

--- a/tests/test_openai_model.py
+++ b/tests/test_openai_model.py
@@ -11,7 +11,7 @@ from mini_articraft.settings import Settings, get_settings
 
 
 def run(awaitable):
-    return asyncio.run(awaitable)
+    return asyncio.get_event_loop().run_until_complete(awaitable)
 
 
 def response_event(


### PR DESCRIPTION
## Summary

Fixes the flaky `exec_command` / `write_stdin` tests.

**Root cause:** every async test drove its coroutine through a per-call
`asyncio.run()`, so a fresh event loop was created and torn down repeatedly in
one process. That churns the Unix subprocess child watcher, which
intermittently (a) dropped exec output — empty `stdout`, tests waiting out
their full deadline — or (b) raised `RuntimeError: Event loop is closed` on an
unrelated later test.

**Fix (test-only):** a session-scoped event loop fixture; the three `run()`
helpers now use that one long-lived loop, which is closed once, gracefully
(pending tasks cancelled), at the end. **No production code is touched.**

## Evidence

| | exec/stdin group | full suite (single run) |
|---|---|---|
| `main` | ~50% flaky, some crashes | failed (3 exec failures) |
| this PR | green on normal runs* | 3/3 green (101 passed) |

\* Under artificial load (8 back-to-back `pytest` processes) a residual
platform-level asyncio-subprocess race can still surface; a normal single run
is reliable.

## Validation (local)

- `uv run ruff check .` / `ruff format --check .` — passed
- `uv run pytest -q` — 101 passed, repeatably
- `uv run pytest -W error::DeprecationWarning -k "exec_command or write_stdin"` —
  passed (no `get_event_loop` deprecation)

## Heads up — deeper change coming

This is the quick, contained stabilizer. I'm following up with a deeper
refactor of the exec "reactor" as **stacked PRs**: own exec sessions on
`ToolContext` (removing the module-global `MANAGER`, per AGENTS.md "no hidden
global state"), give `ExecSession` an explicit lifecycle (`aclose`), a
synchronous output buffer, and fast unit tests for the buffer + lifecycle. That
work will supersede the test-side workaround where it overlaps.

@mattzh72 — flake stabilizer, would like your review/merge; deeper refactor to follow.
