### PR TITLE
Pay for a generation once, replay it forever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,7 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Recorded generation cassettes stay local unless deliberately curated.
+tests/cassettes/*
+!tests/cassettes/.gitkeep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,8 @@ directories for compile and record tests. Do not require real model calls unless
 the test is explicitly about a live adapter.
 
 `tests/harness.py` is the modular test environment for agent-loop behavior:
-scripted models drive the full loop without paid model calls. See
+scripted models and cassette replay (`ReplayHarness`) drive the full loop
+without paid model calls. See
 `tests/README.md` for the lanes and when to use each. Keep the subprocess
 worker contract covered in `test_compile.py`. A few exec-output timing tests
 are known to flake on macOS; do not weaken them locally.

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,35 @@ A scripted step can also be a callable `(ModelQuery) -> Response`, so the
 See `tests/test_agent_scenarios.py` for end-to-end examples (repair loops,
 repeat-failure guidance, allowances).
 
+## Cassettes: pay once, replay forever
+
+`ReplayHarness` manages any number of named recordings as
+`<name>.jsonl` files under one root. The `replay_harness` pytest fixture
+gives each test a scratch library.
+
+```python
+# capture: record a real run once (or a scripted run, for free authoring)
+with replay_harness.capture("hinged-box", OpenAIModel()) as model:
+    run(Agent(model, env).run("a hinged box"))
+
+# set: install or transform a cassette without running anything
+replay_harness.set("plain-box", [calls(tool_call("compile")), text("done")])
+
+# replay: plug any recording into a run; strict mode fails on trajectory drift
+artifacts = run_scenario("a box", model=replay_harness.replay("plain-box"))
+
+# erase / clear
+replay_harness.erase("plain-box")
+```
+
+Strict replay compares a structural fingerprint (roles, tool names, call
+ids), not payload text, because tool outputs embed machine-specific run
+paths. Rows installed by `set()` carry no fingerprint and match any request.
+
+Curated regression cassettes belong in `tests/cassettes/` (git-ignored by
+default; force-add the ones worth keeping). Scratch cassettes belong under
+`tmp_path`.
+
 ## Known platform flakes
 
 On macOS, a few exec-output timing tests can fail with empty captured output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
+from harness import ReplayHarness
 
 
 @pytest.fixture(scope="session")
@@ -34,3 +36,9 @@ def _event_loop():
 def _use_session_loop(_event_loop):
     asyncio.set_event_loop(_event_loop)
     return _event_loop
+
+
+@pytest.fixture
+def replay_harness(tmp_path: Path) -> ReplayHarness:
+    """A scratch cassette library under the test's tmp dir."""
+    return ReplayHarness(tmp_path / "cassettes")

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -7,19 +7,27 @@ Verify the generation loop deeply without paying for model calls:
 2. Scripted agent lane -- :class:`ScriptedModel` plus :func:`run_scenario`
    drive the full agent loop (tools, reminders, compile freshness, record)
    with a deterministic model that can react to what the agent sends it.
+3. Cassette lane -- :class:`ReplayHarness` manages any number of named
+   recordings: capture one from a live (paid) model once, author one from a
+   scripted model for free, or install one by hand; then plug any of them
+   into :func:`run_scenario` by name for offline regression runs.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import itertools
 import json
-from collections.abc import Awaitable, Callable, Iterable
+import re
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Generic, TypeVar
 
+from mini_articraft import Model
 from mini_articraft.agent import Agent, events
 from mini_articraft.agent.tools import Tool, ToolContext
 from mini_articraft.agent.tools._core import schema as _tool_schema
@@ -132,7 +140,15 @@ def _normalize_response(response: Response) -> Response:
 
 
 class ScriptExhaustedError(RuntimeError):
-    """The agent asked for more turns than the script provides."""
+    """The agent asked for more turns than the script (or cassette) provides."""
+
+
+class CassetteError(RuntimeError):
+    """A recording is missing, empty, or otherwise unusable."""
+
+
+class CassetteMismatchError(CassetteError):
+    """A replayed run diverged from the recorded message trajectory."""
 
 
 @dataclass(frozen=True)
@@ -217,6 +233,299 @@ class ScriptedModel(QueuedModel[Step]):
 
 
 # ---------------------------------------------------------------------------
+# Cassette lane: record and replay models
+# ---------------------------------------------------------------------------
+
+
+def _fingerprint(messages: Messages, tools: list[dict[str, Any]] | None = None) -> str:
+    """Hash the structural shape of a request, not its payload text.
+
+    Covers message roles/types, tool-call names, call ids, and the offered
+    tool set: a run whose conversation or tool surface drifts from the
+    recording fails strict replay, while payload text (which embeds
+    machine-specific run paths) stays excluded.
+    """
+    structural: list[dict[str, Any]] = []
+    for message in messages:
+        entry: dict[str, Any] = {
+            "role": message.get("role"),
+            "type": message.get("type"),
+        }
+        for key in ("name", "call_id"):
+            if message.get(key):
+                entry[key] = message[key]
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            entry["tool_calls"] = [call.get("name") for call in tool_calls]
+        structural.append(entry)
+    raw = json.dumps(
+        {
+            "messages": structural,
+            "tools": sorted(str(tool.get("name")) for tool in tools or []),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha1(raw.encode()).hexdigest()
+
+
+def _read_cassette(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise CassetteError(f"invalid cassette row {path}:{lineno}: {exc}") from exc
+    return rows
+
+
+def _append_cassette_row(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(row, default=str) + "\n")
+
+
+class RecordingModel:
+    """Wrap a live model and append every exchange to a JSONL cassette.
+
+    Each line stores a structural fingerprint of the request messages plus the
+    full response dict. Record once with real credentials, commit or keep the
+    cassette, then regression-test offline with :class:`ReplayModel`. Prefer
+    :meth:`ReplayHarness.capture` over constructing this directly.
+    """
+
+    def __init__(self, model: Model, cassette: Path | str):
+        self.model = model
+        self.cassette = Path(cassette)
+        self.queries: list[ModelQuery] = []
+        self.config = getattr(model, "config", None)
+        self.context_window_tokens = getattr(model, "context_window_tokens", 0)
+
+    async def query(
+        self,
+        messages: Messages,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> Response:
+        _record_query(self.queries, messages, tools)
+        response = await self.model.query(messages, tools=tools)
+        _append_cassette_row(
+            self.cassette,
+            {"fingerprint": _fingerprint(messages, tools), "response": response},
+        )
+        return response
+
+    async def close(self) -> None:
+        await self.model.close()
+
+    def assert_exhausted(self) -> None:
+        """Delegate to the wrapped model when it is finite (e.g. scripted)."""
+        if isinstance(self.model, QueuedModel):
+            self.model.assert_exhausted()
+
+
+class ReplayModel(QueuedModel[dict[str, Any]]):
+    """Replay one cassette recorded by :class:`RecordingModel`.
+
+    In strict mode every query's structural fingerprint (roles, message
+    types, tool-call names, call ids, the offered tool set) must match the
+    recording, so a run that diverges from the recorded trajectory fails
+    loudly. Payload contents are intentionally excluded: tool outputs embed
+    machine-specific run paths.
+    Rows without a fingerprint -- hand-authored via :meth:`ReplayHarness.set`
+    -- match any request. Prefer :meth:`ReplayHarness.replay` over
+    constructing this directly.
+    """
+
+    noun: ClassVar[str] = "cassette row"
+
+    def __init__(
+        self,
+        cassette: Path | str,
+        *,
+        strict: bool = True,
+        model_name: str = "gpt-replay",
+        reasoning_effort: str = "",
+    ):
+        super().__init__(
+            [row for row in _read_cassette(Path(cassette)) if "response" in row],
+            model_name=model_name,
+            reasoning_effort=reasoning_effort,
+        )
+        self._strict = strict
+
+    async def query(
+        self, messages: Messages, *, tools: list[dict[str, Any]] | None = None
+    ) -> Response:
+        query = _record_query(self.queries, messages, tools)
+        entry = self._next(query)
+        expected = str(entry.get("fingerprint") or "")
+        if self._strict and expected and expected != _fingerprint(messages, tools):
+            raise CassetteMismatchError(
+                f"turn {query.turn} diverged from the recorded trajectory; "
+                "re-record the cassette if this change is intentional"
+            )
+        return _normalize_response(entry["response"])
+
+
+ScenarioModel = ScriptedModel | RecordingModel | ReplayModel
+
+
+# ---------------------------------------------------------------------------
+# Cassette lane: the replay harness
+# ---------------------------------------------------------------------------
+
+CASSETTE_ROOT = Path(__file__).resolve().parent / "cassettes"
+_CASSETTE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+
+def _cassette_name(name: str) -> str:
+    value = str(name).strip()
+    if not _CASSETTE_NAME.fullmatch(value):
+        raise ValueError("cassette name must be a simple file name (letters, digits, _ . -)")
+    return value
+
+
+class ReplayHarness:
+    """A named library of cassette recordings for offline replay testing.
+
+    One recording is one ``<name>.jsonl`` cassette under ``root``. Any number
+    of recordings coexist; each plugs into :func:`run_scenario` by name::
+
+        library = ReplayHarness(tmp_path / "cassettes")
+
+        # capture: record one run (paid with a live model, free with a
+        # ScriptedModel -- the cheap way to author a cassette)
+        with library.capture("hinged-box", model) as recording:
+            run(Agent(recording, env).run("a hinged box"))
+
+        # set: install a hand-authored recording without any run at all
+        library.set("plain-box", [calls(tool_call("compile")), text("done")])
+
+        # replay: plug any recording into a scenario by name
+        artifacts = run_scenario("a hinged box", model=library.replay("hinged-box"))
+
+        # erase: remove one recording, or clear() to wipe the library
+        library.erase("plain-box")
+
+    ``CASSETTE_ROOT`` (``tests/cassettes/``) is the conventional root for
+    curated recordings; use a ``tmp_path`` root for ephemeral ones.
+    """
+
+    def __init__(self, root: Path | str = CASSETTE_ROOT):
+        self.root = Path(root)
+
+    def path(self, name: str) -> Path:
+        """The cassette path for a recording name (validated, no traversal)."""
+        return self.root / f"{_cassette_name(name)}.jsonl"
+
+    def has(self, name: str) -> bool:
+        return self.path(name).is_file()
+
+    def names(self) -> list[str]:
+        """All recording names in the library, sorted."""
+        if not self.root.is_dir():
+            return []
+        return sorted(path.stem for path in self.root.glob("*.jsonl"))
+
+    def entries(self, name: str) -> list[dict[str, Any]]:
+        """Parsed cassette rows, e.g. to transform and re-``set`` a recording."""
+        path = self.path(name)
+        if not path.is_file():
+            raise CassetteError(f"unknown recording: {name!r}")
+        return _read_cassette(path)
+
+    @contextmanager
+    def capture(
+        self,
+        name: str,
+        model: Model,
+        *,
+        meta: dict[str, Any] | None = None,
+    ) -> Iterator[RecordingModel]:
+        """Record a fresh cassette for ``name`` from the exchanges in the block.
+
+        Any existing cassette is replaced immediately. ``meta`` is stored as
+        a leading metadata row (e.g. the original prompt); replay skips it.
+        Exiting the block without a single recorded exchange raises
+        :class:`CassetteError` -- an empty cassette is always a broken
+        capture. If the block raises, whatever was recorded stays on disk for
+        inspection (the next capture replaces it).
+        """
+        path = self.path(name)
+        self.root.mkdir(parents=True, exist_ok=True)
+        path.unlink(missing_ok=True)
+        if meta:
+            _append_cassette_row(path, {"meta": dict(meta)})
+        recorder = RecordingModel(model, path)
+        yield recorder
+        if not recorder.queries:
+            raise CassetteError(f"capture {name!r} recorded no exchanges")
+
+    def set(self, name: str, rows: Iterable[dict[str, Any]]) -> Path:
+        """Install a cassette from response dicts or full cassette rows.
+
+        Plain response dicts (built with :func:`text`/:func:`calls`) get no
+        fingerprint, so strict replay accepts them for any request. Full rows
+        (e.g. from :meth:`entries`) keep their fingerprints. Returns the
+        cassette path.
+        """
+        normalized: list[dict[str, Any]] = []
+        for row in rows:
+            if "meta" in row:
+                normalized.append({"meta": row["meta"]})
+            elif "response" in row:
+                normalized.append(
+                    {
+                        "fingerprint": str(row.get("fingerprint") or ""),
+                        "response": row["response"],
+                    }
+                )
+            else:
+                normalized.append({"fingerprint": "", "response": _normalize_response(row)})
+        if not any("response" in row for row in normalized):
+            raise CassetteError(f"refusing to install an empty recording: {name!r}")
+        path = self.path(name)
+        self.root.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "".join(json.dumps(row, default=str) + "\n" for row in normalized),
+            encoding="utf-8",
+        )
+        return path
+
+    def meta(self, name: str) -> dict[str, Any]:
+        """Metadata recorded with the cassette (e.g. the prompt), or ``{}``."""
+        for row in self.entries(name):
+            if "meta" in row:
+                return dict(row["meta"])
+        return {}
+
+    def replay(self, name: str, *, strict: bool = True) -> ReplayModel:
+        """Plug recording ``name`` into a run as a :class:`ReplayModel`."""
+        if not self.has(name):
+            raise CassetteError(f"unknown recording: {name!r}")
+        return ReplayModel(self.path(name), strict=strict)
+
+    def erase(self, name: str) -> bool:
+        """Remove one recording. True when one existed."""
+        path = self.path(name)
+        if not path.is_file():
+            return False
+        path.unlink()
+        return True
+
+    def clear(self) -> int:
+        """Remove every recording; returns how many were removed."""
+        removed = 0
+        for name in self.names():
+            self.erase(name)
+            removed += 1
+        return removed
+
+
+# ---------------------------------------------------------------------------
 # Scenario runner
 # ---------------------------------------------------------------------------
 
@@ -254,7 +563,7 @@ class RunArtifacts:
 
     result: dict[str, Any]
     record: Record
-    model: ScriptedModel
+    model: ScenarioModel
     recorder: EventRecorder
     run_dir: Path
 
@@ -273,8 +582,9 @@ class RunArtifacts:
 
 def run_scenario(
     prompt: str,
-    script: Iterable[Step],
+    script: Iterable[Step] | None = None,
     *,
+    model: ScenarioModel | None = None,
     env: LocalEnvironment | None = None,
     tmp_path: Path | None = None,
     run_id: str = "scenario",
@@ -283,15 +593,23 @@ def run_scenario(
 ) -> RunArtifacts:
     """Run the full agent loop for free and return deep-inspectable artifacts.
 
-    Pass ``env`` to choose the environment or ``tmp_path`` for a plain
-    ``LocalEnvironment``. By default the script must be consumed exactly;
-    pass ``assert_exhausted=False`` for open-ended runs.
+    The model is a fresh :class:`ScriptedModel` built from ``script`` unless
+    ``model=`` plugs in something else -- e.g. one recording from a
+    :class:`ReplayHarness`. Pass ``env`` to choose the compile lane
+    (:class:`WarmEnvironment` for speed) or ``tmp_path`` for a plain
+    subprocess ``LocalEnvironment``. By default the model must be consumed
+    exactly; pass ``assert_exhausted=False`` for open-ended runs.
     """
+    if model is None:
+        if script is None:
+            raise ValueError("run_scenario needs script= or model=")
+        model = ScriptedModel(script)
+    elif script is not None:
+        raise ValueError("run_scenario takes script= or model=, not both")
     if env is None:
         if tmp_path is None:
             raise ValueError("run_scenario needs env= or tmp_path=")
         env = LocalEnvironment(output_dir=tmp_path)
-    model = ScriptedModel(script)
     recorder = EventRecorder()
     agent = Agent(model, env, max_turns=max_turns, on_event=recorder)
     result = run(agent.run(prompt, run_id=run_id))

--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -16,6 +16,7 @@ from harness import (
     GOOD_MAIN_PY,
     EventRecorder,
     ModelQuery,
+    ReplayHarness,
     Response,
     calls,
     run_scenario,
@@ -208,3 +209,21 @@ def test_event_stream_is_ordered_and_complete(tmp_path: Path) -> None:
         )
         finished = artifacts.recorder.tool_finishes(name)[0]
         assert started < stream.index(finished)
+
+
+def test_hand_authored_cassette_drives_a_real_run(
+    tmp_path: Path, replay_harness: ReplayHarness
+) -> None:
+    replay_harness.set(
+        "authored-box",
+        [write_main(GOOD_MAIN_PY), compile_workspace(), text("done from tape")],
+    )
+
+    artifacts = run_scenario(
+        "a box",
+        model=replay_harness.replay("authored-box"),
+        env=LocalEnvironment(output_dir=tmp_path),
+    )
+
+    assert artifacts.record.status == "success"
+    assert artifacts.result["message"] == "done from tape"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 from harness import (
     GOOD_MAIN_PY,
+    CassetteError,
+    CassetteMismatchError,
     ModelQuery,
+    ReplayHarness,
     Response,
     ScriptedModel,
     ScriptExhaustedError,
@@ -77,6 +81,131 @@ def test_normalized_responses_do_not_mutate_step_dicts() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ReplayHarness
+# ---------------------------------------------------------------------------
+
+
+def test_capture_set_replay_erase_cycle(replay_harness: ReplayHarness) -> None:
+    assert replay_harness.names() == []
+
+    with replay_harness.capture("box", ScriptedModel([text("hi")])) as recording:
+        run(recording.query([{"role": "user", "content": "go"}]))
+    assert replay_harness.names() == ["box"]
+    assert replay_harness.entries("box")[0]["response"]["text"] == "hi"
+
+    replay = replay_harness.replay("box")
+    assert run(replay.query([{"role": "user", "content": "go"}]))["text"] == "hi"
+    replay.assert_exhausted()
+
+    assert replay_harness.erase("box") is True
+    assert replay_harness.erase("box") is False
+    assert not replay_harness.has("box")
+
+
+def test_capture_replaces_existing_and_rejects_empty_captures(
+    replay_harness: ReplayHarness,
+) -> None:
+    replay_harness.set("run", [text("v1")])
+    with (
+        pytest.raises(CassetteError, match="recorded no exchanges"),
+        replay_harness.capture("run", ScriptedModel([text("v2")])),
+    ):
+        pass  # never queried -> a broken capture
+    assert not replay_harness.has("run")  # the old cassette was replaced up front
+
+
+def test_set_installs_hand_authored_rows(replay_harness: ReplayHarness) -> None:
+    path = replay_harness.set("authored", [calls(tool_call("compile")), text("done", cost=0.5)])
+
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert [row["fingerprint"] for row in rows] == ["", ""]
+    assert rows[0]["response"]["tool_calls"][0]["name"] == "compile"
+    assert rows[1]["response"]["cost"] == 0.5
+
+    replay = replay_harness.replay("authored")  # strict, but fingerprintless rows match anything
+    assert run(replay.query([{"role": "user", "content": "anything"}]))["tool_calls"]
+    with pytest.raises(AssertionError, match="never consumed"):
+        replay.assert_exhausted()
+
+
+def test_set_preserves_full_rows_and_refuses_empty(replay_harness: ReplayHarness) -> None:
+    replay_harness.set("original", [text("hi")])
+    rows = replay_harness.entries("original")
+    replay_harness.set("copy", rows)
+    assert replay_harness.entries("copy") == rows
+    with pytest.raises(CassetteError, match="empty"):
+        replay_harness.set("empty", [])
+
+
+def test_library_rejects_unsafe_names(replay_harness: ReplayHarness) -> None:
+    for bad in ("../up", "a/b", "", "with space"):
+        with pytest.raises(ValueError, match="simple file name"):
+            replay_harness.path(bad)
+
+
+def test_clear_wipes_the_library(replay_harness: ReplayHarness) -> None:
+    replay_harness.set("a", [text("a")])
+    replay_harness.set("b", [text("b")])
+    assert replay_harness.names() == ["a", "b"]
+    assert replay_harness.clear() == 2
+    assert replay_harness.names() == []
+
+
+def test_strict_replay_detects_trajectory_drift(replay_harness: ReplayHarness) -> None:
+    messages_1 = [{"role": "user", "content": "go"}]
+    messages_2 = [*messages_1, {"role": "assistant", "content": "a"}]
+    with replay_harness.capture("run", ScriptedModel([text("a"), text("b")])) as recording:
+        run(recording.query(messages_1))
+        run(recording.query(messages_2))
+
+    replay = replay_harness.replay("run")
+    assert run(replay.query(messages_1))["text"] == "a"
+    with pytest.raises(CassetteMismatchError, match="turn 2 diverged"):
+        run(replay.query([{"role": "user", "content": "different"}]))
+
+
+def test_replay_beyond_the_cassette_is_a_clear_error(replay_harness: ReplayHarness) -> None:
+    replay_harness.set("short", [text("only")])
+    replay = replay_harness.replay("short")
+    run(replay.query([]))
+    with pytest.raises(ScriptExhaustedError, match="beyond the 1 cassette row"):
+        run(replay.query([]))
+
+
+def test_unknown_recording_is_a_clear_error(replay_harness: ReplayHarness) -> None:
+    with pytest.raises(CassetteError, match="unknown recording"):
+        replay_harness.entries("missing")
+    with pytest.raises(CassetteError, match="unknown recording"):
+        replay_harness.replay("missing")
+
+
+def test_capture_stores_metadata_and_replay_skips_it(replay_harness: ReplayHarness) -> None:
+    with replay_harness.capture(
+        "run",
+        ScriptedModel([text("a")]),
+        meta={"prompt": "a box"},
+    ) as recording:
+        run(recording.query([]))
+
+    assert replay_harness.meta("run") == {"prompt": "a box"}
+    assert replay_harness.entries("run")[0]["meta"] == {"prompt": "a box"}
+    replay = replay_harness.replay("run")
+    assert run(replay.query([]))["text"] == "a"  # only exchange rows are replayed
+    replay.assert_exhausted()
+
+
+def test_set_preserves_metadata_rows_but_refuses_meta_only(
+    replay_harness: ReplayHarness,
+) -> None:
+    replay_harness.set("with-meta", [{"meta": {"prompt": "x"}}, text("a")])
+    rows = replay_harness.entries("with-meta")
+    assert rows[0]["meta"] == {"prompt": "x"}
+    assert rows[1]["response"]["text"] == "a"
+    with pytest.raises(CassetteError, match="empty"):
+        replay_harness.set("meta-only", [{"meta": {"prompt": "x"}}])
+
+
+# ---------------------------------------------------------------------------
 # run_scenario
 # ---------------------------------------------------------------------------
 
@@ -125,5 +254,31 @@ def test_run_scenario_fails_when_the_script_is_not_consumed(tmp_path: Path) -> N
 
 
 def test_run_scenario_validates_its_arguments() -> None:
+    with pytest.raises(ValueError, match="script= or model="):
+        run_scenario("a box")
+    with pytest.raises(ValueError, match="not both"):
+        run_scenario("a box", [text("x")], model=ScriptedModel([text("y")]))
     with pytest.raises(ValueError, match="env= or tmp_path="):
         run_scenario("a box", [text("x")])
+
+
+def test_captured_cassette_replays_a_full_scenario(
+    tmp_path: Path, replay_harness: ReplayHarness
+) -> None:
+    script = [write_good_main(), calls(tool_call("compile")), text("done", cost=0.25)]
+    with replay_harness.capture("box", ScriptedModel(script)) as recording:
+        captured = run_scenario(
+            "a box",
+            model=recording,
+            env=LocalEnvironment(output_dir=tmp_path / "a"),
+        )
+    assert captured.record.status == "success"
+
+    replayed = run_scenario(
+        "a box",
+        model=replay_harness.replay("box"),
+        env=LocalEnvironment(output_dir=tmp_path / "b"),
+    )
+    assert replayed.record.status == "success"
+    assert replayed.result["message"] == "done"
+    assert replayed.result["cost"] == 0.25


### PR DESCRIPTION
## Summary

Stacked on #21 (scripted agent lane). Adds the **cassette lane**: named recordings of model exchanges so a generation becomes a permanent offline regression.

**What you get**
- `ReplayHarness.capture` — record a run (wrap a live model to pay once, or wrap `ScriptedModel` to author a cassette for free)
- `ReplayHarness.replay` — plug any recording into `run_scenario` by name
- `ReplayHarness.set` / `erase` / `clear` — install or manage hand-authored tapes
- Strict replay checks a structural fingerprint (roles, tool names, call ids, offered tools); payload text with machine-specific paths is excluded so replays stay portable
- `tests/cassettes/` curated root (gitignored by default, with `.gitkeep`)

**Why:** scripted scenarios author *behavior*; cassettes freeze a *trajectory*. Together you can prove the agent loop without paying on every CI run.

### What's next (later PRs in this stack)

This PR is only the library + round-trip proof. Follow-ups wire it into everyday workflows:

1. **pytest flags + committed recordings** — `--record-cassettes` to capture from a live model when you opt in; default CI mode replays a checked-in cassette under `tests/cassettes/` (skip cleanly if the tape is missing). That is the “pay once, replay in every CI run” path.
2. **Cassette CLI** — `scripts/cassette.py` (`list` / `show` / `run` / `capture` / `erase`) so you can manage and re-run recordings without writing a scratch script.

Until those land, authoring/replay is via `ReplayHarness` in tests or a small script (see below).

### Hands-on (free)

```bash
uv run python - <<'EOF'
import asyncio, sys
sys.path.insert(0, "tests")
asyncio.set_event_loop(asyncio.new_event_loop())
from pathlib import Path
from harness import (GOOD_MAIN_PY, ReplayHarness, ScriptedModel,
                     LocalEnvironment, calls, run_scenario, text, tool_call)

library = ReplayHarness(Path("/tmp/tour-cassettes"))
script = [calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY})),
          calls(tool_call("compile")), text("done", cost=0.25)]
with library.capture("box", ScriptedModel(script)) as model:
    run_scenario("a box", model=model, run_id="capture",
                 env=LocalEnvironment(output_dir=Path("/tmp/tour-runs")))
print("cassette written:", library.path("box"))
out = run_scenario("a box", model=library.replay("box"), run_id="replay",
                   env=LocalEnvironment(output_dir=Path("/tmp/tour-runs")))
print("replay:", out.record.status, "cost:", out.result["cost"])
EOF
```

Expect: `replay: success cost: 0.25` and a 3-line `/tmp/tour-cassettes/box.jsonl`.

## Test plan

- [ ] Base #21 is understood / merged or this PR stays stacked on it
- [ ] `uv run pytest tests/test_harness.py tests/test_agent_scenarios.py -q` (~26 passed)
- [ ] Run the hands-on capture→replay snippet above
- [ ] Confirm no `OPENAI_API_KEY` needed for the above
