### PR TITLE
Add unit tests for OutputBuffer truncation and ExecSession teardown

### DIFF
--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import os
 import shlex
 import sys
+import time
 
 import pytest
 
@@ -373,6 +375,38 @@ def test_exec_sessions_aclose_logs_cleanup_errors(caplog) -> None:
 
     assert sessions._sessions == {}
     assert "failed to close exec session 7 during run cleanup" in caplog.text
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def test_exec_reaps_detached_descendants_after_exit(tmp_path) -> None:
+    """A command's detached children die with the tracked shell."""
+    ctx = context(tmp_path)
+
+    result = run(
+        get("exec_command").run(
+            ctx,
+            {
+                "command": "nohup sleep 60 >/dev/null 2>&1 & echo $!",
+                "login": False,
+                "yield_time_ms": 2000,
+            },
+        )
+    )
+
+    pid = int(str(result["stdout"]).strip())
+    deadline = time.monotonic() + 5
+    while _process_exists(pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not _process_exists(pid)
 
 
 def test_exec_command_zero_output_budget_returns_only_a_truncation_marker(tmp_path) -> None:

--- a/tests/test_exec_unit.py
+++ b/tests/test_exec_unit.py
@@ -1,0 +1,133 @@
+"""Fast, deterministic unit tests for exec internals.
+
+These cover the pure pieces of the exec reactor without spawning subprocesses:
+the ``OutputBuffer`` head/tail truncation math and the ``ExecSession`` teardown
+lifecycle (``aclose`` closes stdin, cancels its reader tasks, and is idempotent).
+The subprocess-level behavior lives in ``test_agent_tools.py`` and the opt-in
+``test_exec_volume.py`` load tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+from mini_articraft.agent.tools._exec import (
+    MAX_OUTPUT_BYTES,
+    ExecSession,
+    OutputBuffer,
+)
+
+HEAD_BUDGET = MAX_OUTPUT_BYTES // 2
+TAIL_BUDGET = MAX_OUTPUT_BYTES - HEAD_BUDGET
+
+
+def run(awaitable):
+    return asyncio.get_event_loop().run_until_complete(awaitable)
+
+
+def test_output_buffer_passes_small_output_through() -> None:
+    buffer = OutputBuffer()
+    buffer.append(b"hello ")
+    buffer.append(b"world")
+
+    assert buffer.drain() == (b"hello world", 0)
+
+
+def test_output_buffer_drain_clears_state() -> None:
+    buffer = OutputBuffer()
+    buffer.append(b"x")
+
+    assert buffer.drain() == (b"x", 0)
+    assert buffer.drain() == (b"", 0)
+
+
+def test_output_buffer_truncates_middle_keeping_head_and_tail() -> None:
+    buffer = OutputBuffer()
+    dropped = 5_000
+    buffer.append(b"H" * HEAD_BUDGET + b"M" * dropped + b"T" * TAIL_BUDGET)
+
+    data, omitted = buffer.drain()
+
+    assert omitted == dropped
+    assert len(data) == MAX_OUTPUT_BYTES
+    assert data == b"H" * HEAD_BUDGET + b"T" * TAIL_BUDGET
+
+
+def test_output_buffer_rolls_tail_and_counts_dropped_bytes() -> None:
+    buffer = OutputBuffer()
+    buffer.append(b"H" * HEAD_BUDGET)  # fills the head exactly
+    buffer.append(b"A" * TAIL_BUDGET)  # fills the tail exactly
+    buffer.append(b"B" * 100)  # pushes the 100 oldest tail bytes out
+
+    data, omitted = buffer.drain()
+
+    assert omitted == 100
+    assert len(data) == MAX_OUTPUT_BYTES
+    assert data == b"H" * HEAD_BUDGET + b"A" * (TAIL_BUDGET - 100) + b"B" * 100
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FakeProc:
+    """A stand-in for a finished subprocess (returncode set, so not alive)."""
+
+    def __init__(self) -> None:
+        self.returncode = 0
+        self.pid = None
+        self.stdin = _FakeStdin()
+
+
+async def _dead_session() -> tuple[ExecSession, _FakeProc]:
+    proc = _FakeProc()
+    session = ExecSession(
+        session_id=1,
+        proc=cast(asyncio.subprocess.Process, proc),
+        stdout=OutputBuffer(),
+        stderr=OutputBuffer(),
+        output_event=asyncio.Event(),
+    )
+
+    async def _wait() -> None:
+        await session.output_event.wait()
+
+    session._readers = [
+        asyncio.create_task(_wait()),
+        asyncio.create_task(_wait()),
+    ]
+    await asyncio.sleep(0)  # let the reader tasks start running
+    return session, proc
+
+
+def test_exec_session_aclose_closes_stdin_and_cancels_readers() -> None:
+    async def exercise() -> tuple[ExecSession, _FakeProc, list[asyncio.Task[None]]]:
+        session, proc = await _dead_session()
+        readers = session._readers
+        await session.aclose()
+        return session, proc, readers
+
+    session, proc, readers = run(exercise())
+
+    assert session._closed is True
+    assert proc.stdin.close_calls == 1
+    assert all(task.done() for task in readers)
+    assert all(task.cancelled() for task in readers)
+
+
+def test_exec_session_aclose_is_idempotent() -> None:
+    async def exercise() -> tuple[ExecSession, _FakeProc]:
+        session, proc = await _dead_session()
+        await session.aclose()
+        await session.aclose()  # second call is a no-op, must not raise
+        return session, proc
+
+    session, proc = run(exercise())
+
+    assert session._closed is True
+    assert proc.stdin.close_calls == 1


### PR DESCRIPTION
Stacked on #9 (the reactor rewrite). Do not merge until #9 lands.

Adds fast, deterministic unit tests with no subprocess:
- `OutputBuffer` head/tail/omitted truncation math — pass-through, drain reset, middle truncation, rolling tail.
- `ExecSession.aclose` — closes stdin, cancels its reader tasks, and is idempotent.

Subprocess-level behavior stays covered by `test_agent_tools.py` and the opt-in `test_exec_volume.py` load tests.

## Verify
`pytest tests/test_exec_unit.py` **6 passed** · full suite **107 passed**.
