### PR TITLE
Live-by-default cassette tests with --record / --replay + the tape CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,5 @@ jobs:
         run: uv run --frozen basedpyright
 
       - name: Test
-        run: uv run --frozen pytest -q
+        # --replay: cassette-backed tests stay offline (live is the local default)
+        run: uv run --frozen pytest -q --replay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,11 @@ typeCheckingMode = "standard"
 [[tool.basedpyright.executionEnvironments]]
 root = "tests"
 
+# The tape CLI also imports the test environment from tests/.
+[[tool.basedpyright.executionEnvironments]]
+root = "scripts"
+extraPaths = ["tests"]
+
 [tool.pytest.ini_options]
 addopts = "-m 'not volume'"
 markers = [

--- a/scripts/tape.py
+++ b/scripts/tape.py
@@ -1,0 +1,156 @@
+"""Manage generation tapes: list, show, record, replay, erase.
+
+The tape library lives in tests/cassettes by default. Capturing costs a
+real generation (OPENAI_API_KEY); replaying is free. Examples:
+
+    uv run python scripts/tape.py list
+    uv run python scripts/tape.py show box
+    uv run python scripts/tape.py record box "a small box"     # live, pays
+    uv run python scripts/tape.py replay box                    # replays offline
+    uv run python scripts/tape.py erase box
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests"))
+
+import harness
+from harness import CASSETTE_ROOT, ReplayHarness, WarmEnvironment
+
+app = typer.Typer(help=__doc__, no_args_is_help=True)
+
+Root = Annotated[Path, typer.Option("--root", "-r", help="Cassette library root.")]
+
+
+@app.command()
+def list(root: Root = CASSETTE_ROOT) -> None:
+    """List recordings in the library."""
+    library = ReplayHarness(root)
+    names = library.names()
+    if not names:
+        typer.echo(f"(no recordings in {library.root})")
+        return
+    for name in names:
+        rows = [row for row in library.entries(name) if "response" in row]
+        prompt = library.meta(name).get("prompt", "")
+        suffix = f"  prompt={prompt!r}" if prompt else ""
+        typer.echo(f"{name}: {len(rows)} exchange(s){suffix}")
+
+
+@app.command()
+def show(name: str, root: Root = CASSETTE_ROOT) -> None:
+    """Show one recording's exchanges."""
+    library = ReplayHarness(root)
+    meta = library.meta(name)
+    if meta:
+        typer.echo(f"meta: {json.dumps(meta, default=str)}")
+    turn = 0
+    for row in library.entries(name):
+        if "response" not in row:
+            continue
+        turn += 1
+        response = row["response"]
+        tool_names = [call.get("name") for call in response.get("tool_calls") or []]
+        preview = (response.get("text") or "")[:80]
+        typer.echo(
+            f"turn {turn}: tools={tool_names} cost={response.get('cost', 0.0)} text={preview!r}"
+        )
+
+
+@app.command()
+def record(
+    name: str,
+    prompt: str,
+    root: Root = CASSETTE_ROOT,
+    max_turns: int = 100,
+) -> None:
+    """Run a live generation and record it as a tape (pays for model calls)."""
+    from mini_articraft.agent import Agent
+    from mini_articraft.environments.local import LocalEnvironment
+    from mini_articraft.models.openai import OpenAIModel
+    from mini_articraft.settings import get_settings
+
+    settings = get_settings()
+    library = ReplayHarness(root)
+    meta = {"prompt": prompt, "model": settings.openai_model}
+    with library.capture(name, OpenAIModel(settings), meta=meta) as model:
+        result = harness.run(
+            Agent(model, LocalEnvironment(), max_turns=max_turns, on_event=_print_event).run(prompt)
+        )
+    _print_result(result)
+    raise typer.Exit(0 if result["status"] == "success" else 1)
+
+
+@app.command()
+def replay(
+    name: str,
+    root: Root = CASSETTE_ROOT,
+    prompt: Annotated[str | None, typer.Option("--prompt", "-p")] = None,
+    output_dir: Annotated[Path, typer.Option("--output-dir", "-o")] = Path("runs"),
+) -> None:
+    """Replay a recorded generation offline, end to end, for free."""
+    library = ReplayHarness(root)
+    actual_prompt = prompt or library.meta(name).get("prompt")
+    if not actual_prompt:
+        raise typer.BadParameter(f"tape {name!r} has no recorded prompt; pass --prompt")
+    run_id = f"tape-{name}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    artifacts = harness.run_scenario(
+        actual_prompt,
+        model=library.replay(name),
+        env=WarmEnvironment(output_dir=output_dir),
+        run_id=run_id,
+        on_event=_print_event,
+    )
+    finished = artifacts.recorder.finished
+    if finished is not None:
+        typer.echo(f"turns={finished.turns} duration={finished.duration}s")
+    _print_result(artifacts.result)
+    raise typer.Exit(0 if artifacts.record.status == "success" else 1)
+
+
+@app.command()
+def erase(name: str, root: Root = CASSETTE_ROOT) -> None:
+    """Remove one recording."""
+    library = ReplayHarness(root)
+    if library.erase(name):
+        typer.echo(f"erased {name}")
+        return
+    raise typer.BadParameter(f"unknown tape: {name!r}")
+
+
+def _print_event(event: harness.events.Event) -> None:
+    if isinstance(event, harness.events.RunStarted):
+        typer.echo(f"run {event.run_id} model={event.model}")
+    elif isinstance(event, harness.events.AssistantMessage):
+        preview = event.text.strip().splitlines()[0][:80] if event.text.strip() else ""
+        tool_names = [call.get("name") for call in event.tool_calls]
+        if tool_names:
+            typer.echo(f"turn {event.turn}: tools={tool_names}")
+        elif preview:
+            typer.echo(f"turn {event.turn}: {preview}")
+
+
+def _print_result(result: dict[str, Any]) -> None:
+    typer.echo(
+        f"status={result['status']} cost=${result.get('cost', 0.0):.4f} result={result.get('result') or '-'}"
+    )
+    if result.get("error"):
+        typer.echo(f"error={result['error']}")
+
+
+def main() -> None:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,20 +80,25 @@ Curated regression cassettes belong in `tests/cassettes/` (git-ignored by
 default; force-add the ones worth keeping). Scratch cassettes belong under
 `tmp_path`.
 
