### PR TITLE
Add attachment-pattern examples: bladed rotor + captured-pin hinge

### DIFF
--- a/src/mini_articraft/sdk/docs/common/00_quickstart.md
+++ b/src/mini_articraft/sdk/docs/common/00_quickstart.md
@@ -72,6 +72,8 @@ Read only the executable example closest to the current task:
   `docs/sdk/examples/molded_mug.py`.
 - Seating radial blades into a hub disk and welding into one rotor:
   `docs/sdk/examples/bladed_rotor.py`.
+- A captured-pin hinge (barrel integral to the lid, pin in the base) that stays
+  connected when opened: `docs/sdk/examples/captured_pin_hinge.py`.
 
 Run `compile` after meaningful edits. Treat checks as design evidence. A failed check is not a
 reason to remove or simplify geometry that the prompt requires.

--- a/src/mini_articraft/sdk/docs/common/00_quickstart.md
+++ b/src/mini_articraft/sdk/docs/common/00_quickstart.md
@@ -70,6 +70,8 @@ Read only the executable example closest to the current task:
 - Mixed build123d and mesh assembly: `docs/sdk/examples/mixed_articulated_assembly.py`.
 - Molding a handle/protrusion into a body (no mounting pads):
   `docs/sdk/examples/molded_mug.py`.
+- Seating radial blades into a hub disk and welding into one rotor:
+  `docs/sdk/examples/bladed_rotor.py`.
 
 Run `compile` after meaningful edits. Treat checks as design evidence. A failed check is not a
 reason to remove or simplify geometry that the prompt requires.

--- a/src/mini_articraft/sdk/docs/examples/bladed_rotor.py
+++ b/src/mini_articraft/sdk/docs/examples/bladed_rotor.py
@@ -1,0 +1,91 @@
+"""Seat a radial array of blades into a hub disk, then weld into one solid rotor.
+
+A fan, turbine, propeller, or spoked wheel is one piece of one material, with many
+blades radiating from a center. Two things make it read as a single solid rotor:
+
+  1. SEAT the roots. Build a solid `hub_disk` (a cylinder) and place each blade so its
+     inner end sits a real margin INSIDE the disk radius -- the root buries into the
+     hub. Matching a root to a tapering cone's surface only grazes it and leaves a gap;
+     burying it into a wide disk seats the blade.
+  2. WELD them. Because the blades and hub share one material, `weld` fuses the buried
+     roots and the disk into ONE seamless solid (an exact boolean union). weld needs
+     the overlap from step 1 -- it fuses an overlap, it cannot close a gap.
+
+This is the radial version of "extend the piece's own end into the body and fuse it":
+the blade's own root reaches into the hub, no separate collar. (A differently colored
+protrusion -- e.g. a black handle on a steel body -- cannot weld without losing its
+color, so it stays an overlapping shape; a same-material rotor should weld.)
+"""
+
+from __future__ import annotations
+
+import math
+
+from mini_articraft.sdk import (
+    ArticulatedObject,
+    BoxGeometry,
+    CylinderGeometry,
+    MeshGeometry,
+    TestContext,
+    TestReport,
+    weld,
+)
+
+
+def _seated_blade_ring(
+    *,
+    count: int,
+    disk_radius: float,
+    r_inner: float,
+    r_tip: float,
+    chord: float,
+    thickness: float,
+) -> MeshGeometry:
+    # r_inner is deliberately well inside disk_radius, so every root buries into the hub.
+    assert r_inner < disk_radius, "blade root must start inside the disk radius to seat"
+    blades: MeshGeometry | None = None
+    length = r_tip - r_inner
+    for index in range(count):
+        angle = 2.0 * math.pi * index / count
+        blade = (
+            BoxGeometry((length, chord, thickness))
+            .translate((r_inner + r_tip) / 2.0, 0.0, 0.0)
+            .rotate_z(angle)
+        )
+        blades = blade if blades is None else blades.merge(blade)
+    assert blades is not None
+    return blades
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("bladed_rotor")
+    rotor = model.part("rotor")
+
+    disk_radius = 0.10
+    hub_disk = CylinderGeometry(disk_radius, 0.05, radial_segments=64)
+    blades = _seated_blade_ring(
+        count=10,
+        disk_radius=disk_radius,
+        r_inner=0.05,  # 0.05 < 0.10 disk radius -> roots buried 0.05 into the hub
+        r_tip=0.24,
+        chord=0.05,
+        thickness=0.012,
+    )
+
+    # One material: weld the seated roots and the disk into a single solid rotor.
+    rotor.add(weld(hub_disk, blades), name="hub_with_blades", color=(0.72, 0.73, 0.75))
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    ctx = TestContext(object_model)
+    _, hi = ctx.shape_world_bounds("rotor", "hub_with_blades")
+    ctx.check(
+        "blades_reach_out_from_the_hub",
+        hi[0] > 0.20,
+        "The welded blades should extend to the tip radius as one solid rotor.",
+    )
+    return ctx.report()

