### PR TITLE
Add a scripted-model test harness for the agent loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,12 @@ Prefer fast pytest tests that exercise the package directly. Use temporary
 directories for compile and record tests. Do not require real model calls unless
 the test is explicitly about a live adapter.
 
+`tests/harness.py` is the modular test environment for agent-loop behavior:
+scripted models drive the full loop without paid model calls. See
+`tests/README.md` for the lanes and when to use each. Keep the subprocess
+worker contract covered in `test_compile.py`. A few exec-output timing tests
+are known to flake on macOS; do not weaken them locally.
+
 Run this before handing off a code change:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,11 @@ include = ["src", "tests", "scripts"]
 exclude = ["src/mini_articraft/sdk/docs"]
 typeCheckingMode = "standard"
 
+# Test modules import the test environment as `import harness` (pytest prepend
+# mode puts tests/ on sys.path); teach the type checker the same root.
+[[tool.basedpyright.executionEnvironments]]
+root = "tests"
+
 [tool.pytest.ini_options]
 addopts = "-m 'not volume'"
 markers = [

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,38 @@
+# Test environment
+
+This suite verifies the generation loop without paid model calls.
+`tests/harness.py` is the shared kit; prefer it over per-file fakes.
+
+## The lanes
+
+| Lane | Cost | Use for |
+| --- | --- | --- |
+| Unit | ~0s | pure functions: SDK checks, `compile_feedback`, signals |
+| Scripted agent | seconds per run | the full agent loop via `ScriptedModel` + `run_scenario` |
+
+```python
+from harness import run_scenario, calls, text, tool_call
+
+artifacts = run_scenario(
+    "a box",
+    [
+        calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY})),
+        calls(tool_call("compile")),
+        text("done"),
+    ],
+    tmp_path=tmp_path,
+)
+assert artifacts.record.status == "success"
+```
+
+A scripted step can also be a callable `(ModelQuery) -> Response`, so the
+"model" can assert on what the agent sent and react to earlier tool outputs.
+See `tests/test_agent_scenarios.py` for end-to-end examples (repair loops,
+repeat-failure guidance, allowances).
+
+## Known platform flakes
+
+On macOS, a few exec-output timing tests can fail with empty captured output
+even on a clean tree; they pass on Linux CI. Reproduce on Linux before
+touching exec semantics, and do not weaken the assertions to make them pass
+locally.

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -1,0 +1,358 @@
+"""Modular test environment for mini-articraft.
+
+Verify the generation loop deeply without paying for model calls:
+
+1. Unit lane -- call pure functions (SDK checks, compile feedback) directly;
+   no harness needed.
+2. Scripted agent lane -- :class:`ScriptedModel` plus :func:`run_scenario`
+   drive the full agent loop (tools, reminders, compile freshness, record)
+   with a deterministic model that can react to what the agent sends it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import itertools
+import json
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar, Generic, TypeVar
+
+from mini_articraft.agent import Agent, events
+from mini_articraft.agent.tools import Tool, ToolContext
+from mini_articraft.agent.tools._core import schema as _tool_schema
+from mini_articraft.agent.tools._core import workspace_digest
+from mini_articraft.environments.local import LocalEnvironment
+from mini_articraft.record import Record, read_conversation
+
+T = TypeVar("T")
+Item = TypeVar("Item")
+
+Response = dict[str, Any]
+ToolCall = dict[str, Any]
+Messages = list[dict[str, Any]]
+
+
+def run(awaitable: Awaitable[T]) -> T:
+    """Drive an awaitable on the session event loop owned by conftest."""
+    return asyncio.get_event_loop().run_until_complete(awaitable)
+
+
+# ---------------------------------------------------------------------------
+# Queries and responses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelQuery:
+    """One recorded model query: the exact messages and tools the agent sent."""
+
+    turn: int
+    messages: Messages
+    tools: list[dict[str, Any]]
+
+    def contains(self, *needles: str) -> bool:
+        """True when a single message content includes every ``needle``."""
+        if not needles:
+            raise ValueError("contains needs at least one needle")
+        return any(
+            all(needle in content for needle in needles)
+            for content in (str(message.get("content")) for message in self.messages)
+        )
+
+    def tool_outputs(self) -> list[dict[str, Any]]:
+        """Parsed ``function_call_output`` payloads the model has seen so far."""
+        return _tool_outputs(self.messages)
+
+
+def _tool_outputs(messages: Messages) -> list[dict[str, Any]]:
+    return [
+        json.loads(str(message.get("output") or "{}"))
+        for message in messages
+        if message.get("type") == "function_call_output"
+    ]
+
+
+def _record_query(
+    queries: list[ModelQuery],
+    messages: Messages,
+    tools: list[dict[str, Any]] | None,
+) -> ModelQuery:
+    query = ModelQuery(
+        turn=len(queries) + 1,
+        messages=list(messages),
+        tools=list(tools or []),
+    )
+    queries.append(query)
+    return query
+
+
+Step = Response | Callable[[ModelQuery], "Response | Awaitable[Response]"]
+
+_call_ids = itertools.count(1)
+
+
+def tool_call(
+    name: str, args: dict[str, Any] | None = None, *, call_id: str | None = None
+) -> ToolCall:
+    """Build one tool call in the wire shape the agent harness consumes.
+
+    Auto-generated ids are unique per process, not per test; pass ``call_id``
+    when a test asserts on specific ids.
+    """
+    return {
+        "id": call_id or f"call_{next(_call_ids)}",
+        "name": name,
+        "arguments": json.dumps(args or {}),
+    }
+
+
+def calls(*tool_calls: ToolCall, **fields: Any) -> Response:
+    """A scripted response of tool calls with no visible text."""
+    return {"text": "", "tool_calls": list(tool_calls), **fields}
+
+
+def text(content: str, **fields: Any) -> Response:
+    """A scripted response of visible text with no tool calls."""
+    return {"text": content, "tool_calls": [], **fields}
+
+
+def _normalize_response(response: Response) -> Response:
+    """Fill the optional response fields without mutating the caller's dict."""
+    if not isinstance(response, dict):
+        raise TypeError(f"model responses must be dicts, got {type(response).__name__}")
+    return {"text": "", "tool_calls": [], "cost": 0.0, "token_usage": {}, **response}
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class ScriptExhaustedError(RuntimeError):
+    """The agent asked for more turns than the script provides."""
+
+
+@dataclass(frozen=True)
+class ModelIdentity:
+    """The model attributes the agent harness reads through ``model.config``."""
+
+    openai_model: str = "gpt-test"
+    openai_reasoning_effort: str = "low"
+
+
+class QueuedModel(Generic[Item]):
+    """Base for finite models: a queue of canned responses plus a query log.
+
+    Subclasses keep only their semantics -- what a queued item is and how one
+    becomes a response. The queue itself (pop with a clear exhaustion error,
+    ``remaining``, ``assert_exhausted``) lives here once.
+    """
+
+    noun: ClassVar[str] = "item"
+
+    def __init__(
+        self,
+        items: Iterable[Item],
+        *,
+        model_name: str = "gpt-test",
+        reasoning_effort: str = "low",
+        context_window_tokens: int = 0,
+    ):
+        self._queue = list(items)
+        self.queries: list[ModelQuery] = []
+        self.config = ModelIdentity(model_name, reasoning_effort)
+        self.context_window_tokens = context_window_tokens
+
+    @property
+    def remaining(self) -> int:
+        return len(self._queue)
+
+    def _next(self, query: ModelQuery) -> Item:
+        if not self._queue:
+            raise ScriptExhaustedError(
+                f"agent queried turn {query.turn} beyond the {query.turn - 1} {self.noun}(s)"
+            )
+        return self._queue.pop(0)
+
+    def assert_exhausted(self) -> None:
+        """Fail when the agent finished without consuming the whole queue."""
+        if self._queue:
+            raise AssertionError(
+                f"{len(self._queue)} {self.noun}(s) were never consumed; "
+                "the agent finished earlier than expected"
+            )
+
+    async def close(self) -> None:
+        pass
+
+
+class ScriptedModel(QueuedModel[Step]):
+    """A deterministic ``Model`` that plays a script of responses.
+
+    Each step is either a response dict (see :func:`text` and :func:`calls`)
+    or a callable receiving the :class:`ModelQuery` for this turn. Callables
+    may assert on the messages the agent sent, react to earlier tool outputs,
+    be ``async`` (e.g. block forever to test cancellation), or raise (to test
+    model failure handling). Querying past the last step raises
+    :class:`ScriptExhaustedError`, which the agent records as a model failure.
+    """
+
+    noun: ClassVar[str] = "scripted step"
+
+    async def query(
+        self,
+        messages: Messages,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> Response:
+        query = _record_query(self.queries, messages, tools)
+        step = self._next(query)
+        response = step(query) if callable(step) else step
+        if inspect.isawaitable(response):
+            response = await response
+        return _normalize_response(response)
+
+
+# ---------------------------------------------------------------------------
+# Scenario runner
+# ---------------------------------------------------------------------------
+
+
+class EventRecorder:
+    """Collect agent events and answer common questions about them."""
+
+    def __init__(self) -> None:
+        self.events: list[events.Event] = []
+
+    def __call__(self, event: events.Event) -> None:
+        self.events.append(event)
+
+    def of(self, kind: type[T]) -> list[T]:
+        """All events of one type, in order."""
+        return [event for event in self.events if isinstance(event, kind)]
+
+    def tool_finishes(self, name: str | None = None) -> list[events.ToolFinished]:
+        """``ToolFinished`` events, optionally filtered to one tool."""
+        finishes = self.of(events.ToolFinished)
+        if name is None:
+            return finishes
+        return [event for event in finishes if event.name == name]
+
+    @property
+    def finished(self) -> events.RunFinished | None:
+        """The terminal event, when the run emitted one last."""
+        last = self.events[-1] if self.events else None
+        return last if isinstance(last, events.RunFinished) else None
+
+
+@dataclass
+class RunArtifacts:
+    """Everything a scenario produced, ready for deep assertions."""
+
+    result: dict[str, Any]
+    record: Record
+    model: ScriptedModel
+    recorder: EventRecorder
+    run_dir: Path
+
+    @property
+    def workspace(self) -> Path:
+        return self.run_dir / "workspace"
+
+    @property
+    def conversation(self) -> list[dict[str, Any]]:
+        return read_conversation(self.run_dir / "conversation.jsonl")
+
+    def tool_outputs(self) -> list[dict[str, Any]]:
+        """Parsed tool result payloads from the persisted conversation."""
+        return _tool_outputs(self.conversation)
+
+
+def run_scenario(
+    prompt: str,
+    script: Iterable[Step],
+    *,
+    env: LocalEnvironment | None = None,
+    tmp_path: Path | None = None,
+    run_id: str = "scenario",
+    max_turns: int = 10,
+    assert_exhausted: bool = True,
+) -> RunArtifacts:
+    """Run the full agent loop for free and return deep-inspectable artifacts.
+
+    Pass ``env`` to choose the environment or ``tmp_path`` for a plain
+    ``LocalEnvironment``. By default the script must be consumed exactly;
+    pass ``assert_exhausted=False`` for open-ended runs.
+    """
+    if env is None:
+        if tmp_path is None:
+            raise ValueError("run_scenario needs env= or tmp_path=")
+        env = LocalEnvironment(output_dir=tmp_path)
+    model = ScriptedModel(script)
+    recorder = EventRecorder()
+    agent = Agent(model, env, max_turns=max_turns, on_event=recorder)
+    result = run(agent.run(prompt, run_id=run_id))
+    if assert_exhausted:
+        model.assert_exhausted()
+    run_dir = Path(str(result["run"]))
+    return RunArtifacts(
+        result=result,
+        record=Record.load(run_dir / "record.json"),
+        model=model,
+        recorder=recorder,
+        run_dir=run_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool fakes shared by agent-loop tests
+# ---------------------------------------------------------------------------
+
+
+def stub_schema(name: str) -> dict[str, Any]:
+    """A minimal tool schema for monkeypatched tool tables."""
+    return _tool_schema(name, name, {}, [])
+
+
+def compile_success_tool() -> Tool:
+    """A fake ``compile`` tool that always succeeds and mints a USDZ file."""
+
+    async def run_compile(context: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+        usdz = context.run_dir / "result" / "usdz" / "0000.usdz"
+        usdz.parent.mkdir(parents=True, exist_ok=True)
+        usdz.write_bytes(b"test-usdz")
+        result = {"status": "success", "usdz": str(usdz)}
+        context.compile_result = result
+        context.successful_compile_result = result
+        context.successful_compile_digest = workspace_digest(context.workspace)
+        return result
+
+    return Tool("compile", stub_schema("compile"), run_compile)
+
+
+# ---------------------------------------------------------------------------
+# Canonical workspace sources
+# ---------------------------------------------------------------------------
+
+GOOD_MAIN_PY = """
+from build123d import Box
+
+from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("box")
+    base = model.part("base")
+    base.add(Box(0.2, 0.2, 0.1), name="body")
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    return TestContext(object_model).report()
+"""

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import shlex
 import sys
 from datetime import datetime
-from typing import Any
 
 import pytest
+from harness import (
+    GOOD_MAIN_PY,
+    ModelQuery,
+    Response,
+    ScriptedModel,
+    calls,
+    compile_success_tool,
+    run,
+    stub_schema,
+    text,
+    tool_call,
+)
 
 import mini_articraft.agent.tools as agent_tools
 from mini_articraft.agent import Agent, events
@@ -24,83 +34,8 @@ from mini_articraft.environments.local import DEFAULT_MAIN_PY, LocalEnvironment
 from mini_articraft.record import Record, read_conversation
 
 
-def run(awaitable):
-    return asyncio.get_event_loop().run_until_complete(awaitable)
-
-
-class FakeModel:
-    def __init__(self, responses: list[dict[str, Any]]):
-        self.responses = responses
-        self.calls: list[dict[str, Any]] = []
-        self.config = type(
-            "FakeConfig",
-            (),
-            {"openai_model": "gpt-test", "openai_reasoning_effort": "low"},
-        )()
-
-    async def query(
-        self,
-        messages: list[dict[str, Any]],
-        *,
-        tools: list[dict[str, Any]] | None = None,
-    ) -> dict[str, Any]:
-        self.calls.append({"messages": list(messages), "tools": list(tools or [])})
-        return self.responses.pop(0)
-
-    async def close(self) -> None:
-        pass
-
-
-def call(call_id: str, name: str, args: dict[str, Any]) -> dict[str, Any]:
-    return {"id": call_id, "name": name, "arguments": json.dumps(args)}
-
-
-def fake_schema(name: str) -> dict[str, Any]:
-    return {
-        "type": "function",
-        "name": name,
-        "description": name,
-        "parameters": {"type": "object", "properties": {}, "required": []},
-    }
-
-
-def compile_success_tool() -> Tool:
-    async def run_compile(context, args):
-        usdz = context.run_dir / "result" / "usdz" / "0000.usdz"
-        usdz.parent.mkdir(parents=True, exist_ok=True)
-        usdz.write_bytes(b"test-usdz")
-        result = {"status": "success", "usdz": str(usdz)}
-        context.compile_result = result
-        context.successful_compile_result = result
-        context.successful_compile_digest = workspace_digest(context.workspace)
-        return result
-
-    return Tool("compile", fake_schema("compile"), run_compile)
-
-
-MODEL_CODE = """
-from build123d import *
-
-from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
-
-
-def build_object_model() -> ArticulatedObject:
-    model = ArticulatedObject("box")
-    base = model.part("base")
-    base.add(Box(1, 1, 1), name="body")
-    return model
-
-
-object_model = build_object_model()
-
-
-def run_tests() -> TestReport:
-    return TestContext(object_model).report()
-"""
-
-
 def test_agent_writes_compiles_and_returns_final_response(tmp_path) -> None:
-    model = FakeModel(
+    model = ScriptedModel(
         [
             {
                 "text": "",
@@ -111,7 +46,13 @@ def test_agent_writes_compiles_and_returns_final_response(tmp_path) -> None:
                     "output_tokens": 20,
                     "total_tokens": 120,
                 },
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": MODEL_CODE})],
+                "tool_calls": [
+                    tool_call(
+                        "write",
+                        {"path": "main.py", "content": GOOD_MAIN_PY},
+                        call_id="call_1",
+                    )
+                ],
             },
             {
                 "text": "",
@@ -122,7 +63,7 @@ def test_agent_writes_compiles_and_returns_final_response(tmp_path) -> None:
                     "output_tokens": 30,
                     "total_tokens": 230,
                 },
-                "tool_calls": [call("call_2", "compile", {})],
+                "tool_calls": [tool_call("compile", {}, call_id="call_2")],
             },
             {
                 "text": "done",
@@ -158,14 +99,14 @@ def test_agent_writes_compiles_and_returns_final_response(tmp_path) -> None:
     assert record.result == "result/usdz/0000.usdz"
     assert record.cost == 1.0
     assert record.token_usage["total_tokens"] == 690
-    assert "<sdk_docs>" not in model.calls[0]["messages"][0]["content"]
-    first_messages = model.calls[0]["messages"]
-    assert [message["role"] for message in first_messages[:3]] == ["system", "user", "user"]
-    assert first_messages[1]["content"].startswith("<sdk_quickstart>")
-    assert "docs/sdk/common/30_articulated_object.md" in first_messages[1]["content"]
-    assert first_messages[2]["content"].startswith("<task>")
-    assert "a box" in first_messages[2]["content"]
-    assert {tool["name"] for tool in model.calls[0]["tools"]} == {
+    first_query = model.queries[0]
+    assert "<sdk_docs>" not in first_query.messages[0]["content"]
+    assert [message["role"] for message in first_query.messages[:3]] == ["system", "user", "user"]
+    assert first_query.messages[1]["content"].startswith("<sdk_quickstart>")
+    assert "docs/sdk/common/30_articulated_object.md" in first_query.messages[1]["content"]
+    assert first_query.messages[2]["content"].startswith("<task>")
+    assert "a box" in first_query.messages[2]["content"]
+    assert {tool["name"] for tool in first_query.tools} == {
         "read",
         "edit",
         "write",
@@ -176,15 +117,14 @@ def test_agent_writes_compiles_and_returns_final_response(tmp_path) -> None:
 
 
 def test_agent_requires_compile_before_final_response(tmp_path) -> None:
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": MODEL_CODE})],
-            },
-            {"text": "done too early", "tool_calls": []},
-            {"text": "", "tool_calls": [call("call_2", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(
+                tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY}, call_id="call_1")
+            ),
+            text("done too early"),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            text("done"),
         ]
     )
     env = LocalEnvironment(output_dir=tmp_path)
@@ -194,10 +134,8 @@ def test_agent_requires_compile_before_final_response(tmp_path) -> None:
 
     assert result["status"] == "success"
     assert result["message"] == "done"
-    assert any(
-        "<compile_required>" in str(message.get("content"))
-        and "No successful compile has completed yet." in str(message.get("content"))
-        for message in model.calls[2]["messages"]
+    assert model.queries[2].contains(
+        "<compile_required>", "No successful compile has completed yet."
     )
     conversation = read_conversation(tmp_path / "box" / "conversation.jsonl")
     assert any(
@@ -222,20 +160,17 @@ def test_agent_keeps_compile_fresh_after_read(
         agent_tools,
         "TOOLS",
         {
-            "write": Tool("write", fake_schema("write"), run_write),
-            "read": Tool("read", fake_schema("read"), run_read, supports_parallel=True),
+            "write": Tool("write", stub_schema("write"), run_write),
+            "read": Tool("read", stub_schema("read"), run_read, supports_parallel=True),
             "compile": compile_success_tool(),
         },
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": "x"})],
-            },
-            {"text": "", "tool_calls": [call("call_2", "compile", {})]},
-            {"text": "", "tool_calls": [call("call_3", "read", {"path": "main.py"})]},
-            {"text": "done after read", "tool_calls": []},
+            calls(tool_call("write", {"path": "main.py", "content": "x"}, call_id="call_1")),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            calls(tool_call("read", {"path": "main.py"}, call_id="call_3")),
+            text("done after read"),
         ]
     )
     env = LocalEnvironment(output_dir=tmp_path)
@@ -245,7 +180,7 @@ def test_agent_keeps_compile_fresh_after_read(
 
     assert result["status"] == "success"
     assert result["message"] == "done after read"
-    assert len(model.calls) == 4
+    assert len(model.queries) == 4
 
 
 def test_agent_keeps_compile_fresh_after_inspection_and_noop_edits(
@@ -258,38 +193,26 @@ def test_agent_keeps_compile_fresh_after_inspection_and_noop_edits(
         "TOOLS",
         selected | {"compile": compile_success_tool()},
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": "x"})],
-            },
-            {"text": "", "tool_calls": [call("call_2", "compile", {})]},
-            {
-                "text": "",
-                "tool_calls": [
-                    call(
-                        "call_3",
-                        "edit",
-                        {"path": "main.py", "old_text": "x", "new_text": "x"},
-                    )
-                ],
-            },
-            {
-                "text": "",
-                "tool_calls": [
-                    call(
-                        "call_4",
-                        "edit",
-                        {"path": "main.py", "old_text": "missing", "new_text": "y"},
-                    )
-                ],
-            },
-            {
-                "text": "",
-                "tool_calls": [call("call_5", "exec_command", {"command": "printf inspected"})],
-            },
-            {"text": "done", "tool_calls": []},
+            calls(tool_call("write", {"path": "main.py", "content": "x"}, call_id="call_1")),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            calls(
+                tool_call(
+                    "edit",
+                    {"path": "main.py", "old_text": "x", "new_text": "x"},
+                    call_id="call_3",
+                )
+            ),
+            calls(
+                tool_call(
+                    "edit",
+                    {"path": "main.py", "old_text": "missing", "new_text": "y"},
+                    call_id="call_4",
+                )
+            ),
+            calls(tool_call("exec_command", {"command": "printf inspected"}, call_id="call_5")),
+            text("done"),
         ]
     )
 
@@ -306,20 +229,14 @@ def test_agent_requires_new_compile_after_real_file_change(monkeypatch, tmp_path
         "TOOLS",
         {"write": write_tool, "compile": compile_success_tool()},
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": "x"})],
-            },
-            {"text": "", "tool_calls": [call("call_2", "compile", {})]},
-            {
-                "text": "",
-                "tool_calls": [call("call_3", "write", {"path": "main.py", "content": "y"})],
-            },
-            {"text": "too early", "tool_calls": []},
-            {"text": "", "tool_calls": [call("call_4", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(tool_call("write", {"path": "main.py", "content": "x"}, call_id="call_1")),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            calls(tool_call("write", {"path": "main.py", "content": "y"}, call_id="call_3")),
+            text("too early"),
+            calls(tool_call("compile", {}, call_id="call_4")),
+            text("done"),
         ]
     )
 
@@ -327,10 +244,8 @@ def test_agent_requires_new_compile_after_real_file_change(monkeypatch, tmp_path
 
     assert result["status"] == "success"
     assert result["message"] == "done"
-    assert any(
-        "<compile_required>" in str(message.get("content"))
-        and "changed since the last successful compile" in str(message.get("content"))
-        for message in model.calls[4]["messages"]
+    assert model.queries[4].contains(
+        "<compile_required>", "changed since the last successful compile"
     )
 
 
@@ -342,52 +257,43 @@ def test_running_exec_session_blocks_compile_and_finalization(monkeypatch, tmp_p
         selected | {"compile": compile_success_tool()},
     )
 
-    class SessionModel(FakeModel):
-        async def query(self, messages, *, tools=None):
-            self.calls.append({"messages": list(messages), "tools": list(tools or [])})
-            turn = len(self.calls)
-            if turn == 1:
-                return {
-                    "text": "",
-                    "tool_calls": [
-                        call(
-                            "call_1",
-                            "exec_command",
-                            {
-                                "command": "read value; printf changed > main.py",
-                                "yield_time_ms": 10,
-                            },
-                        )
-                    ],
-                }
-            if turn == 2:
-                return {"text": "", "tool_calls": [call("call_2", "compile", {})]}
-            if turn == 3:
-                return {"text": "too early", "tool_calls": []}
-            if turn == 4:
-                session_id = next(
-                    json.loads(message["output"])["result"]["session_id"]
-                    for message in messages
-                    if message.get("type") == "function_call_output"
-                    and json.loads(message["output"]).get("result", {}).get("session_id")
+    def send_stdin(query: ModelQuery) -> Response:
+        session_id = next(
+            output["result"]["session_id"]
+            for output in query.tool_outputs()
+            if output.get("result", {}).get("session_id")
+        )
+        return calls(
+            tool_call(
+                "write_stdin",
+                {"session_id": session_id, "chars": "go\n", "yield_time_ms": 1000},
+                call_id="call_3",
+            )
+        )
+
+    model = ScriptedModel(
+        [
+            calls(
+                tool_call(
+                    "exec_command",
+                    {
+                        "command": "read value; printf changed > main.py",
+                        "yield_time_ms": 10,
+                    },
+                    call_id="call_1",
                 )
-                return {
-                    "text": "",
-                    "tool_calls": [
-                        call(
-                            "call_3",
-                            "write_stdin",
-                            {"session_id": session_id, "chars": "go\n", "yield_time_ms": 1000},
-                        )
-                    ],
-                }
-            if turn == 5:
-                return {"text": "", "tool_calls": [call("call_4", "compile", {})]}
-            return {"text": "done", "tool_calls": []}
+            ),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            text("too early"),
+            send_stdin,
+            calls(tool_call("compile", {}, call_id="call_4")),
+            text("done"),
+        ]
+    )
 
     result = run(
         Agent(
-            SessionModel([]),
+            model,
             LocalEnvironment(output_dir=tmp_path),
             max_turns=6,
         ).run("box", run_id="box")
@@ -409,25 +315,19 @@ def test_agent_requires_visible_final_after_fresh_compile(monkeypatch, tmp_path)
         "TOOLS",
         {"write": write_tool, "compile": compile_success_tool()},
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": "x"})],
-            },
-            {"text": "", "tool_calls": [call("call_2", "compile", {})]},
-            {"text": "", "tool_calls": []},
-            {"text": "done", "tool_calls": []},
+            calls(tool_call("write", {"path": "main.py", "content": "x"}, call_id="call_1")),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            text(""),
+            text("done"),
         ]
     )
 
     result = run(Agent(model, LocalEnvironment(output_dir=tmp_path), max_turns=4).run("box"))
 
     assert result["message"] == "done"
-    assert any(
-        "<final_response_required>" in str(message.get("content"))
-        for message in model.calls[3]["messages"]
-    )
+    assert model.queries[3].contains("<final_response_required>")
 
 
 def test_agent_does_not_finalize_success_without_a_usdz_result(monkeypatch, tmp_path) -> None:
@@ -441,12 +341,12 @@ def test_agent_does_not_finalize_success_without_a_usdz_result(monkeypatch, tmp_
     monkeypatch.setattr(
         agent_tools,
         "TOOLS",
-        {"compile": Tool("compile", fake_schema("compile"), run_compile)},
+        {"compile": Tool("compile", stub_schema("compile"), run_compile)},
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {"text": "", "tool_calls": [call("call_1", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(tool_call("compile", {}, call_id="call_1")),
+            text("done"),
         ]
     )
 
@@ -483,25 +383,23 @@ def test_cached_success_survives_a_later_failed_compile(monkeypatch, tmp_path) -
         "TOOLS",
         {
             "write": agent_tools.get("write"),
-            "compile": Tool("compile", fake_schema("compile"), run_compile),
+            "compile": Tool("compile", stub_schema("compile"), run_compile),
         },
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {"text": "", "tool_calls": [call("compile_1", "compile", {})]},
-            {
-                "text": "",
-                "tool_calls": [call("change", "write", {"path": "main.py", "content": "bad"})],
-            },
-            {"text": "", "tool_calls": [call("compile_2", "compile", {})]},
-            {
-                "text": "",
-                "tool_calls": [
-                    call("restore", "write", {"path": "main.py", "content": DEFAULT_MAIN_PY})
-                ],
-            },
-            {"text": "", "tool_calls": [call("compile_3", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(tool_call("compile", {}, call_id="compile_1")),
+            calls(tool_call("write", {"path": "main.py", "content": "bad"}, call_id="change")),
+            calls(tool_call("compile", {}, call_id="compile_2")),
+            calls(
+                tool_call(
+                    "write",
+                    {"path": "main.py", "content": DEFAULT_MAIN_PY},
+                    call_id="restore",
+                )
+            ),
+            calls(tool_call("compile", {}, call_id="compile_3")),
+            text("done"),
         ]
     )
 
@@ -516,40 +414,31 @@ def test_cached_success_survives_a_later_failed_compile(monkeypatch, tmp_path) -
 
 def test_agent_cancellation_terminates_a_live_exec_session(tmp_path) -> None:
     command = f"{shlex.quote(sys.executable)} -c 'import time; time.sleep(60)'"
+    waiting = asyncio.Event()
 
-    class BlockingModel(FakeModel):
-        def __init__(self) -> None:
-            super().__init__([])
-            self.waiting = asyncio.Event()
+    async def block_forever(query: ModelQuery) -> Response:
+        waiting.set()
+        pending: asyncio.Future[None] = asyncio.Future()
+        await pending
+        raise AssertionError("blocking query unexpectedly completed")
 
-        async def query(
-            self,
-            messages: list[dict[str, Any]],
-            *,
-            tools: list[dict[str, Any]] | None = None,
-        ) -> dict[str, Any]:
-            self.calls.append({"messages": list(messages), "tools": list(tools or [])})
-            if len(self.calls) == 1:
-                return {
-                    "text": "",
-                    "tool_calls": [
-                        call(
-                            "exec",
-                            "exec_command",
-                            {"command": command, "yield_time_ms": 10},
-                        )
-                    ],
-                }
-            self.waiting.set()
-            pending: asyncio.Future[None] = asyncio.Future()
-            await pending
-            raise AssertionError("blocking query unexpectedly completed")
+    model = ScriptedModel(
+        [
+            calls(
+                tool_call(
+                    "exec_command",
+                    {"command": command, "yield_time_ms": 10},
+                    call_id="exec",
+                )
+            ),
+            block_forever,
+        ]
+    )
 
     async def exercise() -> None:
         env = LocalEnvironment(output_dir=tmp_path)
-        model = BlockingModel()
         task = asyncio.create_task(Agent(model, env, max_turns=3).run("box", run_id="cancel"))
-        await asyncio.wait_for(model.waiting.wait(), timeout=5)
+        await asyncio.wait_for(waiting.wait(), timeout=5)
         context = ToolContext(env, tmp_path / "cancel", tmp_path / "cancel" / "workspace")
         assert EXEC_MANAGER.has_live_session(context)
         task.cancel()
@@ -561,27 +450,22 @@ def test_agent_cancellation_terminates_a_live_exec_session(tmp_path) -> None:
 
 
 def test_agent_fails_third_consecutive_empty_response(tmp_path) -> None:
-    model = FakeModel([{"text": "", "tool_calls": []} for _ in range(3)])
+    model = ScriptedModel([text("") for _ in range(3)])
 
     result = run(Agent(model, LocalEnvironment(output_dir=tmp_path), max_turns=3).run("box"))
 
     assert result["status"] == "error"
     assert "three consecutive responses" in result["error"]
-    assert any(
-        "Do not continue with reasoning-only output." in str(message.get("content"))
-        for message in model.calls[2]["messages"]
-    )
+    assert model.queries[2].contains("Do not continue with reasoning-only output.")
 
 
 def test_agent_records_model_query_failure(tmp_path) -> None:
-    class FailingModel(FakeModel):
-        async def query(self, messages, *, tools=None):
-            self.calls.append({"messages": list(messages), "tools": list(tools or [])})
-            raise RuntimeError("socket closed")
+    def fail(query: ModelQuery) -> Response:
+        raise RuntimeError("socket closed")
 
-    result = run(
-        Agent(FailingModel([]), LocalEnvironment(output_dir=tmp_path), max_turns=3).run("box")
-    )
+    model = ScriptedModel([fail])
+
+    result = run(Agent(model, LocalEnvironment(output_dir=tmp_path), max_turns=3).run("box"))
 
     assert result["status"] == "error"
     assert result["result"] == ""
@@ -589,14 +473,13 @@ def test_agent_records_model_query_failure(tmp_path) -> None:
 
 
 def test_agent_emits_run_events(tmp_path) -> None:
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [call("call_1", "write", {"path": "main.py", "content": MODEL_CODE})],
-            },
-            {"text": "", "tool_calls": [call("call_2", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(
+                tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY}, call_id="call_1")
+            ),
+            calls(tool_call("compile", {}, call_id="call_2")),
+            text("done"),
         ]
     )
     env = LocalEnvironment(output_dir=tmp_path)
@@ -654,21 +537,18 @@ def test_agent_runs_parallel_safe_tools_concurrently(monkeypatch, tmp_path) -> N
         agent_tools,
         "TOOLS",
         {
-            "read": Tool("read", fake_schema("read"), run_read, supports_parallel=True),
+            "read": Tool("read", stub_schema("read"), run_read, supports_parallel=True),
             "compile": compile_success_tool(),
         },
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [
-                    call("call_1", "read", {"path": "a.py"}),
-                    call("call_2", "read", {"path": "b.py"}),
-                ],
-            },
-            {"text": "", "tool_calls": [call("call_3", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(
+                tool_call("read", {"path": "a.py"}, call_id="call_1"),
+                tool_call("read", {"path": "b.py"}, call_id="call_2"),
+            ),
+            calls(tool_call("compile", {}, call_id="call_3")),
+            text("done"),
         ]
     )
     env = LocalEnvironment(output_dir=tmp_path)
@@ -702,21 +582,18 @@ def test_agent_serializes_non_parallel_tools(monkeypatch, tmp_path) -> None:
         agent_tools,
         "TOOLS",
         {
-            "write": Tool("write", fake_schema("write"), run_write, supports_parallel=True),
+            "write": Tool("write", stub_schema("write"), run_write, supports_parallel=True),
             "compile": compile_success_tool(),
         },
     )
-    model = FakeModel(
+    model = ScriptedModel(
         [
-            {
-                "text": "",
-                "tool_calls": [
-                    call("call_1", "write", {"path": "a.py"}),
-                    call("call_2", "write", {"path": "b.py"}),
-                ],
-            },
-            {"text": "", "tool_calls": [call("call_3", "compile", {})]},
-            {"text": "done", "tool_calls": []},
+            calls(
+                tool_call("write", {"path": "a.py"}, call_id="call_1"),
+                tool_call("write", {"path": "b.py"}, call_id="call_2"),
+            ),
+            calls(tool_call("compile", {}, call_id="call_3")),
+            text("done"),
         ]
     )
     env = LocalEnvironment(output_dir=tmp_path)

--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -1,0 +1,210 @@
+"""Deep agent-loop scenarios: the full pipeline with a scripted model, for $0.
+
+Every scenario runs the real tools and the real compile worker (via
+``LocalEnvironment``), so the model-facing machinery --
+compile signals, repeat-failure guidance, allowances, reminders, the run
+record, the event stream -- is exercised end to end without a paid
+generation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from harness import (
+    GOOD_MAIN_PY,
+    EventRecorder,
+    ModelQuery,
+    Response,
+    calls,
+    run_scenario,
+    text,
+    tool_call,
+)
+
+from mini_articraft.agent.events import AssistantMessage, RunFinished, RunStarted, ToolStarted
+from mini_articraft.environments.local import LocalEnvironment
+
+BROKEN_NO_RUN_TESTS = """
+from build123d import Box
+
+from mini_articraft.sdk import ArticulatedObject
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("box")
+    base = model.part("base")
+    base.add(Box(0.2, 0.2, 0.1), name="body")
+    return model
+
+
+object_model = build_object_model()
+"""
+
+OVERLAP_MAIN = """
+from build123d import Box
+
+from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("press_fit")
+    base = model.part("base")
+    base.add(Box(0.2, 0.2, 0.1), name="body")
+    pin = model.part("pin")
+    pin.add(Box(0.05, 0.05, 0.2), name="body")
+    model.articulation("press_fit_pin", "fixed", parent="base", child="pin")
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    return TestContext(object_model).report()
+"""
+
+OVERLAP_ALLOWED_MAIN = OVERLAP_MAIN.replace(
+    "    return TestContext(object_model).report()",
+    """    ctx = TestContext(object_model)
+    ctx.allow_overlap(
+        "base",
+        "pin",
+        reason="intentional press-fit embed",
+        shape_a="body",
+        shape_b="body",
+    )
+    return ctx.report()""",
+)
+
+
+def write_main(content: str) -> Response:
+    return calls(tool_call("write", {"path": "main.py", "content": content}))
+
+
+def compile_workspace() -> Response:
+    return calls(tool_call("compile"))
+
+
+def compile_signals_shown(tool_outputs: list[dict[str, Any]]) -> list[str]:
+    """The rendered <compile_signals> blocks the model was shown, in order."""
+    return [
+        output["result"]["compile_signals"]
+        for output in tool_outputs
+        if isinstance(output.get("result"), dict) and "compile_signals" in output["result"]
+    ]
+
+
+def event_signal_codes(recorder: EventRecorder) -> list[str]:
+    """Machine-readable signal codes from the full compile results in events."""
+    codes: list[str] = []
+    for finished in recorder.tool_finishes("compile"):
+        bundle = finished.payload["result"]["compile_report"]["signal_bundle"]
+        codes.extend(signal["code"] for signal in bundle["signals"])
+    return codes
+
+
+def test_agent_repairs_a_missing_run_tests_with_real_signals(tmp_path: Path) -> None:
+    env = LocalEnvironment(output_dir=tmp_path)
+
+    def repair(query: ModelQuery) -> Response:
+        signals = compile_signals_shown(query.tool_outputs())
+        assert signals and "[missing_run_tests]" in signals[-1]
+        return write_main(GOOD_MAIN_PY)
+
+    artifacts = run_scenario(
+        "a box",
+        [
+            write_main(BROKEN_NO_RUN_TESTS),
+            compile_workspace(),
+            repair,
+            compile_workspace(),
+            text("done"),
+        ],
+        env=env,
+        max_turns=5,
+    )
+
+    assert artifacts.record.status == "success"
+    assert artifacts.result["message"] == "done"
+    codes = event_signal_codes(artifacts.recorder)
+    assert "COMPILE_MISSING_RUN_TESTS" in codes
+
+
+def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> None:
+    env = LocalEnvironment(output_dir=tmp_path)
+
+    artifacts = run_scenario(
+        "a box",
+        [
+            write_main(BROKEN_NO_RUN_TESTS),
+            compile_workspace(),
+            write_main(BROKEN_NO_RUN_TESTS),
+            compile_workspace(),
+            write_main(BROKEN_NO_RUN_TESTS),
+            compile_workspace(),
+            write_main(GOOD_MAIN_PY),
+            compile_workspace(),
+            text("done"),
+        ],
+        env=env,
+        max_turns=9,
+    )
+
+    assert artifacts.record.status == "success"
+    signals = compile_signals_shown(artifacts.tool_outputs())
+    assert len(signals) == 4
+    assert "matches the previous compile attempt" not in signals[0]
+    assert "matches the previous compile attempt" in signals[1]
+    assert "compile failure 3 in a row" in signals[2]
+
+
+def test_overlap_allowance_flows_through_the_real_worker(tmp_path: Path) -> None:
+    env = LocalEnvironment(output_dir=tmp_path)
+
+    def allow_the_overlap(query: ModelQuery) -> Response:
+        signals = compile_signals_shown(query.tool_outputs())
+        assert signals and "[real_overlap]" in signals[-1]
+        return write_main(OVERLAP_ALLOWED_MAIN)
+
+    artifacts = run_scenario(
+        "a press-fit pin",
+        [
+            write_main(OVERLAP_MAIN),
+            compile_workspace(),
+            allow_the_overlap,
+            compile_workspace(),
+            text("done"),
+        ],
+        env=env,
+        max_turns=5,
+    )
+
+    assert artifacts.record.status == "success"
+    codes = event_signal_codes(artifacts.recorder)
+    assert "QC_REAL_OVERLAP" in codes
+    assert "NOTE_ALLOWED_OVERLAP" in codes
+    final_signals = compile_signals_shown(artifacts.tool_outputs())[-1]
+    assert "allowed by justification" in final_signals
+
+
+def test_event_stream_is_ordered_and_complete(tmp_path: Path) -> None:
+    artifacts = run_scenario(
+        "a box",
+        [write_main(GOOD_MAIN_PY), compile_workspace(), text("done")],
+        env=LocalEnvironment(output_dir=tmp_path),
+    )
+
+    stream = artifacts.recorder.events
+    assert isinstance(stream[0], RunStarted)
+    assert isinstance(stream[-1], RunFinished)
+    assert len(artifacts.recorder.of(AssistantMessage)) == 3
+    for name in ("write", "compile"):
+        started = next(
+            index
+            for index, event in enumerate(stream)
+            if isinstance(event, ToolStarted) and event.name == name
+        )
+        finished = artifacts.recorder.tool_finishes(name)[0]
+        assert started < stream.index(finished)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,129 @@
+"""Tests for the modular test environment itself (tests/harness.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from harness import (
+    GOOD_MAIN_PY,
+    ModelQuery,
+    Response,
+    ScriptedModel,
+    ScriptExhaustedError,
+    calls,
+    run,
+    run_scenario,
+    text,
+    tool_call,
+)
+
+from mini_articraft.agent.events import TurnStarted
+from mini_articraft.environments.local import LocalEnvironment
+
+
+def write_good_main() -> Response:
+    return calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY}))
+
+
+# ---------------------------------------------------------------------------
+# ScriptedModel
+# ---------------------------------------------------------------------------
+
+
+def test_scripted_model_plays_steps_and_fills_defaults() -> None:
+    model = ScriptedModel([text("hello"), calls(tool_call("read", {"path": "a.py"}))])
+
+    first = run(model.query([{"role": "user", "content": "go"}]))
+    assert first == {"text": "hello", "tool_calls": [], "cost": 0.0, "token_usage": {}}
+    assert model.remaining == 1
+
+    second = run(model.query([{"role": "user", "content": "go"}]))
+    assert second["tool_calls"][0]["name"] == "read"
+    assert model.remaining == 0
+    assert [query.turn for query in model.queries] == [1, 2]
+    assert model.queries[0].messages == [{"role": "user", "content": "go"}]
+    model.assert_exhausted()
+
+
+def test_scripted_model_exhaustion_raises_a_clear_error() -> None:
+    model = ScriptedModel([text("only")])
+    run(model.query([]))
+    with pytest.raises(ScriptExhaustedError, match="turn 2 beyond the 1 scripted step"):
+        run(model.query([]))
+
+
+def test_assert_exhausted_catches_unplayed_steps() -> None:
+    model = ScriptedModel([text("a"), text("b")])
+    run(model.query([]))
+    with pytest.raises(AssertionError, match="1 scripted step"):
+        model.assert_exhausted()
+
+
+def test_step_exceptions_propagate_as_model_failures() -> None:
+    def fail(query: ModelQuery) -> Response:
+        raise RuntimeError("socket closed")
+
+    model = ScriptedModel([fail])
+    with pytest.raises(RuntimeError, match="socket closed"):
+        run(model.query([]))
+
+
+def test_normalized_responses_do_not_mutate_step_dicts() -> None:
+    step = {"text": "hi", "tool_calls": []}
+    model = ScriptedModel([step])
+    run(model.query([]))
+    assert step == {"text": "hi", "tool_calls": []}
+
+
+# ---------------------------------------------------------------------------
+# run_scenario
+# ---------------------------------------------------------------------------
+
+
+def test_run_scenario_returns_deep_artifacts(tmp_path: Path) -> None:
+    artifacts = run_scenario(
+        "a box",
+        [write_good_main(), calls(tool_call("compile")), text("done")],
+        env=LocalEnvironment(output_dir=tmp_path),
+    )
+
+    assert artifacts.record.status == "success"
+    assert artifacts.result["message"] == "done"
+    assert (artifacts.workspace / "main.py").is_file()
+    assert [event.turn for event in artifacts.recorder.of(TurnStarted)] == [1, 2, 3]
+    assert len(artifacts.recorder.tool_finishes("compile")) == 1
+    finished = artifacts.recorder.finished
+    assert finished is not None
+    assert finished.status == "success"
+    assert artifacts.tool_outputs()[0]["result"]["path"] == "main.py"
+    assert artifacts.model.queries[-1].turn == 3
+
+
+def test_reactive_steps_can_assert_on_tool_outputs(tmp_path: Path) -> None:
+    def check_write(query: ModelQuery) -> Response:
+        outputs = query.tool_outputs()
+        assert outputs[-1]["result"]["path"] == "main.py"
+        return calls(tool_call("compile"))
+
+    artifacts = run_scenario(
+        "a box",
+        [write_good_main(), check_write, text("done")],
+        env=LocalEnvironment(output_dir=tmp_path),
+    )
+    assert artifacts.record.status == "success"
+
+
+def test_run_scenario_fails_when_the_script_is_not_consumed(tmp_path: Path) -> None:
+    with pytest.raises(AssertionError, match="never consumed"):
+        run_scenario(
+            "a box",
+            [text("done"), text("extra")],
+            env=LocalEnvironment(output_dir=tmp_path),
+            max_turns=1,
+        )
+
+
+def test_run_scenario_validates_its_arguments() -> None:
+    with pytest.raises(ValueError, match="env= or tmp_path="):
+        run_scenario("a box", [text("x")])


### PR DESCRIPTION
## Summary

Generation loops are expensive to test: a real model costs money, and every interesting agent behavior used to need either a paid run or a private per-file fake. This PR adds the **scripted agent lane** — a shared, deterministic stand-in for *model behavior* so we can exercise the real agent loop in CI for $0.

**What this is (and is not):**
- **Is:** a richer deterministic test harness. `ScriptedModel` plays a script of model turns (fixed responses or callables that react to what the agent sent). The tools, compile worker, compile signals, reminders, run record, and event stream are real.
- **Is not:** an autofix product feature. When a scenario “repairs” a broken workspace, that is the *scripted model choosing to write a fixed `main.py`* after seeing real `<compile_signals>` — the same path a paid model would take — so we can lock the feedback → next-turn contract without calling OpenAI.

**Why we want it:**
- Unit tests of `compile_feedback` alone never prove signals actually reach the model and the loop continues.
- Per-file `FakeModel`s do not scale and cannot express reactive multi-turn behavior cleanly.
- This lane is the foundation for later cassette record/replay (pay once, replay forever). Scripted = author scenarios; cassettes = freeze a specific trajectory.

## What's in the box

| Piece | Role |
| --- | --- |
| `tests/harness.py` | Shared kit: `ScriptedModel`, `run_scenario`, `EventRecorder`, `RunArtifacts`, `calls` / `text` / `tool_call`, shared fakes |
| `tests/test_agent_harness.py` | Migrated onto the kit; private `FakeModel` deleted (~300 lines of one-off fakes gone) |
| `tests/test_agent_scenarios.py` | Deep end-to-end scenarios through the real compile worker |
| `tests/test_harness.py` | Meta-tests for the harness itself |
| `tests/README.md` + `AGENTS.md` | Document the lane |

### Example: “repair” is scripted model behavior

```text
write broken main.py  →  compile (real worker fails)
                      →  model query contains [missing_run_tests]
                      →  scripted step writes good main.py
                      →  compile succeeds  →  "done"
```

The middle step is a callable that *asserts* on the signals it was shown, then returns the next tool call — deterministic model behavior, not silent framework patching.

### Scenarios covered (for $0)

- Missing `run_tests()` → real `COMPILE_MISSING_RUN_TESTS` signal → scripted fix → success
- Repeat compile failures escalate guidance (`matches the previous compile attempt` → `compile failure 3 in a row`)
- Real overlap → allowance rewrite → `NOTE_ALLOWED_OVERLAP` / “allowed by justification”
- Event stream ordered and complete (`RunStarted` … tool start/finish … `RunFinished`)

### Authoring shape

```python
artifacts = run_scenario(
    "a box",
    [
        calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY})),
        calls(tool_call("compile")),
        text("done"),
    ],
    tmp_path=tmp_path,
)
assert artifacts.record.status == "success"
```

Steps may also be `(ModelQuery) -> Response` callables to assert on / react to prior tool outputs.

## Test plan

- [ ] `uv run pytest tests/test_agent_harness.py -q` — expect 18 passed
- [ ] `uv run pytest tests/test_agent_scenarios.py -v` — expect 5 passed; watch the repair / escalation / allowance scenarios
- [ ] `uv run pytest tests/test_harness.py tests/test_agent_scenarios.py tests/test_agent_harness.py -q` — fuller gate (~31 passed; cold compiles ~45s)
- [ ] Confirm no paid model calls (no `OPENAI_API_KEY` required for the above)