-## Live tests in replay mode
+## Live tests: `--record` / `--replay`
 
-Tests using the `cassette_model` fixture run live only when asked:
+Tests using the `cassette_model` fixture are **live by default**. Named
+cassettes (`tests/cassettes/<name>.jsonl`; default name = test function,
+or e.g. `cassette_model("latest")`) are used only when you ask:
 
 ```bash
-# offline (default): replay tests/cassettes/<test name>.jsonl; skip if missing
+# default: always live (needs OPENAI_API_KEY)
 uv run pytest tests/test_live_generation.py
 
-# live: pay once, (re)record the cassette
-OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+# offline: replay the named cassette; exit if missing
+uv run pytest tests/test_live_generation.py --replay
+
+# live + (re)record the cassette (needs OPENAI_API_KEY)
+OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 ```
 
-Record intentionally, commit the cassette (`git add -f`), and CI replays it
-for free. Cassette names default to the test function name.
+Commit a cassette (`git add -f`) and run CI with `--replay` for a hard
+offline gate. No `--replay` means no cassette — always the real model.
 
 ## Known platform flakes
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,6 +80,21 @@ Curated regression cassettes belong in `tests/cassettes/` (git-ignored by
 default; force-add the ones worth keeping). Scratch cassettes belong under
 `tmp_path`.
 
