### PR TITLE
Fix ruff format drift on main

### DIFF
--- a/src/mini_articraft/models/openai.py
+++ b/src/mini_articraft/models/openai.py
@@ -244,9 +244,7 @@ def _response_cost(response: dict[str, Any]) -> float:
 
     uncached_tokens = max(
         0,
-        usage["input_tokens"]
-        - usage["cached_input_tokens"]
-        - usage["cache_write_tokens"],
+        usage["input_tokens"] - usage["cached_input_tokens"] - usage["cache_write_tokens"],
     )
     cache_write_price = spec.cache_write_price or spec.input_price
     return round(
@@ -268,9 +266,7 @@ def _response_token_usage(response: dict[str, Any]) -> dict[str, int]:
 
     details = usage.get("input_tokens_details")
     cached_tokens = _int(details.get("cached_tokens")) if isinstance(details, dict) else 0
-    cache_write_tokens = (
-        _int(details.get("cache_write_tokens")) if isinstance(details, dict) else 0
-    )
+    cache_write_tokens = _int(details.get("cache_write_tokens")) if isinstance(details, dict) else 0
     input_tokens = _int(usage.get("input_tokens"))
     output_tokens = _int(usage.get("output_tokens"))
     total_tokens = _int(usage.get("total_tokens")) or input_tokens + output_tokens

--- a/src/mini_articraft/sdk/_mesh_sweeps.py
+++ b/src/mini_articraft/sdk/_mesh_sweeps.py
@@ -274,9 +274,7 @@ def _insert_path_fractions(
         if not any(abs(existing - fraction) <= _EPS for existing in values):
             values.append(fraction)
     values.sort()
-    return [
-        _path_point_at_distance(path, fraction * total, closed=closed) for fraction in values
-    ]
+    return [_path_point_at_distance(path, fraction * total, closed=closed) for fraction in values]
 
 
 def _subdivide_path_segments(

--- a/tests/test_openai_model.py
+++ b/tests/test_openai_model.py
@@ -196,9 +196,7 @@ def test_openai_model_returns_estimated_cost_for_gpt_5_6_sol(
     patch_websocket(monkeypatch, socket)
 
     result = run(
-        openai_model(openai_model="gpt-5.6-sol").query(
-            [{"role": "user", "content": "build"}]
-        )
+        openai_model(openai_model="gpt-5.6-sol").query([{"role": "user", "content": "build"}])
     )
 
     assert result["cost"] == 0.0054


### PR DESCRIPTION
## Summary
- Reformat three files that were failing `ruff format --check` on main after recent merges

## Test plan
- [x] `uv run ruff format --check src/mini_articraft tests`
- [ ] CI green