### PR TITLE
Expand ruff lint selection and fix the new findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,12 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["B", "C4", "E", "F", "I", "PERF", "PLE", "PLW", "PTH", "RUF", "SIM", "UP"]
 ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# typer builds CLI options by calling typer.Option in parameter defaults.
+"src/mini_articraft/cli/mini.py" = ["B008"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -21,8 +21,7 @@ def _tracked_files() -> list[str]:
     result = subprocess.run(
         ["git", "ls-files"],
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     return [line for line in result.stdout.splitlines() if line]
@@ -44,9 +43,7 @@ def _is_forbidden(path: str) -> bool:
         return True
     if any(part in _FORBIDDEN_DIRECTORIES for part in parts):
         return True
-    if any(part.endswith(".egg-info") for part in parts):
-        return True
-    return False
+    return any(part.endswith(".egg-info") for part in parts)
 
 
 _FORBIDDEN_DIRECTORIES = {

--- a/src/mini_articraft/agent/tools/_exec.py
+++ b/src/mini_articraft/agent/tools/_exec.py
@@ -127,8 +127,11 @@ class ExecManager:
         self._sessions[session.session_id] = session
         assert proc.stdout is not None
         assert proc.stderr is not None
-        asyncio.create_task(_read_stream(session, proc.stdout, session.stdout))
-        asyncio.create_task(_read_stream(session, proc.stderr, session.stderr))
+
+        # Known fire-and-forget leak; the exec reactor refactor (PR #9) stores
+        # these tasks on the session and cancels them in aclose().
+        asyncio.create_task(_read_stream(session, proc.stdout, session.stdout))  # noqa: RUF006
+        asyncio.create_task(_read_stream(session, proc.stderr, session.stderr))  # noqa: RUF006
         return session
 
     def get(self, context: ToolContext, session_id: int) -> ExecSession:

--- a/src/mini_articraft/environments/worker.py
+++ b/src/mini_articraft/environments/worker.py
@@ -172,12 +172,11 @@ def _raise_for_failed_test_report(report: TestReport) -> None:
     if report.passed:
         return
     lines = ["SDK tests failed:"]
-    for failure in report.failures[:10]:
-        lines.append(f"- {failure.name}: {failure.details}")
+    lines.extend(f"- {failure.name}: {failure.details}" for failure in report.failures[:10])
     if len(report.failures) > 10:
         lines.append(f"... ({len(report.failures) - 10} more)")
     exc = ValueError("\n".join(lines))
-    setattr(exc, "test_report", report)
+    exc.test_report = report
     raise exc
 
 

--- a/src/mini_articraft/record.py
+++ b/src/mini_articraft/record.py
@@ -20,7 +20,7 @@ class Record:
         return asdict(self)
 
     @classmethod
-    def load(cls, path: Path) -> "Record":
+    def load(cls, path: Path) -> Record:
         if not path.exists():
             return cls()
         payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/mini_articraft/sdk/object.py
+++ b/src/mini_articraft/sdk/object.py
@@ -245,7 +245,7 @@ def _as_color(value: tuple[float, ...], *, field: str) -> Color:
         raise ValidationError(f"{field} must have 3 or 4 numeric values") from exc
 
     if len(raw) == 3:
-        raw = raw + (1.0,)
+        raw = (*raw, 1.0)
     if len(raw) != 4:
         raise ValidationError(f"{field} must have 3 or 4 numeric values")
     if any(not math.isfinite(component) for component in raw):

--- a/src/mini_articraft/sdk/testing.py
+++ b/src/mini_articraft/sdk/testing.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import ClassVar, Iterator
+from typing import ClassVar
 
 from mini_articraft.errors import ValidationError
 from mini_articraft.sdk._collision import (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from typer.testing import CliRunner
 
@@ -12,7 +12,7 @@ from mini_articraft.settings import Settings
 
 
 class FakeOpenAIModel:
-    instances: list["FakeOpenAIModel"] = []
+    instances: ClassVar[list[FakeOpenAIModel]] = []
 
     def __init__(self, settings: Settings):
         self.settings = settings
@@ -24,7 +24,7 @@ class FakeOpenAIModel:
 
 
 class FakeEnvironment:
-    instances: list["FakeEnvironment"] = []
+    instances: ClassVar[list[FakeEnvironment]] = []
 
     def __init__(self, **kwargs: Any):
         self.kwargs = kwargs
@@ -32,8 +32,8 @@ class FakeEnvironment:
 
 
 class FakeAgent:
-    instances: list["FakeAgent"] = []
-    result: dict[str, object] = {
+    instances: ClassVar[list[FakeAgent]] = []
+    result: ClassVar[dict[str, object]] = {
         "status": "success",
         "run": "/tmp/run",
         "result": "result/model.usdz",

--- a/tests/test_openai_model.py
+++ b/tests/test_openai_model.py
@@ -323,7 +323,7 @@ def test_openai_model_raises_on_incomplete_response(monkeypatch: pytest.MonkeyPa
     )
     patch_websocket(monkeypatch, socket)
 
-    with pytest.raises(ModelError, match="max_output_tokens.*no visible output"):
+    with pytest.raises(ModelError, match=r"max_output_tokens.*no visible output"):
         run(openai_model().query([{"role": "user", "content": "hello"}]))
 
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -30,7 +30,7 @@ def test_origin_is_not_public_sdk_api() -> None:
 def test_part_color_is_normalized_and_validated() -> None:
     obj = ArticulatedObject("color", units="meters")
     assert obj.part("base", shape(), color=(0.1, 0.2, 0.3)).color == (0.1, 0.2, 0.3, 1.0)
-    with pytest.raises(ValidationError, match="between 0.0 and 1.0"):
+    with pytest.raises(ValidationError, match=r"between 0\.0 and 1\.0"):
         obj.part("bad", shape(), color=(1.2, 0.0, 0.0))
 
 

--- a/tests/test_testing_sdk.py
+++ b/tests/test_testing_sdk.py
@@ -121,9 +121,8 @@ def test_pose_rejects_unknown_joint_name() -> None:
     model.part("base", box())
     ctx = TestContext(model)
 
-    with pytest.raises(ValidationError, match="Unknown joint"):
-        with ctx.pose(missing=1.0):
-            pass
+    with pytest.raises(ValidationError, match="Unknown joint"), ctx.pose(missing=1.0):
+        pass
 
 
 def test_pose_context_changes_mesh_collision_state_and_restores() -> None:


### PR DESCRIPTION
Expands ruff's lint selection from `E, F, I` to also cover `B` (bugbear), `C4` (comprehensions), `PERF`, `PLE`/`PLW` (pylint errors/warnings), `PTH` (pathlib), `RUF`, `SIM` (simplify), and `UP` (pyupgrade), and fixes the 21 findings the new rules surface. The existing `ruff check` CI step tightens automatically — no workflow change.

## What
- `ClassVar` annotations on the CLI test fakes' shared class attributes (RUF012) — these are intentionally class-level registries, now typed as such.
- Raw-string regex patterns for `pytest.raises(match=...)` (RUF043).
- `capture_output=True` and a direct condition return in the hygiene script (UP022, SIM103).
- Modern typing imports and unquoted annotations (UP035, UP037), tuple unpacking over concatenation (RUF005), `list.extend` over an append loop (PERF401), single `with` statement (SIM117).
- **RUF006 (dangling `asyncio.create_task`) flagged the exec reader tasks in `_exec.py` — the exact leak the reactor refactor (#9) fixes** by storing the tasks and cancelling them in `aclose()`. Here they get a targeted `noqa` with a pointer; the lines drop out entirely once #9 lands and this rebases.
- typer's option-in-parameter-default idiom gets a per-file `B008` ignore for `cli/mini.py`.

Ordered fixes-first so both commits pass the full check suite.

## Verify
`ruff check` clean under the expanded selection · `ruff format --check` clean · `pytest -q` green on CI (four exec-timing tests are flaky on my Mac on all branches including untouched main — a machine-local login-shell stall; ubuntu unaffected).