+## Live tests in replay mode
+
+Tests using the `cassette_model` fixture run live only when asked:
+
+```bash
+# offline (default): replay tests/cassettes/<test name>.jsonl; skip if missing
+uv run pytest tests/test_live_generation.py
+
+# live: pay once, (re)record the cassette
+OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+```
+
+Record intentionally, commit the cassette (`git add -f`), and CI replays it
+for free. Cassette names default to the test function name.
+
 ## Known platform flakes
 
 On macOS, a few exec-output timing tests can fail with empty captured output

--- a/tests/README.md
+++ b/tests/README.md
@@ -100,6 +100,22 @@ OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 Commit a cassette (`git add -f`) and run CI with `--replay` for a hard
 offline gate. No `--replay` means no cassette — always the real model.
 
+## The tape CLI
+
+`scripts/tape.py` manages the recording library by hand:
+
+```bash
+uv run python scripts/tape.py list            # recordings + prompts
+uv run python scripts/tape.py show box        # one recording's exchanges
+uv run python scripts/tape.py replay box      # replay offline, end to end
+uv run python scripts/tape.py record box "a small box"   # live, pays once
+uv run python scripts/tape.py erase box
+```
+
+`record` stores the prompt as cassette metadata, which is what `replay`
+replays against. `--root` points at another library (the default is
+`tests/cassettes/`).
+
 ## Known platform flakes
 
 On macOS, a few exec-output timing tests can fail with empty captured output

