### PR TITLE
Warn cleanly when required env vars are missing

### DIFF
--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -10,7 +10,7 @@ import typer
 from pydantic import ValidationError
 
 from mini_articraft.agent import Agent, events
-from mini_articraft.cli.tui import replay_run, run_live
+from mini_articraft.cli.tui import print_settings_error, replay_run, run_live
 from mini_articraft.environments import LocalEnvironment
 from mini_articraft.models import OpenAIModel
 from mini_articraft.settings import DEFAULT_OUTPUT_DIR, Settings, get_settings
@@ -134,24 +134,21 @@ def _settings(
     try:
         settings = get_settings()
     except ValidationError as exc:
-        typer.echo(_settings_error(exc), err=True)
+        _report_settings_error(exc)
         raise typer.Exit(1) from None
     return settings.model_copy(update=updates)
 
 
-def _settings_error(exc: ValidationError) -> str:
+def _report_settings_error(exc: ValidationError) -> None:
     missing = [
         str(error["loc"][0])
         for error in exc.errors()
         if error.get("type") == "missing" and error.get("loc")
     ]
     if missing:
-        names = ", ".join(missing)
-        return (
-            f"missing required environment variable: {names}\n"
-            "Set it in the environment or a .env file (see .env.example)."
-        )
-    return f"invalid settings:\n{exc}"
+        print_settings_error(missing=missing)
+        return
+    print_settings_error(detail=str(exc))
 
 
 def _print_result(result: dict[str, object]) -> None:

--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -131,7 +131,27 @@ def _settings(
         )
         if value is not None
     }
-    return get_settings().model_copy(update=updates)
+    try:
+        settings = get_settings()
+    except ValidationError as exc:
+        typer.echo(_settings_error(exc), err=True)
+        raise typer.Exit(1) from None
+    return settings.model_copy(update=updates)
+
+
+def _settings_error(exc: ValidationError) -> str:
+    missing = [
+        str(error["loc"][0])
+        for error in exc.errors()
+        if error.get("type") == "missing" and error.get("loc")
+    ]
+    if missing:
+        names = ", ".join(missing)
+        return (
+            f"missing required environment variable: {names}\n"
+            "Set it in the environment or a .env file (see .env.example)."
+        )
+    return f"invalid settings:\n{exc}"
 
 
 def _print_result(result: dict[str, object]) -> None:

--- a/src/mini_articraft/cli/tui.py
+++ b/src/mini_articraft/cli/tui.py
@@ -17,6 +17,8 @@ from typing import Any
 
 from rich.console import Console
 from rich.live import Live
+from rich.markup import escape
+from rich.panel import Panel
 from rich.rule import Rule
 from rich.spinner import Spinner
 from rich.text import Text
@@ -30,6 +32,36 @@ LiveRun = Callable[[EventHandler], Coroutine[Any, Any, dict[str, Any]]]
 PRIMARY_STYLE = "white"
 SIGNAL_STYLE = "grey70"
 TOKEN_BAR_WIDTH = 24
+
+
+def print_settings_error(
+    *,
+    missing: list[str] | None = None,
+    detail: str | None = None,
+    console: Console | None = None,
+) -> None:
+    """Print a setup error for missing or invalid settings."""
+    console = console or Console(stderr=True)
+    if missing:
+        names = ", ".join(escape(name) for name in missing)
+        body = Text.from_markup(
+            f"[bold]Missing required environment variable:[/bold] [yellow]{names}[/yellow]\n\n"
+            "Copy [cyan].env.example[/cyan] → [cyan].env[/cyan] and set your key,\n"
+            "or export it in the shell before running."
+        )
+        title = "setup needed"
+    else:
+        body = Text(detail or "invalid settings", style="red")
+        title = "invalid settings"
+    console.print(
+        Panel(
+            body,
+            title=f"[bold red]{title}[/bold red]",
+            border_style="red",
+            expand=False,
+            padding=(1, 2),
+        )
+    )
 
 
 def run_live(generate: LiveRun) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,8 +108,10 @@ def test_cli_warns_on_missing_required_settings(monkeypatch, tmp_path: Path) -> 
     result = CliRunner().invoke(mini.app, ["generate", "make a hinge", "--no-tui"])
 
     assert result.exit_code == 1
-    assert "missing required environment variable: OPENAI_API_KEY" in result.output
+    assert "Missing required environment variable" in result.output
+    assert "OPENAI_API_KEY" in result.output
     assert ".env.example" in result.output
+    assert "setup needed" in result.output
     assert "Traceback" not in result.output
     assert "ValidationError" not in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 from mini_articraft.cli import mini
 from mini_articraft.record import Record, append_conversation
-from mini_articraft.settings import Settings
+from mini_articraft.settings import Settings, get_settings
 
 
 class FakeOpenAIModel:
@@ -98,6 +98,20 @@ def test_cli_runs_agent_with_only_core_overrides(monkeypatch, tmp_path: Path) ->
     assert FakeAgent.instances[0].prompt == "make a hinge"
     assert "status: success" in result.output
     assert "run: /tmp/run" in result.output
+
+
+def test_cli_warns_on_missing_required_settings(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    get_settings.cache_clear()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = CliRunner().invoke(mini.app, ["generate", "make a hinge", "--no-tui"])
+
+    assert result.exit_code == 1
+    assert "missing required environment variable: OPENAI_API_KEY" in result.output
+    assert ".env.example" in result.output
+    assert "Traceback" not in result.output
+    assert "ValidationError" not in result.output
 
 
 def test_cli_exits_nonzero_when_agent_fails(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Catch missing settings (e.g. `OPENAI_API_KEY`) before generate starts and exit without a pydantic stacktrace
- Render the first-run setup error as a Rich panel that points at `.env.example` → `.env`

![Missing OPENAI_API_KEY setup panel](https://d.uguu.se/swuAkMAW.png)

## Test plan
- [ ] From a directory without `.env` / with `OPENAI_API_KEY` unset: `uv run mini-articraft generate "make a folding chair"` shows the setup panel and exit code 1
- [ ] With a valid project `.env`, generate starts normally
- [ ] `uv run pytest tests/test_cli.py -q`