### PR TITLE
Validate articulation in motion: catch hinges that separate their child

### DIFF
--- a/src/mini_articraft/environments/worker.py
+++ b/src/mini_articraft/environments/worker.py
@@ -125,6 +125,7 @@ def _run_baseline_tests(obj: ArticulatedObject, authored_report: TestReport) -> 
     ctx.warn_if_part_contains_disconnected_geometry_islands()
     ctx.warn_if_absurd_dimensions()
     ctx.fail_if_parts_overlap_in_current_pose()
+    ctx.fail_if_articulation_separates_child()
     return _without_allowance_notes(ctx.report())
 
 

--- a/src/mini_articraft/sdk/testing.py
+++ b/src/mini_articraft/sdk/testing.py
@@ -17,7 +17,7 @@ from mini_articraft.sdk._collision import (
     Vec3,
     _pair_key,
 )
-from mini_articraft.sdk.joints import Articulation
+from mini_articraft.sdk.joints import Articulation, ArticulationType
 from mini_articraft.sdk.object import ArticulatedObject, Part, PartRef
 
 DEFAULT_MESH_TOLERANCE = 0.001
@@ -498,6 +498,66 @@ class TestContext:
     ) -> bool:
         return self._check_disconnected_geometry(contact_tol=contact_tol, name=name, warn=True)
 