--- a/tests/cassettes/test_box_generation.jsonl
+++ b/tests/cassettes/test_box_generation.jsonl
@@ -1,0 +1,4 @@
+{"meta": {"prompt": "a simple box", "authored": true}}
+{"fingerprint": "", "response": {"text": "", "tool_calls": [{"id": "call_1", "name": "write", "arguments": "{\"path\": \"main.py\", \"content\": \"\\nfrom build123d import Box\\n\\nfrom mini_articraft.sdk import ArticulatedObject, TestContext, TestReport\\n\\n\\ndef build_object_model() -> ArticulatedObject:\\n    model = ArticulatedObject(\\\"box\\\")\\n    base = model.part(\\\"base\\\")\\n    base.add(Box(0.2, 0.2, 0.1), name=\\\"body\\\")\\n    return model\\n\\n\\nobject_model = build_object_model()\\n\\n\\ndef run_tests() -> TestReport:\\n    return TestContext(object_model).report()\\n\"}"}], "cost": 0.0, "token_usage": {}}}
+{"fingerprint": "", "response": {"text": "", "tool_calls": [{"id": "call_2", "name": "compile", "arguments": "{}"}], "cost": 0.0, "token_usage": {}}}
+{"fingerprint": "", "response": {"text": "done", "tool_calls": [], "cost": 0.0, "token_usage": {}}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,13 +49,23 @@ def replay_harness(tmp_path: Path) -> ReplayHarness:
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--record-cassettes",
+    group = parser.getgroup("cassettes")
+    group.addoption(
+        "--record",
         action="store_true",
         default=False,
         help=(
-            "run cassette-backed tests live and re-record their cassettes "
-            "(needs OPENAI_API_KEY); the default is offline replay"
+            "run cassette-backed tests live and (re)record named cassettes "
+            "(needs OPENAI_API_KEY)"
+        ),
+    )
+    group.addoption(
+        "--replay",
+        action="store_true",
+        default=False,
+        help=(
+            "replay named cassettes offline; exit if a cassette is missing "
+            "(without this flag, cassette-backed tests always run live)"
         ),
     )
 
@@ -65,26 +75,39 @@ CassetteModelOpener = Callable[[str | None], AbstractContextManager[ScenarioMode
 
 @pytest.fixture
 def cassette_model(request: pytest.FixtureRequest) -> CassetteModelOpener:
-    """Open a cassette-backed model for live/e2e tests.
+    """Open a named model for live/e2e tests.
 
-    Default: offline replay of ``tests/cassettes/<name>.jsonl`` (the test's
-    own name when none is given), skipping when no cassette exists. With
-    ``--record-cassettes``: run live against the real model and re-record
-    the cassette (needs ``OPENAI_API_KEY``).
+    Names default to the test function (``cassette_model()``), or pass an
+    explicit name such as ``cassette_model("latest")``.
+
+    - default (no flags): always live (real model)
+    - ``--record``: live + (re)write the cassette
+    - ``--replay``: offline cassette only; exit if missing
     """
-    record = request.config.getoption("--record-cassettes")
+    record = bool(request.config.getoption("--record"))
+    replay = bool(request.config.getoption("--replay"))
+    if record and replay:
+        pytest.exit("use only one of --record and --replay", returncode=2)
+
     library = ReplayHarness(CASSETTE_ROOT)
 
     @contextmanager
     def open_cassette(name: str | None = None) -> Iterator[ScenarioModel]:
         cassette_name = name or request.node.name
+        if replay:
+            if not library.has(cassette_name):
+                path = library.path(cassette_name)
+                pytest.exit(
+                    f"cassette {cassette_name!r} missing at {path}; record with --record",
+                    returncode=1,
+                )
+            yield library.replay(cassette_name)
+            return
         if record:
             with library.capture(cassette_name, _live_model()) as recording:
                 yield recording
             return
-        if not library.has(cassette_name):
-            pytest.skip(f"cassette {cassette_name!r} not recorded; run with --record-cassettes")
-        yield library.replay(cassette_name)
+        yield _live_model()
 
     return open_cassette
 
@@ -95,4 +118,4 @@ def _live_model() -> Model:
 
         return OpenAIModel()
     except Exception as exc:
-        pytest.skip(f"--record-cassettes needs OPENAI_API_KEY: {exc}")
+        pytest.exit(f"live model needs OPENAI_API_KEY: {exc}", returncode=1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help=(
-            "run cassette-backed tests live and (re)record named cassettes "
-            "(needs OPENAI_API_KEY)"
+            "run cassette-backed tests live and (re)record named cassettes (needs OPENAI_API_KEY)"
         ),
     )
     group.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,4 +117,4 @@ def _live_model() -> Model:
 
         return OpenAIModel()
     except Exception as exc:
-        pytest.exit(f"live model needs OPENAI_API_KEY: {exc}", returncode=1)
+        pytest.fail(f"live model needs OPENAI_API_KEY: {exc}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 
 import pytest
-from harness import CASSETTE_ROOT, ReplayHarness, ScenarioModel
+from harness import CASSETTE_ROOT, ReplayHarness
 
 from mini_articraft import Model
 
@@ -69,7 +69,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-CassetteModelOpener = Callable[[str | None], AbstractContextManager[ScenarioModel]]
+CassetteModelOpener = Callable[[str | None], AbstractContextManager[Model]]
 
 
 @pytest.fixture
@@ -91,7 +91,7 @@ def cassette_model(request: pytest.FixtureRequest) -> CassetteModelOpener:
     library = ReplayHarness(CASSETTE_ROOT)
 
     @contextmanager
-    def open_cassette(name: str | None = None) -> Iterator[ScenarioModel]:
+    def open_cassette(name: str | None = None) -> Iterator[Model]:
         cassette_name = name or request.node.name
         if replay:
             if not library.has(cassette_name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 
 import pytest
-from harness import ReplayHarness
+from harness import CASSETTE_ROOT, ReplayHarness, ScenarioModel
+
+from mini_articraft import Model
 
 
 @pytest.fixture(scope="session")
@@ -42,3 +46,53 @@ def _use_session_loop(_event_loop):
 def replay_harness(tmp_path: Path) -> ReplayHarness:
     """A scratch cassette library under the test's tmp dir."""
     return ReplayHarness(tmp_path / "cassettes")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--record-cassettes",
+        action="store_true",
+        default=False,
+        help=(
+            "run cassette-backed tests live and re-record their cassettes "
+            "(needs OPENAI_API_KEY); the default is offline replay"
+        ),
+    )
+
+
+CassetteModelOpener = Callable[[str | None], AbstractContextManager[ScenarioModel]]
+
+
+@pytest.fixture
+def cassette_model(request: pytest.FixtureRequest) -> CassetteModelOpener:
+    """Open a cassette-backed model for live/e2e tests.
+
+    Default: offline replay of ``tests/cassettes/<name>.jsonl`` (the test's
+    own name when none is given), skipping when no cassette exists. With
+    ``--record-cassettes``: run live against the real model and re-record
+    the cassette (needs ``OPENAI_API_KEY``).
+    """
+    record = request.config.getoption("--record-cassettes")
+    library = ReplayHarness(CASSETTE_ROOT)
+
+    @contextmanager
+    def open_cassette(name: str | None = None) -> Iterator[ScenarioModel]:
+        cassette_name = name or request.node.name
+        if record:
+            with library.capture(cassette_name, _live_model()) as recording:
+                yield recording
+            return
+        if not library.has(cassette_name):
+            pytest.skip(f"cassette {cassette_name!r} not recorded; run with --record-cassettes")
+        yield library.replay(cassette_name)
+
+    return open_cassette
+
+
+def _live_model() -> Model:
+    try:
+        from mini_articraft.models.openai import OpenAIModel
+
+        return OpenAIModel()
+    except Exception as exc:
+        pytest.skip(f"--record-cassettes needs OPENAI_API_KEY: {exc}")

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -824,7 +824,7 @@ class RunArtifacts:
 
     result: dict[str, Any]
     record: Record
-    model: ScenarioModel
+    model: ScenarioModel | Model
     recorder: EventRecorder
     run_dir: Path
 
@@ -845,7 +845,7 @@ def run_scenario(
     prompt: str,
     script: Iterable[Step] | None = None,
     *,
-    model: ScenarioModel | None = None,
+    model: ScenarioModel | Model | None = None,
     env: LocalEnvironment | None = None,
     tmp_path: Path | None = None,
     run_id: str = "scenario",
@@ -856,10 +856,11 @@ def run_scenario(
 
     The model is a fresh :class:`ScriptedModel` built from ``script`` unless
     ``model=`` plugs in something else -- e.g. one recording from a
-    :class:`ReplayHarness`. Pass ``env`` to choose the compile lane
-    (:class:`WarmEnvironment` for speed) or ``tmp_path`` for a plain
-    subprocess ``LocalEnvironment``. By default the model must be consumed
-    exactly; pass ``assert_exhausted=False`` for open-ended runs.
+    :class:`ReplayHarness`, or a live :class:`~mini_articraft.Model`. Pass
+    ``env`` to choose the compile lane (:class:`WarmEnvironment` for speed)
+    or ``tmp_path`` for a plain subprocess ``LocalEnvironment``. By default
+    finite harness models must be consumed exactly; pass
+    ``assert_exhausted=False`` for open-ended or live runs.
     """
     if model is None:
         if script is None:
@@ -875,7 +876,9 @@ def run_scenario(
     agent = Agent(model, env, max_turns=max_turns, on_event=recorder)
     result = run(agent.run(prompt, run_id=run_id))
     if assert_exhausted:
-        model.assert_exhausted()
+        check = getattr(model, "assert_exhausted", None)
+        if callable(check):
+            check()
     run_dir = Path(str(result["run"]))
     return RunArtifacts(
         result=result,

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -851,6 +851,7 @@ def run_scenario(
     run_id: str = "scenario",
     max_turns: int = 10,
     assert_exhausted: bool = True,
+    on_event: Callable[[events.Event], None] | None = None,
 ) -> RunArtifacts:
     """Run the full agent loop for free and return deep-inspectable artifacts.
 
@@ -860,7 +861,9 @@ def run_scenario(
     ``env`` to choose the compile lane (:class:`WarmEnvironment` for speed)
     or ``tmp_path`` for a plain subprocess ``LocalEnvironment``. By default
     finite harness models must be consumed exactly; pass
-    ``assert_exhausted=False`` for open-ended or live runs.
+    ``assert_exhausted=False`` for open-ended or live runs. Every event also
+    flows to ``on_event`` when given (the artifacts recorder always sees it
+    too).
     """
     if model is None:
         if script is None:
@@ -873,7 +876,13 @@ def run_scenario(
             raise ValueError("run_scenario needs env= or tmp_path=")
         env = LocalEnvironment(output_dir=tmp_path)
     recorder = EventRecorder()
-    agent = Agent(model, env, max_turns=max_turns, on_event=recorder)
+
+    def callback(event: events.Event) -> None:
+        recorder(event)
+        if on_event is not None:
+            on_event(event)
+
+    agent = Agent(model, env, max_turns=max_turns, on_event=callback)
     result = run(agent.run(prompt, run_id=run_id))
     if assert_exhausted:
         check = getattr(model, "assert_exhausted", None)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -410,6 +410,7 @@ def test_run_scenario_returns_deep_artifacts(tmp_path: Path) -> None:
     assert finished is not None
     assert finished.status == "success"
     assert artifacts.tool_outputs()[0]["result"]["path"] == "main.py"
+    assert isinstance(artifacts.model, ScriptedModel)
     assert artifacts.model.queries[-1].turn == 3
 
 

--- a/tests/test_live_generation.py
+++ b/tests/test_live_generation.py
@@ -1,11 +1,12 @@
 """Live/e2e generation tests backed by the cassette lane.
 
-Default: replay the committed cassettes offline, for free. Re-record them
-with a real model when the trajectory intentionally changes:
+Default: always live (real model). Cassettes are opt-in via flags:
 
-    OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+    uv run pytest tests/test_live_generation.py --replay
+    OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 
-Cassette names default to the test function name.
+Cassette names default to the test function name
+(``cassette_model("latest")`` for an explicit name).
 """
 
 from __future__ import annotations

--- a/tests/test_live_generation.py
+++ b/tests/test_live_generation.py
@@ -1,0 +1,26 @@
+"""Live/e2e generation tests backed by the cassette lane.
+
+Default: replay the committed cassettes offline, for free. Re-record them
+with a real model when the trajectory intentionally changes:
+
+    OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+
+Cassette names default to the test function name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness import WarmEnvironment, run_scenario
+
+
+def test_box_generation(cassette_model, tmp_path: Path) -> None:
+    with cassette_model() as model:
+        artifacts = run_scenario(
+            "a simple box",
+            model=model,
+            env=WarmEnvironment(output_dir=tmp_path),
+        )
+    assert artifacts.record.status == "success"
+    assert artifacts.record.result.endswith(".usdz")

--- a/tests/test_tape_cli.py
+++ b/tests/test_tape_cli.py
@@ -1,0 +1,93 @@
+"""Tests for the tape CLI (scripts/tape.py)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from harness import GOOD_MAIN_PY, ReplayHarness, calls, text, tool_call
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / "scripts" / "tape.py"
+
+
+def cli(*args: str, root: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI), *args, "--root", str(root)],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.fixture
+def library_root(tmp_path: Path) -> Path:
+    root = tmp_path / "cassettes"
+    library = ReplayHarness(root)
+    library.set(
+        "box",
+        [
+            {"meta": {"prompt": "a simple box"}},
+            calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY})),
+            calls(tool_call("compile")),
+            text("done", cost=0.25),
+        ],
+    )
+    library.set("promptless", [text("hi")])
+    return root
+
+
+def test_list_shows_recordings_and_prompts(library_root: Path, tmp_path: Path) -> None:
+    result = cli("list", root=library_root, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "box: 3 exchange(s)" in result.stdout
+    assert "prompt='a simple box'" in result.stdout
+    assert "promptless: 1 exchange(s)" in result.stdout
+
+
+def test_show_prints_exchanges(library_root: Path, tmp_path: Path) -> None:
+    result = cli("show", "box", root=library_root, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert 'meta: {"prompt": "a simple box"}' in result.stdout
+    assert "tools=['write']" in result.stdout
+    assert "tools=['compile']" in result.stdout
+    assert "text='done'" in result.stdout
+
+
+def test_replay_replays_a_recorded_generation(library_root: Path, tmp_path: Path) -> None:
+    result = cli(
+        "replay", "box", "--output-dir", str(tmp_path / "runs"), root=library_root, cwd=tmp_path
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "turns=3" in result.stdout
+    assert "status=success" in result.stdout
+    assert "cost=$0.2500" in result.stdout
+    run_dirs = list((tmp_path / "runs").glob("tape-box-*"))
+    assert len(run_dirs) == 1
+    assert (run_dirs[0] / "result" / "usdz" / "0000.usdz").is_file()
+
+
+def test_replay_requires_a_prompt_without_metadata(library_root: Path, tmp_path: Path) -> None:
+    result = cli("replay", "promptless", root=library_root, cwd=tmp_path)
+
+    assert result.returncode != 0
+    assert "no recorded prompt" in result.stderr
+
+
+def test_erase_removes_a_recording(library_root: Path, tmp_path: Path) -> None:
+    result = cli("erase", "promptless", root=library_root, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "erased promptless" in result.stdout
+    assert not (library_root / "promptless.jsonl").exists()
+
+    missing = cli("erase", "promptless", root=library_root, cwd=tmp_path)
+    assert missing.returncode != 0
+    assert "unknown tape" in missing.stderr


### PR DESCRIPTION
## Summary

Stacked on #23 (warm compile lane). Wires the cassette library into pytest with two explicit flags and the first committed cassette.

### Behavior (important)

Cassette-backed tests (`cassette_model`) are **live by default** — they use the real model, same as a normal generation run.

| Flag | Behavior |
| --- | --- |
| *(none)* | **Always live.** No cassette is read or written. Needs `OPENAI_API_KEY`. |
| `--record` | **Live + save.** Runs the real model and (re)writes `tests/cassettes/<name>.jsonl`. |
| `--replay` | **Cassette only.** Offline replay of the named tape. **Exits** if the cassette is missing (does not skip, does not fall back to live). |

`--record` and `--replay` are mutually exclusive.

**Why this shape:** a cassette is an intentional offline artifact, not a silent default. CI and local offline runs opt in with `--replay`. Day-to-day / first runs stay live. Pay once with `--record`, commit the tape (`git add -f`), then `--replay` forever.

### Named recordings

Default name = test function (`test_box_generation` → `tests/cassettes/test_box_generation.jsonl`). Pass an explicit name when you want one, e.g. `cassette_model("latest")`.

### Also in this PR

- `cassette_model` fixture + `--record` / `--replay` options
- First committed cassette: `tests/cassettes/test_box_generation.jsonl`
- `tests/test_live_generation.py` end-to-end generation test

## Test plan

- [ ] `uv run pytest tests/test_live_generation.py --replay -v` — 1 passed (offline)
- [ ] Move the cassette aside, run `--replay` again — process exits with “cassette missing” (not skip)
- [ ] (optional, pays) `OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record`
- [ ] Base #23 understood / merged or this PR stays stacked


### Tape CLI (folded into this PR)

`scripts/tape.py` manages the recording library by hand: `list`, `show`,
`record` (live, pays once), `replay` (offline, end to end), `erase`.
Recordings carry a metadata row (prompt, model) that `replay` runs against;
`run_scenario` takes `on_event=` for the live transcript.

```bash
uv run python scripts/tape.py replay test_box_generation
```
