### PR TITLE
Warm compile lane: shared worker + one assembly owner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,9 @@ directories for compile and record tests. Do not require real model calls unless
 the test is explicitly about a live adapter.
 
 `tests/harness.py` is the modular test environment for agent-loop behavior:
-scripted models and cassette replay (`ReplayHarness`) drive the full loop
-without paid model calls. See
-`tests/README.md` for the lanes and when to use each. Keep the subprocess
+scripted models, warm-worker compiles (`WarmEnvironment`), and cassette replay
+(`ReplayHarness`) cover the full loop without paid model calls. See
+`tests/README.md` for the four lanes and when to use each. Keep the subprocess
 worker contract covered in `test_compile.py`. A few exec-output timing tests
 are known to flake on macOS; do not weaken them locally.
 

--- a/src/mini_articraft/environments/local.py
+++ b/src/mini_articraft/environments/local.py
@@ -116,13 +116,12 @@ class LocalEnvironment:
                 returncode=completed.returncode,
             )
 
-        payload.setdefault("stdout", "")
-        payload["stderr"] = str(payload.get("stderr", "")) + completed.stderr
-        payload.setdefault("error", "")
-        payload.setdefault("traceback", "")
-        payload["returncode"] = completed.returncode
-        payload["compile_report"] = build_compile_report_from_payload(payload)
-        return _with_paths(run_dir, payload)
+        return _finalize_payload(
+            run_dir,
+            payload,
+            stderr=completed.stderr,
+            returncode=completed.returncode,
+        )
 
     def _record_compile(self, run_dir: Path) -> None:
         record = Record.load(run_dir / "record.json")
