### PR TITLE
Cover the warm worker internals

### DIFF
--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+import types
 from pathlib import Path
 
+import _compile_server
+import harness
 import pytest
 from harness import (
     GOOD_MAIN_PY,
@@ -323,6 +327,46 @@ def test_compile_server_rejects_invalid_json(
 
     with pytest.raises(CompileServerError, match="invalid JSON"):
         server.compile(run_dir, timeout_seconds=30)
+
+
+def test_compile_server_stop_is_idempotent() -> None:
+    """Stopping with no worker is a no-op, as is stopping twice."""
+    server = harness._CompileServer()
+    server._stop()
+    server._stop()
+
+
+def test_compile_server_parses_requests() -> None:
+    assert _compile_server._parse_request("not json") is None
+    assert _compile_server._parse_request('{"wrong": "shape"}') is None
+    assert _compile_server._parse_request('{"run_dir": 42}') is None
+    parsed = _compile_server._parse_request('{"run_dir": "/tmp/some-run"}')
+    assert parsed == Path("/tmp/some-run").resolve()
+
+
+def test_compile_server_evicts_only_workspace_modules(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "run" / "workspace"
+    workspace.mkdir(parents=True)
+    inside = workspace / "helper.py"
+    inside.write_text("", encoding="utf-8")
+    outside = tmp_path / "other.py"
+    outside.write_text("", encoding="utf-8")
+    for name, file in (
+        ("fake_inside", inside),
+        ("fake_outside", outside),
+        ("fake_builtin", None),
+    ):
+        module = types.ModuleType(name)
+        module.__file__ = None if file is None else str(file)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    _compile_server._evict_workspace_modules(workspace)
+
+    assert "fake_inside" not in sys.modules
+    assert "fake_outside" in sys.modules
+    assert "fake_builtin" in sys.modules
 
 
 def test_warm_environment_enforces_the_timeout_contract(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -470,6 +470,93 @@ def test_strict_replay_detects_trajectory_drift(replay_harness: ReplayHarness) -
         run(replay.query([{"role": "user", "content": "different"}]))
 
 
+def test_strict_replay_detects_tool_set_drift(replay_harness: ReplayHarness) -> None:
+    recorded_tools = [{"name": "compile"}]
+    with replay_harness.capture("run", ScriptedModel([text("a"), text("b")])) as recording:
+        run(recording.query([{"role": "user", "content": "go"}], tools=recorded_tools))
+        run(recording.query([{"role": "user", "content": "go"}], tools=recorded_tools))
+
+    replay = replay_harness.replay("run")
+    first = run(replay.query([{"role": "user", "content": "go"}], tools=recorded_tools))
+    assert first["text"] == "a"
+    with pytest.raises(CassetteMismatchError, match="turn 2 diverged"):
+        run(replay.query([{"role": "user", "content": "go"}], tools=[{"name": "different"}]))
+
+
+def test_strict_replay_ignores_payload_text(replay_harness: ReplayHarness) -> None:
+    """Same structure, different words: payload text is not fingerprinted."""
+    with replay_harness.capture("run", ScriptedModel([text("a"), text("b")])) as recording:
+        run(recording.query([{"role": "user", "content": "first wording"}]))
+        run(
+            recording.query(
+                [
+                    {"role": "user", "content": "first wording"},
+                    {"role": "assistant", "content": "a"},
+                ]
+            )
+        )
+
+    replay = replay_harness.replay("run")
+    assert run(replay.query([{"role": "user", "content": "DIFFERENT WORDING"}]))["text"] == "a"
+    second = run(
+        replay.query(
+            [
+                {"role": "user", "content": "DIFFERENT WORDING"},
+                {"role": "assistant", "content": "a"},
+            ]
+        )
+    )
+    assert second["text"] == "b"
+
+
+def test_non_strict_replay_skips_fingerprint_checks(replay_harness: ReplayHarness) -> None:
+    with replay_harness.capture("run", ScriptedModel([text("a")])) as recording:
+        run(recording.query([{"role": "user", "content": "go"}]))
+
+    replay = replay_harness.replay("run", strict=False)
+    assert run(replay.query([{"role": "assistant", "content": "anything"}]))["text"] == "a"
+
+
+def test_recording_model_delegates_exhaustion_to_finite_models(
+    replay_harness: ReplayHarness,
+) -> None:
+    inner = ScriptedModel([text("a"), text("leftover")])
+    with replay_harness.capture("run", inner) as recording:
+        run(recording.query([]))
+    with pytest.raises(AssertionError, match="never consumed"):
+        recording.assert_exhausted()
+
+
+def test_a_failed_capture_keeps_the_partial_cassette(replay_harness: ReplayHarness) -> None:
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        replay_harness.capture("run", ScriptedModel([text("a")])) as recording,
+    ):
+        run(recording.query([]))
+        raise RuntimeError("boom")
+    assert replay_harness.entries("run")  # the partial cassette stays for inspection
+
+    with replay_harness.capture("run", ScriptedModel([text("b")])) as recording:
+        run(recording.query([]))
+    assert [row["response"]["text"] for row in replay_harness.entries("run")] == ["b"]
+
+
+def test_malformed_cassette_rows_report_their_location(replay_harness: ReplayHarness) -> None:
+    path = replay_harness.set("broken", [text("ok")])
+    path.write_text(
+        '{"fingerprint": "", "response": {"text": "ok"}}\nnot json\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(CassetteError, match=r"invalid cassette row .*:2"):
+        replay_harness.entries("broken")
+
+
+def test_set_normalizes_plain_responses(replay_harness: ReplayHarness) -> None:
+    replay_harness.set("norm", [{"text": "hi"}])
+    row = replay_harness.entries("norm")[0]
+    assert row["response"] == {"text": "hi", "tool_calls": [], "cost": 0.0, "token_usage": {}}
+
+
 def test_replay_beyond_the_cassette_is_a_clear_error(replay_harness: ReplayHarness) -> None:
     replay_harness.set("short", [text("only")])
     replay = replay_harness.replay("short")


### PR DESCRIPTION
Part of the modular-test-environment stack (base: the primitive-contracts PR).

Behavior-preserving tests for the pieces the warm-lane contract rests on:

- stop idempotency with no running worker
- request-line parsing (garbage, wrong shape, non-string run_dir)
- workspace-module eviction removes exactly the modules rooted in the compiled workspace

Verified: 3 new tests; gates green (40 passed in `tests/test_harness.py`).