### PR TITLE
Assert records as objects instead of serialized dict literals

### DIFF
--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from mini_articraft.environments.local import LocalEnvironment
-from mini_articraft.record import read_conversation
+from mini_articraft.record import Record, read_conversation
 
 
 def write_main(run_dir, code: str) -> None:
@@ -55,16 +55,12 @@ def run_tests() -> TestReport:
     manifest = json.loads(run_dir.joinpath("result", "model.json").read_text())
     assert manifest["name"] == "drawer"
 
-    record = json.loads(run_dir.joinpath("record.json").read_text())
-    assert record == {
-        "run_id": "drawer",
-        "status": "success",
-        "attempts": 1,
-        "error": "",
-        "result": "result/model.usdz",
-        "cost": 0.0,
-        "token_usage": {},
-    }
+    assert Record.load(run_dir / "record.json") == Record(
+        run_id="drawer",
+        status="success",
+        attempts=1,
+        result="result/model.usdz",
+    )
 
     conversation = read_conversation(run_dir / "conversation.jsonl")
     assert conversation == [{"error": "", "role": "compiler", "status": "success"}]

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -9,13 +9,11 @@ from mini_articraft.record import Record, append_conversation, read_conversation
 
 def test_record_saves_slim_run_summary(tmp_path) -> None:
     path = tmp_path / "record.json"
-    record = Record(run_id="run_1", status="success", result="result/model.usdz")
 
-    record.save(path)
+    Record().save(path)
 
-    # Save/load round-trips the whole record via dataclass equality.
-    assert Record.load(path) == record
-    # The on-disk summary stays slim: pin the field set, not every value.
+    # Pin the serialized field set: the record stays a slim summary. Values and
+    # load round-tripping are covered by test_record_round_trips_all_fields.
     assert set(json.loads(path.read_text(encoding="utf-8"))) == {
         "run_id",
         "status",

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from mini_articraft.record import Record, append_conversation, read_conversation
 
 
@@ -14,7 +16,7 @@ def test_record_saves_slim_run_summary(tmp_path) -> None:
     # Save/load round-trips the whole record via dataclass equality.
     assert Record.load(path) == record
     # The on-disk summary stays slim: pin the field set, not every value.
-    assert set(json.loads(path.read_text())) == {
+    assert set(json.loads(path.read_text(encoding="utf-8"))) == {
         "run_id",
         "status",
         "attempts",
@@ -23,6 +25,42 @@ def test_record_saves_slim_run_summary(tmp_path) -> None:
         "cost",
         "token_usage",
     }
+
+
+def test_record_round_trips_all_fields(tmp_path) -> None:
+    path = tmp_path / "record.json"
+    record = Record(
+        run_id="run_9",
+        status="error",
+        attempts=3,
+        error="boom",
+        result="result/model.usdz",
+        cost=1.25,
+        token_usage={"input": 10, "output": 4},
+    )
+
+    record.save(path)
+
+    assert Record.load(path) == record
+
+
+def test_record_load_missing_file_returns_default(tmp_path) -> None:
+    assert Record.load(tmp_path / "absent.json") == Record()
+
+
+def test_record_load_ignores_unknown_keys(tmp_path) -> None:
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps({"run_id": "run_1", "legacy_field": "x"}), encoding="utf-8")
+
+    assert Record.load(path) == Record(run_id="run_1")
+
+
+def test_record_load_rejects_non_object_json(tmp_path) -> None:
+    path = tmp_path / "record.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        Record.load(path)
 
 
 def test_conversation_jsonl_is_append_only(tmp_path) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -11,20 +11,18 @@ def test_record_saves_slim_run_summary(tmp_path) -> None:
 
     record.save(path)
 
-    payload = json.loads(path.read_text())
-    assert payload == {
-        "run_id": "run_1",
-        "status": "success",
-        "attempts": 0,
-        "error": "",
-        "result": "result/model.usdz",
-        "cost": 0.0,
-        "token_usage": {},
+    # Save/load round-trips the whole record via dataclass equality.
+    assert Record.load(path) == record
+    # The on-disk summary stays slim: pin the field set, not every value.
+    assert set(json.loads(path.read_text())) == {
+        "run_id",
+        "status",
+        "attempts",
+        "error",
+        "result",
+        "cost",
+        "token_usage",
     }
-
-    loaded = Record.load(path)
-    assert loaded.run_id == "run_1"
-    assert loaded.status == "success"
 
 
 def test_conversation_jsonl_is_append_only(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Replaces the big `assert payload == {…7 keys…}` dict literals in the record
tests with idiomatic object comparison (dataclass `__eq__`):

- **`test_record.py`** — round-trips the object: `Record.load(path) == record`,
  then pins only the on-disk *field set* (a small key set) so the "slim summary"
  intent is still guarded without restating every value.
- **`test_compile.py`** — compares the loaded record to
  `Record(run_id="drawer", status="success", attempts=1, result="result/model.usdz")`,
  letting dataclass defaults cover `error`/`cost`/`token_usage`.

No behavior change — same guarantees, less brittle, no per-key value map
maintained in two places.

## Validation (local)

- `uv run ruff check .` / `ruff format --check .` — passed
- `uv run pytest -q tests/test_record.py tests/test_compile.py` — 14 passed

@mattzh72 — small test-readability cleanup, would like your review/merge.