--- a/src/mini_articraft/sdk/docs/examples/captured_pin_hinge.py
+++ b/src/mini_articraft/sdk/docs/examples/captured_pin_hinge.py
@@ -1,0 +1,112 @@
+"""A captured-pin hinge: barrel integral to the lid, pin in the base, stays connected open.
+
+A hinged lid, door, or laptop pivots on a barrel that wraps a pin. Model it as two
+clean pieces, not a pile of lugs and tongues:
+
+  1. The PIN belongs to the stationary part (`base`): a thin cylinder on the hinge axis.
+  2. The BARREL belongs to the moving part (`lid`) and is INTEGRAL to it -- it overlaps
+     the lid's own body, so it is part of the lid, not a separate floating knuckle.
+  3. The barrel wraps the pin (a captured pin): declare that one intended cross-part
+     overlap with `allow_overlap`.
+  4. Put the articulation origin exactly on the pin axis, so the barrel stays centered
+     on the pin through the whole swing -- the lid never separates when it opens.
+
+Keep the hinge above/behind the body so the barrel does not dip into the base. This is
+the clean alternative to bridging a lid to a body with support lugs and blend blocks.
+"""
+
+from __future__ import annotations
+
+import math
+
+from mini_articraft.sdk import (
+    ArticulatedObject,
+    ArticulationType,
+    BoxGeometry,
+    CylinderGeometry,
+    MotionLimits,
+    Origin,
+    TestContext,
+    TestReport,
+)
+
+PIN_Y = 0.082
+PIN_Z = 0.092
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("hinged_box")
+
+    base = model.part("base")
+    base.add(
+        BoxGeometry((0.20, 0.15, 0.08)).translate(0.0, 0.0, 0.04),
+        name="box_body",
+        color=(0.30, 0.32, 0.36),
+    )
+    # Stationary pin on the hinge axis, held above/behind the body's rear-top edge.
+    base.add(
+        CylinderGeometry(0.006, 0.19, radial_segments=32)
+        .rotate_y(math.pi / 2)
+        .translate(0.0, PIN_Y, PIN_Z),
+        name="hinge_pin",
+        color=(0.10, 0.10, 0.11),
+    )
+
+    lid = model.part("lid")
+    # The lid part is authored in a local frame whose origin sits at the hinge origin
+    # (the pin). So the barrel is at the local origin, and the plate is offset forward
+    # of the pin (-y) to cover the top.
+    lid.add(
+        BoxGeometry((0.19, 0.175, 0.012)).translate(0.0, -PIN_Y, 0.088 - PIN_Z),
+        name="lid_plate",
+        color=(0.62, 0.64, 0.68),
+    )
+    # Barrel is INTEGRAL to the lid (overlaps the plate) and wraps the pin at the origin.
+    lid.add(
+        CylinderGeometry(0.011, 0.16, radial_segments=32).rotate_y(math.pi / 2),
+        name="lid_hinge_barrel",
+        color=(0.62, 0.64, 0.68),
+    )
+
+    model.articulation(
+        "lid_hinge",
+        ArticulationType.REVOLUTE,
+        base,
+        lid,
+        origin=Origin(xyz=(0.0, PIN_Y, PIN_Z)),
+        axis=(-1.0, 0.0, 0.0),  # positive motion lifts the front of the lid upward
+        motion_limits=MotionLimits(lower=0.0, upper=1.9),
+    )
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    ctx = TestContext(object_model)
+    ctx.allow_overlap(
+        "lid",
+        "base",
+        shape_a="lid_hinge_barrel",
+        shape_b="hinge_pin",
+        reason="The lid's hinge barrel is captured around the base's stationary pin.",
+    )
+    ctx.expect_collision(
+        "base",
+        "lid",
+        shape_a="hinge_pin",
+        shape_b="lid_hinge_barrel",
+        name="barrel_captures_the_pin",
+    )
+    # The barrel is part of the lid, not a floating knuckle.
+    ctx.expect_collision(
+        "lid",
+        "lid",
+        shape_a="lid_plate",
+        shape_b="lid_hinge_barrel",
+        name="barrel_is_integral_to_the_lid",
+    )
+    # The lid must stay attached to the base through the whole open sweep.
+    ctx.fail_if_articulation_separates_child()
+    return ctx.report()


### PR DESCRIPTION
The agent clones executable examples far more than it follows prose (proven by the molded_mug win). These add two *pattern* examples for base cases it currently botches:

- **`bladed_rotor.py`** — seat radial blades into a solid hub disk (bury the roots inside the disk, don't graze a cone), then `weld` the same-material roots + disk into one solid rotor. Fixes fans/turbines whose blades float ~2mm off the hub. Generalizes to propellers, spoked wheels, mixer beaters.
- **`captured_pin_hinge.py`** — a clean hinge: pin in the stationary base, barrel *integral* to the moving lid (overlaps the lid plate, not a floating knuckle), wrapping the pin as a captured-pin allowance, origin on the pin axis so the lid stays connected through the full open. The clean alternative to the lug/tongue mess (the recurring kettle-hinge defect).

Both pass the example-execution test and are wired into the quickstart. These are distinct *patterns*, not per-object examples.