+    def fail_if_articulation_separates_child(
+        self,
+        *,
+        samples: int = 4,
+        gap_tol: float = 0.003,
+        name: str | None = None,
+    ) -> bool:
+        """Fail if a hinge/pivot pulls its moving child away from its parent.
+
+        For every REVOLUTE and CONTINUOUS articulation, this samples the joint
+        across its motion range and measures the closest distance between the child
+        part and its parent. A real hinge or pivot keeps them touching throughout;
+        if the child instead separates by more than `gap_tol` beyond its rest gap as
+        the joint moves, the joint origin/axis is misplaced -- the classic "lid that
+        floats off when opened". PRISMATIC joints are exempt, since their parts
+        often separate on purpose (lift-off kettles, sliding drawers).
+
+        The other geometry checks only look at the rest pose, so this is what
+        catches articulation defects that appear only in motion.
+        """
+        samples = max(2, int(samples))
+        gap_tol = _non_negative(gap_tol, "gap_tol")
+        check_name = name or f"fail_if_articulation_separates_child(gap_tol={gap_tol:.6g})"
+        findings: list[str] = []
+        for articulation in self.model.articulations:
+            if articulation.articulation_type not in (
+                ArticulationType.REVOLUTE,
+                ArticulationType.CONTINUOUS,
+            ):
+                continue
+            parent = _part_name(articulation.parent, field_name="parent")
+            child = _part_name(articulation.child, field_name="child")
+            values = _articulation_sweep_values(articulation, samples)
+            with self.pose({articulation.name: values[0]}):
+                rest_gap = self.distance_between(parent, child).distance
+            worst_gap, worst_value = rest_gap, values[0]
+            for value in values[1:]:
+                with self.pose({articulation.name: value}):
+                    gap = self.distance_between(parent, child).distance
+                if gap > worst_gap:
+                    worst_gap, worst_value = gap, value
+            if worst_gap - rest_gap > gap_tol:
+                findings.append(
+                    f"articulation={articulation.name!r} "
+                    f"type={articulation.articulation_type} parent={parent!r} "
+                    f"child={child!r} rest_gap={rest_gap:.4g}m max_gap={worst_gap:.4g}m "
+                    f"at value={worst_value:.4g} "
+                    f"(child pulls {worst_gap - rest_gap:.4g}m off the parent as it moves)"
+                )
+        if not findings:
+            return self._record(check_name, True)
+        details = (
+            "A hinge/pivot pulls its moving child away from its parent -- the parts "
+            "touch at rest but separate when the joint is actuated (e.g. a lid that "
+            "floats off when opened). Place the articulation origin and axis so the "
+            "child stays connected to the parent throughout its motion range:\n"
+            + "\n".join(findings)
+        )
+        return self._record(check_name, False, details)
+
     def warn_if_absurd_dimensions(
         self,
         *,
@@ -673,6 +733,23 @@ def _part_name(value: PartRef, *, field_name: str) -> str:
     if not isinstance(raw, str) or not raw.strip():
         raise ValidationError(f"{field_name} must be a part name or Part")
     return raw.strip()
+
+
+def _articulation_sweep_values(articulation: Articulation, samples: int) -> list[float]:
+    """Joint values to sample across an articulation's motion range.
+
+    The first value is the rest pose. A bounded joint sweeps lower..upper; a
+    continuous or unbounded joint samples a half turn (0..pi), which is enough to
+    reveal a child that separates as it rotates.
+    """
+    limits = articulation.motion_limits
+    if limits is not None and limits.lower is not None and limits.upper is not None:
+        low, high = float(limits.lower), float(limits.upper)
+    else:
+        low, high = 0.0, math.pi
+    if high <= low:
+        return [low]
+    return [low + (high - low) * index / (samples - 1) for index in range(samples)]
 
 
 def _articulation_name(value: object) -> str:

--- a/tests/test_articulation_motion.py
+++ b/tests/test_articulation_motion.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from mini_articraft.sdk import (
+    ArticulatedObject,
+    ArticulationType,
+    BoxGeometry,
+    MotionLimits,
+    Origin,
+    TestContext,
+)
+
+
+def _hinged_lid(pivot: tuple[float, float, float]) -> ArticulatedObject:
+    """A base slab with a lid resting on it, hinged about X at `pivot`.
+
+    The lid geometry lives in the joint frame, so it is authored relative to
+    `pivot` such that at rest it seats on the base top (world z=0.01) regardless of
+    where the pivot is. A pivot on the contact plane keeps the lid seated as it
+    swings; a pivot above the contact plane lifts the lid clear as it rotates.
+    """
+    model = ArticulatedObject("hinge_test")
+    base = model.part("base")
+    base.add(BoxGeometry((0.10, 0.10, 0.02)), name="base_slab")  # top at z=0.01
+    world_center = (0.0, 0.0, 0.02)
+    offset = tuple(world_center[i] - pivot[i] for i in range(3))
+    lid = model.part("lid")
+    lid.add(BoxGeometry((0.10, 0.10, 0.02)).translate(*offset), name="lid_slab")
+    model.articulation(
+        "lid_hinge",
+        ArticulationType.REVOLUTE,
+        base,
+        lid,
+        origin=Origin(xyz=pivot),
+        axis=(1.0, 0.0, 0.0),
+        motion_limits=MotionLimits(lower=0.0, upper=1.2),
+    )
+    return model
+
+
+def test_separation_check_passes_hinge_at_the_contact_edge() -> None:
+    # Pivot on the rear contact edge: the lid flips but its rear edge stays seated.
+    model = _hinged_lid((0.0, -0.05, 0.01))
+    ctx = TestContext(model)
+    ctx.fail_if_articulation_separates_child()
+    assert ctx.report().passed
+
+
+def test_separation_check_fails_a_lid_that_lifts_off() -> None:
+    # Pivot above the contact plane: rotating lifts the lid clear of the base.
+    model = _hinged_lid((0.0, -0.05, 0.06))
+    ctx = TestContext(model)
+    ctx.fail_if_articulation_separates_child()
+    report = ctx.report()
+    assert not report.passed
+    assert "lid_hinge" in report.failures[0].details
+
+
+def test_separation_check_ignores_prismatic_liftoff() -> None:
+    # A prismatic lift-off is meant to separate; it must not be flagged.
+    model = ArticulatedObject("liftoff")
+    base = model.part("base")
+    base.add(BoxGeometry((0.10, 0.10, 0.02)), name="base_slab")
+    body = model.part("body")
+    body.add(BoxGeometry((0.08, 0.08, 0.10)).translate(0.0, 0.0, 0.06), name="body_box")
+    model.articulation(
+        "lift",
+        ArticulationType.PRISMATIC,
+        base,
+        body,
+        origin=Origin(xyz=(0.0, 0.0, 0.0)),
+        axis=(0.0, 0.0, 1.0),
+        motion_limits=MotionLimits(lower=0.0, upper=0.10),
+    )
+    ctx = TestContext(model)
+    ctx.fail_if_articulation_separates_child()
+    assert ctx.report().passed


### PR DESCRIPTION
Stacked on #14 (junction/weld work) — the diff here is just the articulation commit.

## Problem

The compiler only validated the **rest pose**, so a hinge whose geometry is wrong *only when actuated* passed clean — the classic **lid that floats off when opened**. Measured on a generated kettle: lid touches the body at rest (0mm) but separates to 4.4mm the moment it opens and never reconnects.

## Fix

Add `fail_if_articulation_separates_child` and wire it into the compiler baseline. For each **REVOLUTE/CONTINUOUS** articulation it samples the joint across its motion range and requires the child to stay within `gap_tol` (3mm) of its parent throughout — flagging it if the child pulls away as the joint moves. **PRISMATIC** joints are exempt (lift-off kettles, sliding drawers separate on purpose). Uses the delta from the rest gap, so a legitimate resting clearance doesn't trip it.

## Validation

- **Catches** the floating kettle lid (4.4mm separation).
- **Zero false positives** across the mixer (4 joints), jet, watering can, stool, and teapot — every joint type (revolute, continuous, prismatic).
- **End-to-end:** regenerating a kettle, treasure chest, and laptop with the check active, the agent now produces hinges that stay connected (0.0mm gap through the full range) and models real hinge barrels unprompted. The kettle lid now flips instead of floating.

3 unit tests (good hinge passes, lifting hinge fails, prismatic exempt); full suite green; lint/type clean.

## Note

The compiler baseline previously had no motion-aware check at all; this is the first one. Only revolute/continuous are enforced for now — the same sampling machinery could later check overlap-in-motion too.