@@ -207,6 +206,28 @@ def _with_paths(run_dir: Path, result: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _finalize_payload(
+    run_dir: Path,
+    payload: dict[str, Any],
+    *,
+    stderr: str,
+    returncode: int | None,
+) -> dict[str, Any]:
+    """Assemble the environment-level compile result from a worker payload.
+
+    Single owner of result assembly for any worker transport: captured worker
+    stderr is followed by process-level stderr, missing keys are defaulted,
+    and the compile report and run paths are attached here.
+    """
+    payload.setdefault("stdout", "")
+    payload["stderr"] = str(payload.get("stderr", "")) + stderr
+    payload.setdefault("error", "")
+    payload.setdefault("traceback", "")
+    payload["returncode"] = returncode
+    payload["compile_report"] = build_compile_report_from_payload(payload)
+    return _with_paths(run_dir, payload)
+
+
 def _error_result(
     run_dir: Path,
     *,
@@ -215,7 +236,5 @@ def _error_result(
     stderr: str = "",
     returncode: int | None = None,
 ) -> dict[str, Any]:
-    payload = empty_compile_payload(error=error, stdout=stdout, stderr=stderr)
-    payload["returncode"] = returncode
-    payload["compile_report"] = build_compile_report_from_payload(payload)
-    return _with_paths(run_dir, payload)
+    payload = empty_compile_payload(error=error, stdout=stdout)
+    return _finalize_payload(run_dir, payload, stderr=stderr, returncode=returncode)

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,15 +3,17 @@
 This suite verifies the generation loop without paid model calls.
 `tests/harness.py` is the shared kit; prefer it over per-file fakes.
 
-## The lanes
+## The four lanes
 
 | Lane | Cost | Use for |
 | --- | --- | --- |
 | Unit | ~0s | pure functions: SDK checks, `compile_feedback`, signals |
-| Scripted agent | seconds per run | the full agent loop via `ScriptedModel` + `run_scenario` |
+| Warm compile | ~0.1s per compile | compile behavior via `WarmEnvironment` |
+| Scripted agent | ~0.5s per run | the full agent loop via `ScriptedModel` + `run_scenario` |
+| Cassette replay | free | recorded real runs via `ReplayHarness` |
 
 ```python
-from harness import run_scenario, calls, text, tool_call
+from harness import WarmEnvironment, run_scenario, calls, text, tool_call
 
 artifacts = run_scenario(
     "a box",
@@ -20,7 +22,7 @@ artifacts = run_scenario(
         calls(tool_call("compile")),
         text("done"),
     ],
-    tmp_path=tmp_path,
+    env=WarmEnvironment(output_dir=tmp_path),
 )
 assert artifacts.record.status == "success"
 ```
@@ -29,6 +31,25 @@ A scripted step can also be a callable `(ModelQuery) -> Response`, so the
 "model" can assert on what the agent sent and react to earlier tool outputs.
 See `tests/test_agent_scenarios.py` for end-to-end examples (repair loops,
 repeat-failure guidance, allowances).
+
+## WarmEnvironment vs LocalEnvironment
+
+Both lanes run every compile in a worker subprocess with the same timeout,
+cleanup, and result-assembly contract (shared in
+`src/mini_articraft/environments/local.py`). They differ only in the worker
+lifecycle:
+
+- `LocalEnvironment` (cold) spawns a fresh interpreter per compile (~3s).
+  It owns the fresh-interpreter, process-cleanup, and installed-wheel
+  contracts (`test_compile.py`).
+- `WarmEnvironment` (warm) keeps one worker (`tests/_compile_server.py`)
+  alive for the whole test session, so compiles cost ~0.1s. A compile that
+  times out or kills the worker (e.g. `os._exit` in workspace code) gets an
+  error result; the next compile lazily starts a fresh worker. Compiles are
+  serialized through the shared worker.
+
+Agent-loop tests that monkeypatch the compile tool (`compile_success_tool()`)
+never compile at all and can use either environment.
 
 ## Cassettes: pay once, replay forever
 

--- a/tests/_compile_server.py
+++ b/tests/_compile_server.py
@@ -1,0 +1,71 @@
+"""Warm compile worker for the test suite.
+
+Reads ``{"run_dir": ...}`` requests as newline-delimited JSON on stdin and
+writes one compile payload line per request on stdout -- the same payload
+shape ``mini_articraft.environments.worker`` prints for a one-shot compile.
+Keeping one worker alive lets a test session pay the geometry import cost
+once instead of once per compile (~3s -> ~0.1s).
+
+This is the tests-only half of the worker contract. If a persistent worker
+ever becomes a product feature, promote this loop into
+``mini_articraft/environments/worker.py``; the wire format is already shared.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from mini_articraft.compile_feedback import empty_compile_payload
+from mini_articraft.environments.worker import compile_run
+
+
+def main() -> int:
+    _emit({"ready": True})  # startup handshake: imports are done, requests are served
+    for line in sys.stdin:
+        run_dir = _parse_request(line)
+        if run_dir is None:
+            _emit(empty_compile_payload(error=f"bad compile request: {line.strip()!r}"))
+            continue
+        try:
+            _emit(compile_run(run_dir))
+        except BaseException as exc:  # keep serving after a broken compile
+            _emit(empty_compile_payload(error=f"{type(exc).__name__}: {exc}"))
+        _evict_workspace_modules(run_dir / "workspace")
+    return 0
+
+
+def _parse_request(line: str) -> Path | None:
+    try:
+        request = json.loads(line)
+        return Path(request["run_dir"]).resolve()
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, default=str) + "\n")
+    sys.stdout.flush()
+
+
+def _evict_workspace_modules(workspace: Path) -> None:
+    """Forget modules imported from the workspace so the next run re-imports.
+
+    Two runs may both define ``helper.py``; without eviction the second
+    compile would silently see the first run's module from ``sys.modules``.
+    """
+    for name, module in list(sys.modules.items()):
+        file = getattr(module, "__file__", None)
+        if file is None:
+            continue
+        try:
+            if Path(file).resolve().is_relative_to(workspace):
+                del sys.modules[name]
+        except OSError:
+            continue
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -1,38 +1,57 @@
 """Modular test environment for mini-articraft.
 
-Verify the generation loop deeply without paying for model calls:
+Verify the generation loop deeply without paying for model calls. Four
+lanes, cheapest first:
 
 1. Unit lane -- call pure functions (SDK checks, compile feedback) directly;
    no harness needed.
-2. Scripted agent lane -- :class:`ScriptedModel` plus :func:`run_scenario`
+2. Warm compile lane -- :class:`WarmEnvironment` keeps one compile worker
+   subprocess alive for the whole test session: the same isolation, timeout,
+   and cleanup contract as ``LocalEnvironment``, but the geometry imports are
+   paid once instead of once per compile (~3s -> ~0.1s).
+3. Scripted agent lane -- :class:`ScriptedModel` plus :func:`run_scenario`
    drive the full agent loop (tools, reminders, compile freshness, record)
    with a deterministic model that can react to what the agent sends it.
-3. Cassette lane -- :class:`ReplayHarness` manages any number of named
+4. Cassette lane -- :class:`ReplayHarness` manages any number of named
    recordings: capture one from a live (paid) model once, author one from a
    scripted model for free, or install one by hand; then plug any of them
    into :func:`run_scenario` by name for offline regression runs.
+
+The cold lane (``LocalEnvironment``, fresh worker per compile) stays the
+reference for the fresh-interpreter and installed-wheel contracts; both
+lanes share the worker payload shape and ``local.py``'s result assembly, so
+behavior differences between them are bugs, not semantics.
 """
 
 from __future__ import annotations
 
 import asyncio
+import atexit
+import contextlib
 import hashlib
 import inspect
 import itertools
 import json
+import os
+import queue
 import re
+import signal
+import subprocess
+import sys
+import threading
+import time
 from collections.abc import Awaitable, Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TypeVar
 
 from mini_articraft import Model
 from mini_articraft.agent import Agent, events
 from mini_articraft.agent.tools import Tool, ToolContext
 from mini_articraft.agent.tools._core import schema as _tool_schema
 from mini_articraft.agent.tools._core import workspace_digest
-from mini_articraft.environments.local import LocalEnvironment
+from mini_articraft.environments.local import LocalEnvironment, _error_result, _finalize_payload
 from mini_articraft.record import Record, read_conversation
 
 T = TypeVar("T")
@@ -523,6 +542,248 @@ class ReplayHarness:
             self.erase(name)
             removed += 1
         return removed
+
+
+# ---------------------------------------------------------------------------
+# Warm compile lane
+# ---------------------------------------------------------------------------
+
+_SERVER_SCRIPT = Path(__file__).resolve().parent / "_compile_server.py"
+
+# A fresh worker announces readiness (its first stdout line) once its imports
+# are done. The allowance bounds that handshake, so the per-compile timeout
+# can always bound the compile itself, spawn or no spawn.
+_WORKER_STARTUP_ALLOWANCE = 30.0
+
+
+class CompileServerError(RuntimeError):
+    """The warm compile worker cannot be used at all."""
+
+
+# The outcome of one compile request: the payload, or the reason there is
+# none (the worker is killed in both failure cases and lazily restarted).
+CompileStatus = Literal["ok", "timeout", "died"]
+
+
+class _CompileServer:
+    """One warm compile-worker subprocess shared by all ``WarmEnvironment``s.
+
+    Speaks newline-delimited JSON with ``tests/_compile_server.py``: the
+    worker announces readiness after its imports, then answers one
+    ``{"run_dir": ...}`` request per line with one compile payload line.
+    A compile that times out or takes the worker down with it (e.g.
+    ``os._exit`` in workspace code) costs one worker generation; the next
+    compile lazily starts a fresh one. Every queued line is tagged with its
+    generation so a stale reader from a killed worker can never be mistaken
+    for the current compile's response.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._lines: queue.Queue[tuple[int, str | None]] = queue.Queue()
+        self._proc: subprocess.Popen[str] | None = None
+        self._generation = 0
+        atexit.register(self._stop)
+
+    def compile(
+        self,
+        run_dir: Path,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[CompileStatus, dict[str, Any] | None]:
+        """Compile one run through the warm worker.
+
+        Returns ``("ok", payload)``. A compile that times out or takes the
+        worker down with it returns ``("timeout", None)`` or
+        ``("died", None)``; the worker is restarted on the next compile.
+        Compiles are serialized: one worker serves one compile at a time.
+        """
+        with self._lock:
+            generation = self._send(run_dir)
+            deadline = time.monotonic() + timeout_seconds
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._stop()
+                    return "timeout", None
+                try:
+                    item_generation, line = self._lines.get(timeout=remaining)
+                except queue.Empty:
+                    self._stop()
+                    return "timeout", None
+                if item_generation != generation:
+                    continue  # stale line from a killed worker generation
+                if line is None:
+                    self._stop()
+                    return "died", None
+                try:
+                    return "ok", json.loads(line)
+                except json.JSONDecodeError as exc:
+                    self._stop()
+                    raise CompileServerError(
+                        f"warm compile worker returned invalid JSON: {exc}"
+                    ) from exc
+
+    def _send(self, run_dir: Path) -> int:
+        """Write one request and return the serving worker's generation.
+
+        Retrying once on a write failure is safe: a broken pipe means the
+        worker is dead or dying, so no live compiler can hold the request --
+        recompiling on a fresh worker never duplicates a compile.
+        """
+        request = json.dumps({"run_dir": str(run_dir.resolve())}) + "\n"
+        for attempt in range(2):
+            proc, just_started = self._ensure_running()
+            self._drain_stale_lines()
+            if just_started and not self._await_ready():
+                self._stop()
+                if attempt:
+                    raise CompileServerError("warm compile worker failed to start") from None
+                continue
+            try:
+                assert proc.stdin is not None
+                proc.stdin.write(request)
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError):
+                self._stop()
+                if attempt:
+                    raise CompileServerError("warm compile worker is not usable") from None
+                continue
+            return self._generation
+        raise AssertionError("unreachable")
+
+    def _await_ready(self) -> bool:
+        """Wait for a fresh worker's readiness marker, bounded by the allowance."""
+        deadline = time.monotonic() + _WORKER_STARTUP_ALLOWANCE
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            try:
+                generation, line = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                return False
+            if generation != self._generation:
+                continue
+            if line is None:
+                return False  # the worker died during startup
+            try:
+                marker = json.loads(line)
+            except json.JSONDecodeError:
+                return False
+            return marker == {"ready": True}
+
+    def _ensure_running(self) -> tuple[subprocess.Popen[str], bool]:
+        if self._proc is None or self._proc.poll() is not None:
+            self._start()
+            assert self._proc is not None
+            return self._proc, True
+        return self._proc, False
+
+    def _start(self) -> None:
+        self._generation += 1
+        self._proc = subprocess.Popen(
+            [sys.executable, str(_SERVER_SCRIPT)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        reader = threading.Thread(
+            target=self._read_lines,
+            args=(self._proc, self._generation),
+            daemon=True,
+        )
+        reader.start()
+
+    def _read_lines(self, proc: subprocess.Popen[str], generation: int) -> None:
+        try:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                self._lines.put((generation, line))
+        finally:
+            self._lines.put((generation, None))  # EOF: the worker exited
+
+    def _drain_stale_lines(self) -> None:
+        while True:
+            try:
+                self._lines.get_nowait()
+            except queue.Empty:
+                return
+
+    def _stop(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is None:
+            return
+        if proc.stdin is not None:
+            with contextlib.suppress(OSError):
+                proc.stdin.close()
+        if proc.poll() is not None:
+            proc.wait()
+            return
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait()
+
+
+class WarmEnvironment(LocalEnvironment):
+    """A ``LocalEnvironment`` that compiles through one shared warm worker.
+
+    Same contract as the cold lane -- every compile runs in a worker
+    subprocess with the same timeout and cleanup semantics, and result
+    assembly is shared with ``LocalEnvironment`` -- but the worker
+    (``tests/_compile_server.py``) stays alive between compiles, so the
+    geometry imports are paid once per test session instead of once per
+    compile (~3s -> ~0.1s each). A compile that times out or crashes the
+    worker gets an error result, and the next compile lazily starts a fresh
+    worker. Compiles are serialized through the single shared worker.
+
+    ``compile_count`` tracks how many real compiles ran, which makes
+    freshness-cache behavior directly assertable.
+    """
+
+    _server: ClassVar[_CompileServer | None] = None
+    _server_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.compile_count = 0
+
+    @classmethod
+    def _shared_server(cls) -> _CompileServer:
+        with cls._server_lock:
+            if cls._server is None:
+                cls._server = _CompileServer()
+            return cls._server
+
+    def _run_worker(self, run_dir: Path) -> dict[str, Any]:
+        self.compile_count += 1
+        status, payload = self._shared_server().compile(
+            run_dir,
+            timeout_seconds=self.config.timeout_seconds,
+        )
+        if status == "timeout":
+            return _error_result(
+                run_dir,
+                error=f"compile timed out after {self.config.timeout_seconds:g}s",
+            )
+        if payload is None:
+            return _error_result(
+                run_dir,
+                error="compile worker exited mid-compile "
+                "(workspace code may have exited the process)",
+            )
+        return _finalize_payload(
+            run_dir,
+            payload,
+            stderr="",
+            returncode=0 if payload["status"] == "success" else 1,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -18,6 +18,7 @@ from harness import (
     ModelQuery,
     ReplayHarness,
     Response,
+    WarmEnvironment,
     calls,
     run_scenario,
     text,
@@ -25,7 +26,6 @@ from harness import (
 )
 
 from mini_articraft.agent.events import AssistantMessage, RunFinished, RunStarted, ToolStarted
-from mini_articraft.environments.local import LocalEnvironment
 
 BROKEN_NO_RUN_TESTS = """
 from build123d import Box
@@ -107,7 +107,7 @@ def event_signal_codes(recorder: EventRecorder) -> list[str]:
 
 
 def test_agent_repairs_a_missing_run_tests_with_real_signals(tmp_path: Path) -> None:
-    env = LocalEnvironment(output_dir=tmp_path)
+    env = WarmEnvironment(output_dir=tmp_path)
 
     def repair(query: ModelQuery) -> Response:
         signals = compile_signals_shown(query.tool_outputs())
@@ -129,12 +129,13 @@ def test_agent_repairs_a_missing_run_tests_with_real_signals(tmp_path: Path) -> 
 
     assert artifacts.record.status == "success"
     assert artifacts.result["message"] == "done"
+    assert env.compile_count == 2
     codes = event_signal_codes(artifacts.recorder)
     assert "COMPILE_MISSING_RUN_TESTS" in codes
 
 
 def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> None:
-    env = LocalEnvironment(output_dir=tmp_path)
+    env = WarmEnvironment(output_dir=tmp_path)
 
     artifacts = run_scenario(
         "a box",
@@ -154,6 +155,7 @@ def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> No
     )
 
     assert artifacts.record.status == "success"
+    assert env.compile_count == 4
     signals = compile_signals_shown(artifacts.tool_outputs())
     assert len(signals) == 4
     assert "matches the previous compile attempt" not in signals[0]
@@ -162,7 +164,7 @@ def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> No
 
 
 def test_overlap_allowance_flows_through_the_real_worker(tmp_path: Path) -> None:
-    env = LocalEnvironment(output_dir=tmp_path)
+    env = WarmEnvironment(output_dir=tmp_path)
 
     def allow_the_overlap(query: ModelQuery) -> Response:
         signals = compile_signals_shown(query.tool_outputs())
@@ -183,6 +185,7 @@ def test_overlap_allowance_flows_through_the_real_worker(tmp_path: Path) -> None
     )
 
     assert artifacts.record.status == "success"
+    assert env.compile_count == 2
     codes = event_signal_codes(artifacts.recorder)
     assert "QC_REAL_OVERLAP" in codes
     assert "NOTE_ALLOWED_OVERLAP" in codes
@@ -194,7 +197,7 @@ def test_event_stream_is_ordered_and_complete(tmp_path: Path) -> None:
     artifacts = run_scenario(
         "a box",
         [write_main(GOOD_MAIN_PY), compile_workspace(), text("done")],
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
 
     stream = artifacts.recorder.events
@@ -222,7 +225,7 @@ def test_hand_authored_cassette_drives_a_real_run(
     artifacts = run_scenario(
         "a box",
         model=replay_harness.replay("authored-box"),
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
 
     assert artifacts.record.status == "success"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -10,11 +10,13 @@ from harness import (
     GOOD_MAIN_PY,
     CassetteError,
     CassetteMismatchError,
+    CompileServerError,
     ModelQuery,
     ReplayHarness,
     Response,
     ScriptedModel,
     ScriptExhaustedError,
+    WarmEnvironment,
     calls,
     run,
     run_scenario,
@@ -24,6 +26,7 @@ from harness import (
 
 from mini_articraft.agent.events import TurnStarted
 from mini_articraft.environments.local import LocalEnvironment
+from mini_articraft.record import Record
 
 
 def write_good_main() -> Response:
@@ -78,6 +81,187 @@ def test_normalized_responses_do_not_mutate_step_dicts() -> None:
     model = ScriptedModel([step])
     run(model.query([]))
     assert step == {"text": "hi", "tool_calls": []}
+
+
+# ---------------------------------------------------------------------------
+# WarmEnvironment
+# ---------------------------------------------------------------------------
+
+
+def test_warm_environment_compiles_via_the_shared_worker(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "success"
+    assert payload["returncode"] == 0
+    assert env.compile_count == 1
+    assert Path(payload["usdz"]).is_file()
+    assert payload["compile_report"]["status"] == "success"
+    assert Record.load(run_dir / "record.json").attempts == 1
+
+
+def test_warm_environment_surfaces_failures_with_signals(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("broken")
+    (run_dir / "workspace" / "main.py").write_text(
+        "object_model = 'not a model'\n", encoding="utf-8"
+    )
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert payload["returncode"] == 1
+    report = payload["compile_report"]
+    codes = {signal["code"] for signal in report["signal_bundle"]["signals"]}
+    assert codes == {"COMPILE_RUNTIME_FAILURE"}
+    assert "compile_runtime" in report["signals_text"]
+
+
+def test_warm_environment_requires_main_py(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("empty")
+    (run_dir / "workspace" / "main.py").unlink()
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert "workspace/main.py is required" in payload["error"]
+    assert env.compile_count == 0
+
+
+def test_warm_environment_matches_the_cold_subprocess_contract(tmp_path: Path) -> None:
+    outcomes = {}
+    environments = {
+        "cold": LocalEnvironment(output_dir=tmp_path / "cold"),
+        "warm": WarmEnvironment(output_dir=tmp_path / "warm"),
+    }
+    for lane, env in environments.items():
+        run_dir = env.create_run("box")
+        (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+        payload = env.compile_path(run_dir)
+        outcomes[lane] = (
+            payload["status"],
+            payload["compile_report"]["status"],
+            Path(payload["usdz"]).is_file(),
+        )
+    assert outcomes["cold"] == outcomes["warm"] == ("success", "success", True)
+
+
+HELPER_MAIN = """
+import helper
+
+from build123d import Box
+
+from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+
+print(f"helper says {helper.VALUE}")
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("box")
+    base = model.part("base")
+    base.add(Box(0.2, 0.2, 0.1), name="body")
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    return TestContext(object_model).report()
+"""
+
+
+def _compile_helper_run(env: WarmEnvironment, run_id: str, value: str) -> dict:
+    run_dir = env.create_run(run_id)
+    workspace = run_dir / "workspace"
+    workspace.joinpath("helper.py").write_text(f'VALUE = "{value}"\n', encoding="utf-8")
+    workspace.joinpath("main.py").write_text(HELPER_MAIN, encoding="utf-8")
+    return env.compile_path(run_dir)
+
+
+def test_warm_environment_isolates_workspace_modules_between_runs(tmp_path: Path) -> None:
+    """Two runs may both define helper.py; each compile must see its own."""
+    env = WarmEnvironment(output_dir=tmp_path)
+
+    first = _compile_helper_run(env, "first", "first-run")
+    second = _compile_helper_run(env, "second", "second-run")
+
+    assert first["status"] == second["status"] == "success"
+    assert "helper says first-run" in first["stdout"]
+    assert "helper says second-run" in second["stdout"]
+
+
+def test_warm_environment_survives_workspace_code_that_exits(tmp_path: Path) -> None:
+    """os._exit in workspace code kills the worker, not the test process."""
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("selfish")
+    (run_dir / "workspace" / "main.py").write_text("import os\nos._exit(1)\n", encoding="utf-8")
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert "exited mid-compile" in payload["error"]
+
+    healthy = env.create_run("healthy")
+    (healthy / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    assert env.compile_path(healthy)["status"] == "success"  # a fresh worker took over
+
+
+def test_compile_server_ignores_stale_generation_lines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines from a killed worker generation can never pose as the response."""
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    server = env._shared_server()
+    monkeypatch.setattr(server, "_drain_stale_lines", lambda: None)
+    server._lines.put((-1, '{"status": "stale"}'))
+    server._lines.put((-1, None))
+
+    status, payload = server.compile(run_dir, timeout_seconds=30)
+
+    assert status == "ok"
+    assert payload is not None
+    assert payload["status"] == "success"
+
+
+def test_compile_server_rejects_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A protocol violation is an infrastructure error, not a compile result."""
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    server = env._shared_server()
+    monkeypatch.setattr(server, "_drain_stale_lines", lambda: None)
+    status, _ = server.compile(run_dir, timeout_seconds=30)  # worker at a known generation
+    assert status == "ok"
+    server._lines.put((server._generation, "this is not json"))
+
+    with pytest.raises(CompileServerError, match="invalid JSON"):
+        server.compile(run_dir, timeout_seconds=30)
+
+
+def test_warm_environment_enforces_the_timeout_contract(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path, timeout_seconds=0.5)
+    run_dir = env.create_run("slow")
+    (run_dir / "workspace" / "main.py").write_text(
+        "import time\ntime.sleep(30)\n", encoding="utf-8"
+    )
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert "timed out after 0.5s" in payload["error"]
+
+    healthy = env.create_run("healthy")
+    (healthy / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    assert env.compile_path(healthy)["status"] == "success"  # a fresh worker took over
 
 
 # ---------------------------------------------------------------------------
@@ -214,7 +398,7 @@ def test_run_scenario_returns_deep_artifacts(tmp_path: Path) -> None:
     artifacts = run_scenario(
         "a box",
         [write_good_main(), calls(tool_call("compile")), text("done")],
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
 
     assert artifacts.record.status == "success"
@@ -238,7 +422,7 @@ def test_reactive_steps_can_assert_on_tool_outputs(tmp_path: Path) -> None:
     artifacts = run_scenario(
         "a box",
         [write_good_main(), check_write, text("done")],
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
     assert artifacts.record.status == "success"
 
@@ -248,7 +432,7 @@ def test_run_scenario_fails_when_the_script_is_not_consumed(tmp_path: Path) -> N
         run_scenario(
             "a box",
             [text("done"), text("extra")],
-            env=LocalEnvironment(output_dir=tmp_path),
+            env=WarmEnvironment(output_dir=tmp_path),
             max_turns=1,
         )
 
@@ -270,14 +454,14 @@ def test_captured_cassette_replays_a_full_scenario(
         captured = run_scenario(
             "a box",
             model=recording,
-            env=LocalEnvironment(output_dir=tmp_path / "a"),
+            env=WarmEnvironment(output_dir=tmp_path / "a"),
         )
     assert captured.record.status == "success"
 
     replayed = run_scenario(
         "a box",
         model=replay_harness.replay("box"),
-        env=LocalEnvironment(output_dir=tmp_path / "b"),
+        env=WarmEnvironment(output_dir=tmp_path / "b"),
     )
     assert replayed.record.status == "success"
     assert replayed.result["message"] == "done"


### PR DESCRIPTION
## Summary

Stacked on #22 (cassette lane). Two commits that make the test harness's compile path shareable and fast — **no product behavior change**, and this does not use cassette recording/replay.

1. **One assembly owner** (`_finalize_payload` in `local.py`) — cold `_run_worker` / `_error_result` used to hand-build the environment-level compile result. That contract now lives in one place so a second transport can reuse the same shape.
2. **Warm compile lane** (`WarmEnvironment` + `tests/_compile_server.py`) — one compile-worker subprocess stays alive for the pytest session. Compiles drop from ~3s to ~0.1s while keeping the cold-lane contract: same timeouts, cleanup, and result assembly.

Scenarios / harness suites switch to the warm lane for speed. Isolation proofs cover workspace-module eviction, `os._exit` containment (kills the worker, not pytest), and compile timeout enforcement.

**Why:** scripted + cassette lanes still need real compiles; without a warm worker the suite stays cold-subprocess-bound. This is a test-harness optimization only.

## Test plan

- [ ] Base #22 is understood / merged or this PR stays stacked on it
- [ ] `uv run pytest tests/test_harness.py tests/test_agent_scenarios.py -q --durations=3` — expect ~15s (was ~45s cold)
- [ ] Isolation proofs:
  ```bash
  uv run pytest -v \
    tests/test_harness.py::test_warm_environment_isolates_workspace_modules_between_runs \
    tests/test_harness.py::test_warm_environment_survives_workspace_code_that_exits \
    tests/test_harness.py::test_warm_environment_enforces_the_timeout_contract
  ```
- [ ] Confirm no `OPENAI_API_KEY` / cassette recording required
