### PR TITLE
Pin the scripted-lane primitive contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,5 @@ jobs:
         run: uv run --frozen basedpyright
 
       - name: Test
-        run: uv run --frozen pytest -q
+        # --replay: cassette-backed tests stay offline (live is the local default)
+        run: uv run --frozen pytest -q --replay

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,9 @@ directories for compile and record tests. Do not require real model calls unless
 the test is explicitly about a live adapter.
 
 `tests/harness.py` is the modular test environment for agent-loop behavior:
-scripted models and cassette replay (`ReplayHarness`) drive the full loop
-without paid model calls. See
-`tests/README.md` for the lanes and when to use each. Keep the subprocess
+scripted models, warm-worker compiles (`WarmEnvironment`), and cassette replay
+(`ReplayHarness`) cover the full loop without paid model calls. See
+`tests/README.md` for the four lanes and when to use each. Keep the subprocess
 worker contract covered in `test_compile.py`. A few exec-output timing tests
 are known to flake on macOS; do not weaken them locally.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,11 @@ typeCheckingMode = "standard"
 [[tool.basedpyright.executionEnvironments]]
 root = "tests"
 
+# The tape CLI also imports the test environment from tests/.
+[[tool.basedpyright.executionEnvironments]]
+root = "scripts"
+extraPaths = ["tests"]
+
 [tool.pytest.ini_options]
 addopts = "-m 'not volume'"
 markers = [

--- a/scripts/tape.py
+++ b/scripts/tape.py
@@ -1,0 +1,156 @@
+"""Manage generation tapes: list, show, record, replay, erase.
+
+The tape library lives in tests/cassettes by default. Capturing costs a
+real generation (OPENAI_API_KEY); replaying is free. Examples:
+
+    uv run python scripts/tape.py list
+    uv run python scripts/tape.py show box
+    uv run python scripts/tape.py record box "a small box"     # live, pays
+    uv run python scripts/tape.py replay box                    # replays offline
+    uv run python scripts/tape.py erase box
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests"))
+
+import harness
+from harness import CASSETTE_ROOT, ReplayHarness, WarmEnvironment
+
+app = typer.Typer(help=__doc__, no_args_is_help=True)
+
+Root = Annotated[Path, typer.Option("--root", "-r", help="Cassette library root.")]
+
+
+@app.command()
+def list(root: Root = CASSETTE_ROOT) -> None:
+    """List recordings in the library."""
+    library = ReplayHarness(root)
+    names = library.names()
+    if not names:
+        typer.echo(f"(no recordings in {library.root})")
+        return
+    for name in names:
+        rows = [row for row in library.entries(name) if "response" in row]
+        prompt = library.meta(name).get("prompt", "")
+        suffix = f"  prompt={prompt!r}" if prompt else ""
+        typer.echo(f"{name}: {len(rows)} exchange(s){suffix}")
+
+
+@app.command()
+def show(name: str, root: Root = CASSETTE_ROOT) -> None:
+    """Show one recording's exchanges."""
+    library = ReplayHarness(root)
+    meta = library.meta(name)
+    if meta:
+        typer.echo(f"meta: {json.dumps(meta, default=str)}")
+    turn = 0
+    for row in library.entries(name):
+        if "response" not in row:
+            continue
+        turn += 1
+        response = row["response"]
+        tool_names = [call.get("name") for call in response.get("tool_calls") or []]
+        preview = (response.get("text") or "")[:80]
+        typer.echo(
+            f"turn {turn}: tools={tool_names} cost={response.get('cost', 0.0)} text={preview!r}"
+        )
+
+
+@app.command()
+def record(
+    name: str,
+    prompt: str,
+    root: Root = CASSETTE_ROOT,
+    max_turns: int = 100,
+) -> None:
+    """Run a live generation and record it as a tape (pays for model calls)."""
+    from mini_articraft.agent import Agent
+    from mini_articraft.environments.local import LocalEnvironment
+    from mini_articraft.models.openai import OpenAIModel
+    from mini_articraft.settings import get_settings
+
+    settings = get_settings()
+    library = ReplayHarness(root)
+    meta = {"prompt": prompt, "model": settings.openai_model}
+    with library.capture(name, OpenAIModel(settings), meta=meta) as model:
+        result = harness.run(
+            Agent(model, LocalEnvironment(), max_turns=max_turns, on_event=_print_event).run(prompt)
+        )
+    _print_result(result)
+    raise typer.Exit(0 if result["status"] == "success" else 1)
+
+
+@app.command()
+def replay(
+    name: str,
+    root: Root = CASSETTE_ROOT,
+    prompt: Annotated[str | None, typer.Option("--prompt", "-p")] = None,
+    output_dir: Annotated[Path, typer.Option("--output-dir", "-o")] = Path("runs"),
+) -> None:
+    """Replay a recorded generation offline, end to end, for free."""
+    library = ReplayHarness(root)
+    actual_prompt = prompt or library.meta(name).get("prompt")
+    if not actual_prompt:
+        raise typer.BadParameter(f"tape {name!r} has no recorded prompt; pass --prompt")
+    run_id = f"tape-{name}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    artifacts = harness.run_scenario(
+        actual_prompt,
+        model=library.replay(name),
+        env=WarmEnvironment(output_dir=output_dir),
+        run_id=run_id,
+        on_event=_print_event,
+    )
+    finished = artifacts.recorder.finished
+    if finished is not None:
+        typer.echo(f"turns={finished.turns} duration={finished.duration}s")
+    _print_result(artifacts.result)
+    raise typer.Exit(0 if artifacts.record.status == "success" else 1)
+
+
+@app.command()
+def erase(name: str, root: Root = CASSETTE_ROOT) -> None:
+    """Remove one recording."""
+    library = ReplayHarness(root)
+    if library.erase(name):
+        typer.echo(f"erased {name}")
+        return
+    raise typer.BadParameter(f"unknown tape: {name!r}")
+
+
+def _print_event(event: harness.events.Event) -> None:
+    if isinstance(event, harness.events.RunStarted):
+        typer.echo(f"run {event.run_id} model={event.model}")
+    elif isinstance(event, harness.events.AssistantMessage):
+        preview = event.text.strip().splitlines()[0][:80] if event.text.strip() else ""
+        tool_names = [call.get("name") for call in event.tool_calls]
+        if tool_names:
+            typer.echo(f"turn {event.turn}: tools={tool_names}")
+        elif preview:
+            typer.echo(f"turn {event.turn}: {preview}")
+
+
+def _print_result(result: dict[str, Any]) -> None:
+    typer.echo(
+        f"status={result['status']} cost=${result.get('cost', 0.0):.4f} result={result.get('result') or '-'}"
+    )
+    if result.get("error"):
+        typer.echo(f"error={result['error']}")
+
+
+def main() -> None:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mini_articraft/environments/local.py
+++ b/src/mini_articraft/environments/local.py
@@ -116,13 +116,12 @@ class LocalEnvironment:
                 returncode=completed.returncode,
             )
 
-        payload.setdefault("stdout", "")
-        payload["stderr"] = str(payload.get("stderr", "")) + completed.stderr
-        payload.setdefault("error", "")
-        payload.setdefault("traceback", "")
-        payload["returncode"] = completed.returncode
-        payload["compile_report"] = build_compile_report_from_payload(payload)
-        return _with_paths(run_dir, payload)
+        return _finalize_payload(
+            run_dir,
+            payload,
+            stderr=completed.stderr,
+            returncode=completed.returncode,
+        )
 
     def _record_compile(self, run_dir: Path) -> None:
         record = Record.load(run_dir / "record.json")
@@ -207,6 +206,28 @@ def _with_paths(run_dir: Path, result: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _finalize_payload(
+    run_dir: Path,
+    payload: dict[str, Any],
+    *,
+    stderr: str,
+    returncode: int | None,
+) -> dict[str, Any]:
+    """Assemble the environment-level compile result from a worker payload.
+
+    Single owner of result assembly for any worker transport: captured worker
+    stderr is followed by process-level stderr, missing keys are defaulted,
+    and the compile report and run paths are attached here.
+    """
+    payload.setdefault("stdout", "")
+    payload["stderr"] = str(payload.get("stderr", "")) + stderr
+    payload.setdefault("error", "")
+    payload.setdefault("traceback", "")
+    payload["returncode"] = returncode
+    payload["compile_report"] = build_compile_report_from_payload(payload)
+    return _with_paths(run_dir, payload)
+
+
 def _error_result(
     run_dir: Path,
     *,
@@ -215,7 +236,5 @@ def _error_result(
     stderr: str = "",
     returncode: int | None = None,
 ) -> dict[str, Any]:
-    payload = empty_compile_payload(error=error, stdout=stdout, stderr=stderr)
-    payload["returncode"] = returncode
-    payload["compile_report"] = build_compile_report_from_payload(payload)
-    return _with_paths(run_dir, payload)
+    payload = empty_compile_payload(error=error, stdout=stdout)
+    return _finalize_payload(run_dir, payload, stderr=stderr, returncode=returncode)

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,15 +3,17 @@
 This suite verifies the generation loop without paid model calls.
 `tests/harness.py` is the shared kit; prefer it over per-file fakes.
 
-## The lanes
+## The four lanes
 
 | Lane | Cost | Use for |
 | --- | --- | --- |
 | Unit | ~0s | pure functions: SDK checks, `compile_feedback`, signals |
-| Scripted agent | seconds per run | the full agent loop via `ScriptedModel` + `run_scenario` |
+| Warm compile | ~0.1s per compile | compile behavior via `WarmEnvironment` |
+| Scripted agent | ~0.5s per run | the full agent loop via `ScriptedModel` + `run_scenario` |
+| Cassette replay | free | recorded real runs via `ReplayHarness` |
 
 ```python
-from harness import run_scenario, calls, text, tool_call
+from harness import WarmEnvironment, run_scenario, calls, text, tool_call
 
 artifacts = run_scenario(
     "a box",
@@ -20,7 +22,7 @@ artifacts = run_scenario(
         calls(tool_call("compile")),
         text("done"),
     ],
-    tmp_path=tmp_path,
+    env=WarmEnvironment(output_dir=tmp_path),
 )
 assert artifacts.record.status == "success"
 ```
@@ -29,6 +31,25 @@ A scripted step can also be a callable `(ModelQuery) -> Response`, so the
 "model" can assert on what the agent sent and react to earlier tool outputs.
 See `tests/test_agent_scenarios.py` for end-to-end examples (repair loops,
 repeat-failure guidance, allowances).
+
+## WarmEnvironment vs LocalEnvironment
+
+Both lanes run every compile in a worker subprocess with the same timeout,
+cleanup, and result-assembly contract (shared in
+`src/mini_articraft/environments/local.py`). They differ only in the worker
+lifecycle:
+
+- `LocalEnvironment` (cold) spawns a fresh interpreter per compile (~3s).
+  It owns the fresh-interpreter, process-cleanup, and installed-wheel
+  contracts (`test_compile.py`).
+- `WarmEnvironment` (warm) keeps one worker (`tests/_compile_server.py`)
+  alive for the whole test session, so compiles cost ~0.1s. A compile that
+  times out or kills the worker (e.g. `os._exit` in workspace code) gets an
+  error result; the next compile lazily starts a fresh worker. Compiles are
+  serialized through the shared worker.
+
+Agent-loop tests that monkeypatch the compile tool (`compile_success_tool()`)
+never compile at all and can use either environment.
 
 ## Cassettes: pay once, replay forever
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,20 +80,25 @@ Curated regression cassettes belong in `tests/cassettes/` (git-ignored by
 default; force-add the ones worth keeping). Scratch cassettes belong under
 `tmp_path`.
 
-## Live tests in replay mode
+## Live tests: `--record` / `--replay`
 
-Tests using the `cassette_model` fixture run live only when asked:
+Tests using the `cassette_model` fixture are **live by default**. Named
+cassettes (`tests/cassettes/<name>.jsonl`; default name = test function,
+or e.g. `cassette_model("latest")`) are used only when you ask:
 
 ```bash
-# offline (default): replay tests/cassettes/<test name>.jsonl; skip if missing
+# default: always live (needs OPENAI_API_KEY)
 uv run pytest tests/test_live_generation.py
 
-# live: pay once, (re)record the cassette
-OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+# offline: replay the named cassette; exit if missing
+uv run pytest tests/test_live_generation.py --replay
+
+# live + (re)record the cassette (needs OPENAI_API_KEY)
+OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 ```
 
-Record intentionally, commit the cassette (`git add -f`), and CI replays it
-for free. Cassette names default to the test function name.
+Commit a cassette (`git add -f`) and run CI with `--replay` for a hard
+offline gate. No `--replay` means no cassette — always the real model.
 
 ## Known platform flakes
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,6 +80,21 @@ Curated regression cassettes belong in `tests/cassettes/` (git-ignored by
 default; force-add the ones worth keeping). Scratch cassettes belong under
 `tmp_path`.
 
+## Live tests in replay mode
+
+Tests using the `cassette_model` fixture run live only when asked:
+
+```bash
+# offline (default): replay tests/cassettes/<test name>.jsonl; skip if missing
+uv run pytest tests/test_live_generation.py
+
+# live: pay once, (re)record the cassette
+OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+```
+
+Record intentionally, commit the cassette (`git add -f`), and CI replays it
+for free. Cassette names default to the test function name.
+
 ## Known platform flakes
 
 On macOS, a few exec-output timing tests can fail with empty captured output

--- a/tests/README.md
+++ b/tests/README.md
@@ -100,6 +100,22 @@ OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 Commit a cassette (`git add -f`) and run CI with `--replay` for a hard
 offline gate. No `--replay` means no cassette — always the real model.
 
+## The tape CLI
+
+`scripts/tape.py` manages the recording library by hand:
+
+```bash
+uv run python scripts/tape.py list            # recordings + prompts
+uv run python scripts/tape.py show box        # one recording's exchanges
+uv run python scripts/tape.py replay box      # replay offline, end to end
+uv run python scripts/tape.py record box "a small box"   # live, pays once
+uv run python scripts/tape.py erase box
+```
+
+`record` stores the prompt as cassette metadata, which is what `replay`
+replays against. `--root` points at another library (the default is
+`tests/cassettes/`).
+
 ## Known platform flakes
 
 On macOS, a few exec-output timing tests can fail with empty captured output

--- a/tests/_compile_server.py
+++ b/tests/_compile_server.py
@@ -1,0 +1,71 @@
+"""Warm compile worker for the test suite.
+
+Reads ``{"run_dir": ...}`` requests as newline-delimited JSON on stdin and
+writes one compile payload line per request on stdout -- the same payload
+shape ``mini_articraft.environments.worker`` prints for a one-shot compile.
+Keeping one worker alive lets a test session pay the geometry import cost
+once instead of once per compile (~3s -> ~0.1s).
+
+This is the tests-only half of the worker contract. If a persistent worker
+ever becomes a product feature, promote this loop into
+``mini_articraft/environments/worker.py``; the wire format is already shared.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from mini_articraft.compile_feedback import empty_compile_payload
+from mini_articraft.environments.worker import compile_run
+
+
+def main() -> int:
+    _emit({"ready": True})  # startup handshake: imports are done, requests are served
+    for line in sys.stdin:
+        run_dir = _parse_request(line)
+        if run_dir is None:
+            _emit(empty_compile_payload(error=f"bad compile request: {line.strip()!r}"))
+            continue
+        try:
+            _emit(compile_run(run_dir))
+        except BaseException as exc:  # keep serving after a broken compile
+            _emit(empty_compile_payload(error=f"{type(exc).__name__}: {exc}"))
+        _evict_workspace_modules(run_dir / "workspace")
+    return 0
+
+
+def _parse_request(line: str) -> Path | None:
+    try:
+        request = json.loads(line)
+        return Path(request["run_dir"]).resolve()
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, default=str) + "\n")
+    sys.stdout.flush()
+
+
+def _evict_workspace_modules(workspace: Path) -> None:
+    """Forget modules imported from the workspace so the next run re-imports.
+
+    Two runs may both define ``helper.py``; without eviction the second
+    compile would silently see the first run's module from ``sys.modules``.
+    """
+    for name, module in list(sys.modules.items()):
+        file = getattr(module, "__file__", None)
+        if file is None:
+            continue
+        try:
+            if Path(file).resolve().is_relative_to(workspace):
+                del sys.modules[name]
+        except OSError:
+            continue
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cassettes/test_box_generation.jsonl
+++ b/tests/cassettes/test_box_generation.jsonl
@@ -1,0 +1,4 @@
+{"meta": {"prompt": "a simple box", "authored": true}}
+{"fingerprint": "", "response": {"text": "", "tool_calls": [{"id": "call_1", "name": "write", "arguments": "{\"path\": \"main.py\", \"content\": \"\\nfrom build123d import Box\\n\\nfrom mini_articraft.sdk import ArticulatedObject, TestContext, TestReport\\n\\n\\ndef build_object_model() -> ArticulatedObject:\\n    model = ArticulatedObject(\\\"box\\\")\\n    base = model.part(\\\"base\\\")\\n    base.add(Box(0.2, 0.2, 0.1), name=\\\"body\\\")\\n    return model\\n\\n\\nobject_model = build_object_model()\\n\\n\\ndef run_tests() -> TestReport:\\n    return TestContext(object_model).report()\\n\"}"}], "cost": 0.0, "token_usage": {}}}
+{"fingerprint": "", "response": {"text": "", "tool_calls": [{"id": "call_2", "name": "compile", "arguments": "{}"}], "cost": 0.0, "token_usage": {}}}
+{"fingerprint": "", "response": {"text": "done", "tool_calls": [], "cost": 0.0, "token_usage": {}}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,13 +49,23 @@ def replay_harness(tmp_path: Path) -> ReplayHarness:
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--record-cassettes",
+    group = parser.getgroup("cassettes")
+    group.addoption(
+        "--record",
         action="store_true",
         default=False,
         help=(
-            "run cassette-backed tests live and re-record their cassettes "
-            "(needs OPENAI_API_KEY); the default is offline replay"
+            "run cassette-backed tests live and (re)record named cassettes "
+            "(needs OPENAI_API_KEY)"
+        ),
+    )
+    group.addoption(
+        "--replay",
+        action="store_true",
+        default=False,
+        help=(
+            "replay named cassettes offline; exit if a cassette is missing "
+            "(without this flag, cassette-backed tests always run live)"
         ),
     )
 
@@ -65,26 +75,39 @@ CassetteModelOpener = Callable[[str | None], AbstractContextManager[ScenarioMode
 
 @pytest.fixture
 def cassette_model(request: pytest.FixtureRequest) -> CassetteModelOpener:
-    """Open a cassette-backed model for live/e2e tests.
+    """Open a named model for live/e2e tests.
 
-    Default: offline replay of ``tests/cassettes/<name>.jsonl`` (the test's
-    own name when none is given), skipping when no cassette exists. With
-    ``--record-cassettes``: run live against the real model and re-record
-    the cassette (needs ``OPENAI_API_KEY``).
+    Names default to the test function (``cassette_model()``), or pass an
+    explicit name such as ``cassette_model("latest")``.
+
+    - default (no flags): always live (real model)
+    - ``--record``: live + (re)write the cassette
+    - ``--replay``: offline cassette only; exit if missing
     """
-    record = request.config.getoption("--record-cassettes")
+    record = bool(request.config.getoption("--record"))
+    replay = bool(request.config.getoption("--replay"))
+    if record and replay:
+        pytest.exit("use only one of --record and --replay", returncode=2)
+
     library = ReplayHarness(CASSETTE_ROOT)
 
     @contextmanager
     def open_cassette(name: str | None = None) -> Iterator[ScenarioModel]:
         cassette_name = name or request.node.name
+        if replay:
+            if not library.has(cassette_name):
+                path = library.path(cassette_name)
+                pytest.exit(
+                    f"cassette {cassette_name!r} missing at {path}; record with --record",
+                    returncode=1,
+                )
+            yield library.replay(cassette_name)
+            return
         if record:
             with library.capture(cassette_name, _live_model()) as recording:
                 yield recording
             return
-        if not library.has(cassette_name):
-            pytest.skip(f"cassette {cassette_name!r} not recorded; run with --record-cassettes")
-        yield library.replay(cassette_name)
+        yield _live_model()
 
     return open_cassette
 
@@ -95,4 +118,4 @@ def _live_model() -> Model:
 
         return OpenAIModel()
     except Exception as exc:
-        pytest.skip(f"--record-cassettes needs OPENAI_API_KEY: {exc}")
+        pytest.exit(f"live model needs OPENAI_API_KEY: {exc}", returncode=1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help=(
-            "run cassette-backed tests live and (re)record named cassettes "
-            "(needs OPENAI_API_KEY)"
+            "run cassette-backed tests live and (re)record named cassettes (needs OPENAI_API_KEY)"
         ),
     )
     group.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,4 +117,4 @@ def _live_model() -> Model:
 
         return OpenAIModel()
     except Exception as exc:
-        pytest.exit(f"live model needs OPENAI_API_KEY: {exc}", returncode=1)
+        pytest.fail(f"live model needs OPENAI_API_KEY: {exc}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 
 import pytest
-from harness import CASSETTE_ROOT, ReplayHarness, ScenarioModel
+from harness import CASSETTE_ROOT, ReplayHarness
 
 from mini_articraft import Model
 
@@ -69,7 +69,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-CassetteModelOpener = Callable[[str | None], AbstractContextManager[ScenarioModel]]
+CassetteModelOpener = Callable[[str | None], AbstractContextManager[Model]]
 
 
 @pytest.fixture
@@ -91,7 +91,7 @@ def cassette_model(request: pytest.FixtureRequest) -> CassetteModelOpener:
     library = ReplayHarness(CASSETTE_ROOT)
 
     @contextmanager
-    def open_cassette(name: str | None = None) -> Iterator[ScenarioModel]:
+    def open_cassette(name: str | None = None) -> Iterator[Model]:
         cassette_name = name or request.node.name
         if replay:
             if not library.has(cassette_name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 
 import pytest
-from harness import ReplayHarness
+from harness import CASSETTE_ROOT, ReplayHarness, ScenarioModel
+
+from mini_articraft import Model
 
 
 @pytest.fixture(scope="session")
@@ -42,3 +46,53 @@ def _use_session_loop(_event_loop):
 def replay_harness(tmp_path: Path) -> ReplayHarness:
     """A scratch cassette library under the test's tmp dir."""
     return ReplayHarness(tmp_path / "cassettes")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--record-cassettes",
+        action="store_true",
+        default=False,
+        help=(
+            "run cassette-backed tests live and re-record their cassettes "
+            "(needs OPENAI_API_KEY); the default is offline replay"
+        ),
+    )
+
+
+CassetteModelOpener = Callable[[str | None], AbstractContextManager[ScenarioModel]]
+
+
+@pytest.fixture
+def cassette_model(request: pytest.FixtureRequest) -> CassetteModelOpener:
+    """Open a cassette-backed model for live/e2e tests.
+
+    Default: offline replay of ``tests/cassettes/<name>.jsonl`` (the test's
+    own name when none is given), skipping when no cassette exists. With
+    ``--record-cassettes``: run live against the real model and re-record
+    the cassette (needs ``OPENAI_API_KEY``).
+    """
+    record = request.config.getoption("--record-cassettes")
+    library = ReplayHarness(CASSETTE_ROOT)
+
+    @contextmanager
+    def open_cassette(name: str | None = None) -> Iterator[ScenarioModel]:
+        cassette_name = name or request.node.name
+        if record:
+            with library.capture(cassette_name, _live_model()) as recording:
+                yield recording
+            return
+        if not library.has(cassette_name):
+            pytest.skip(f"cassette {cassette_name!r} not recorded; run with --record-cassettes")
+        yield library.replay(cassette_name)
+
+    return open_cassette
+
+
+def _live_model() -> Model:
+    try:
+        from mini_articraft.models.openai import OpenAIModel
+
+        return OpenAIModel()
+    except Exception as exc:
+        pytest.skip(f"--record-cassettes needs OPENAI_API_KEY: {exc}")

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -824,7 +824,7 @@ class RunArtifacts:
 
     result: dict[str, Any]
     record: Record
-    model: ScenarioModel
+    model: ScenarioModel | Model
     recorder: EventRecorder
     run_dir: Path
 
@@ -845,7 +845,7 @@ def run_scenario(
     prompt: str,
     script: Iterable[Step] | None = None,
     *,
-    model: ScenarioModel | None = None,
+    model: ScenarioModel | Model | None = None,
     env: LocalEnvironment | None = None,
     tmp_path: Path | None = None,
     run_id: str = "scenario",
@@ -856,10 +856,11 @@ def run_scenario(
 
     The model is a fresh :class:`ScriptedModel` built from ``script`` unless
     ``model=`` plugs in something else -- e.g. one recording from a
-    :class:`ReplayHarness`. Pass ``env`` to choose the compile lane
-    (:class:`WarmEnvironment` for speed) or ``tmp_path`` for a plain
-    subprocess ``LocalEnvironment``. By default the model must be consumed
-    exactly; pass ``assert_exhausted=False`` for open-ended runs.
+    :class:`ReplayHarness`, or a live :class:`~mini_articraft.Model`. Pass
+    ``env`` to choose the compile lane (:class:`WarmEnvironment` for speed)
+    or ``tmp_path`` for a plain subprocess ``LocalEnvironment``. By default
+    finite harness models must be consumed exactly; pass
+    ``assert_exhausted=False`` for open-ended or live runs.
     """
     if model is None:
         if script is None:
@@ -875,7 +876,9 @@ def run_scenario(
     agent = Agent(model, env, max_turns=max_turns, on_event=recorder)
     result = run(agent.run(prompt, run_id=run_id))
     if assert_exhausted:
-        model.assert_exhausted()
+        check = getattr(model, "assert_exhausted", None)
+        if callable(check):
+            check()
     run_dir = Path(str(result["run"]))
     return RunArtifacts(
         result=result,

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -1,38 +1,57 @@
 """Modular test environment for mini-articraft.
 
-Verify the generation loop deeply without paying for model calls:
+Verify the generation loop deeply without paying for model calls. Four
+lanes, cheapest first:
 
 1. Unit lane -- call pure functions (SDK checks, compile feedback) directly;
    no harness needed.
-2. Scripted agent lane -- :class:`ScriptedModel` plus :func:`run_scenario`
+2. Warm compile lane -- :class:`WarmEnvironment` keeps one compile worker
+   subprocess alive for the whole test session: the same isolation, timeout,
+   and cleanup contract as ``LocalEnvironment``, but the geometry imports are
+   paid once instead of once per compile (~3s -> ~0.1s).
+3. Scripted agent lane -- :class:`ScriptedModel` plus :func:`run_scenario`
    drive the full agent loop (tools, reminders, compile freshness, record)
    with a deterministic model that can react to what the agent sends it.
-3. Cassette lane -- :class:`ReplayHarness` manages any number of named
+4. Cassette lane -- :class:`ReplayHarness` manages any number of named
    recordings: capture one from a live (paid) model once, author one from a
    scripted model for free, or install one by hand; then plug any of them
    into :func:`run_scenario` by name for offline regression runs.
+
+The cold lane (``LocalEnvironment``, fresh worker per compile) stays the
+reference for the fresh-interpreter and installed-wheel contracts; both
+lanes share the worker payload shape and ``local.py``'s result assembly, so
+behavior differences between them are bugs, not semantics.
 """
 
 from __future__ import annotations
 
 import asyncio
+import atexit
+import contextlib
 import hashlib
 import inspect
 import itertools
 import json
+import os
+import queue
 import re
+import signal
+import subprocess
+import sys
+import threading
+import time
 from collections.abc import Awaitable, Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TypeVar
 
 from mini_articraft import Model
 from mini_articraft.agent import Agent, events
 from mini_articraft.agent.tools import Tool, ToolContext
 from mini_articraft.agent.tools._core import schema as _tool_schema
 from mini_articraft.agent.tools._core import workspace_digest
-from mini_articraft.environments.local import LocalEnvironment
+from mini_articraft.environments.local import LocalEnvironment, _error_result, _finalize_payload
 from mini_articraft.record import Record, read_conversation
 
 T = TypeVar("T")
@@ -523,6 +542,248 @@ class ReplayHarness:
             self.erase(name)
             removed += 1
         return removed
+
+
+# ---------------------------------------------------------------------------
+# Warm compile lane
+# ---------------------------------------------------------------------------
+
+_SERVER_SCRIPT = Path(__file__).resolve().parent / "_compile_server.py"
+
+# A fresh worker announces readiness (its first stdout line) once its imports
+# are done. The allowance bounds that handshake, so the per-compile timeout
+# can always bound the compile itself, spawn or no spawn.
+_WORKER_STARTUP_ALLOWANCE = 30.0
+
+
+class CompileServerError(RuntimeError):
+    """The warm compile worker cannot be used at all."""
+
+
+# The outcome of one compile request: the payload, or the reason there is
+# none (the worker is killed in both failure cases and lazily restarted).
+CompileStatus = Literal["ok", "timeout", "died"]
+
+
+class _CompileServer:
+    """One warm compile-worker subprocess shared by all ``WarmEnvironment``s.
+
+    Speaks newline-delimited JSON with ``tests/_compile_server.py``: the
+    worker announces readiness after its imports, then answers one
+    ``{"run_dir": ...}`` request per line with one compile payload line.
+    A compile that times out or takes the worker down with it (e.g.
+    ``os._exit`` in workspace code) costs one worker generation; the next
+    compile lazily starts a fresh one. Every queued line is tagged with its
+    generation so a stale reader from a killed worker can never be mistaken
+    for the current compile's response.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._lines: queue.Queue[tuple[int, str | None]] = queue.Queue()
+        self._proc: subprocess.Popen[str] | None = None
+        self._generation = 0
+        atexit.register(self._stop)
+
+    def compile(
+        self,
+        run_dir: Path,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[CompileStatus, dict[str, Any] | None]:
+        """Compile one run through the warm worker.
+
+        Returns ``("ok", payload)``. A compile that times out or takes the
+        worker down with it returns ``("timeout", None)`` or
+        ``("died", None)``; the worker is restarted on the next compile.
+        Compiles are serialized: one worker serves one compile at a time.
+        """
+        with self._lock:
+            generation = self._send(run_dir)
+            deadline = time.monotonic() + timeout_seconds
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._stop()
+                    return "timeout", None
+                try:
+                    item_generation, line = self._lines.get(timeout=remaining)
+                except queue.Empty:
+                    self._stop()
+                    return "timeout", None
+                if item_generation != generation:
+                    continue  # stale line from a killed worker generation
+                if line is None:
+                    self._stop()
+                    return "died", None
+                try:
+                    return "ok", json.loads(line)
+                except json.JSONDecodeError as exc:
+                    self._stop()
+                    raise CompileServerError(
+                        f"warm compile worker returned invalid JSON: {exc}"
+                    ) from exc
+
+    def _send(self, run_dir: Path) -> int:
+        """Write one request and return the serving worker's generation.
+
+        Retrying once on a write failure is safe: a broken pipe means the
+        worker is dead or dying, so no live compiler can hold the request --
+        recompiling on a fresh worker never duplicates a compile.
+        """
+        request = json.dumps({"run_dir": str(run_dir.resolve())}) + "\n"
+        for attempt in range(2):
+            proc, just_started = self._ensure_running()
+            self._drain_stale_lines()
+            if just_started and not self._await_ready():
+                self._stop()
+                if attempt:
+                    raise CompileServerError("warm compile worker failed to start") from None
+                continue
+            try:
+                assert proc.stdin is not None
+                proc.stdin.write(request)
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError):
+                self._stop()
+                if attempt:
+                    raise CompileServerError("warm compile worker is not usable") from None
+                continue
+            return self._generation
+        raise AssertionError("unreachable")
+
+    def _await_ready(self) -> bool:
+        """Wait for a fresh worker's readiness marker, bounded by the allowance."""
+        deadline = time.monotonic() + _WORKER_STARTUP_ALLOWANCE
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            try:
+                generation, line = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                return False
+            if generation != self._generation:
+                continue
+            if line is None:
+                return False  # the worker died during startup
+            try:
+                marker = json.loads(line)
+            except json.JSONDecodeError:
+                return False
+            return marker == {"ready": True}
+
+    def _ensure_running(self) -> tuple[subprocess.Popen[str], bool]:
+        if self._proc is None or self._proc.poll() is not None:
+            self._start()
+            assert self._proc is not None
+            return self._proc, True
+        return self._proc, False
+
+    def _start(self) -> None:
+        self._generation += 1
+        self._proc = subprocess.Popen(
+            [sys.executable, str(_SERVER_SCRIPT)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        reader = threading.Thread(
+            target=self._read_lines,
+            args=(self._proc, self._generation),
+            daemon=True,
+        )
+        reader.start()
+
+    def _read_lines(self, proc: subprocess.Popen[str], generation: int) -> None:
+        try:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                self._lines.put((generation, line))
+        finally:
+            self._lines.put((generation, None))  # EOF: the worker exited
+
+    def _drain_stale_lines(self) -> None:
+        while True:
+            try:
+                self._lines.get_nowait()
+            except queue.Empty:
+                return
+
+    def _stop(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is None:
+            return
+        if proc.stdin is not None:
+            with contextlib.suppress(OSError):
+                proc.stdin.close()
+        if proc.poll() is not None:
+            proc.wait()
+            return
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait()
+
+
+class WarmEnvironment(LocalEnvironment):
+    """A ``LocalEnvironment`` that compiles through one shared warm worker.
+
+    Same contract as the cold lane -- every compile runs in a worker
+    subprocess with the same timeout and cleanup semantics, and result
+    assembly is shared with ``LocalEnvironment`` -- but the worker
+    (``tests/_compile_server.py``) stays alive between compiles, so the
+    geometry imports are paid once per test session instead of once per
+    compile (~3s -> ~0.1s each). A compile that times out or crashes the
+    worker gets an error result, and the next compile lazily starts a fresh
+    worker. Compiles are serialized through the single shared worker.
+
+    ``compile_count`` tracks how many real compiles ran, which makes
+    freshness-cache behavior directly assertable.
+    """
+
+    _server: ClassVar[_CompileServer | None] = None
+    _server_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.compile_count = 0
+
+    @classmethod
+    def _shared_server(cls) -> _CompileServer:
+        with cls._server_lock:
+            if cls._server is None:
+                cls._server = _CompileServer()
+            return cls._server
+
+    def _run_worker(self, run_dir: Path) -> dict[str, Any]:
+        self.compile_count += 1
+        status, payload = self._shared_server().compile(
+            run_dir,
+            timeout_seconds=self.config.timeout_seconds,
+        )
+        if status == "timeout":
+            return _error_result(
+                run_dir,
+                error=f"compile timed out after {self.config.timeout_seconds:g}s",
+            )
+        if payload is None:
+            return _error_result(
+                run_dir,
+                error="compile worker exited mid-compile "
+                "(workspace code may have exited the process)",
+            )
+        return _finalize_payload(
+            run_dir,
+            payload,
+            stderr="",
+            returncode=0 if payload["status"] == "success" else 1,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -851,6 +851,7 @@ def run_scenario(
     run_id: str = "scenario",
     max_turns: int = 10,
     assert_exhausted: bool = True,
+    on_event: Callable[[events.Event], None] | None = None,
 ) -> RunArtifacts:
     """Run the full agent loop for free and return deep-inspectable artifacts.
 
@@ -860,7 +861,9 @@ def run_scenario(
     ``env`` to choose the compile lane (:class:`WarmEnvironment` for speed)
     or ``tmp_path`` for a plain subprocess ``LocalEnvironment``. By default
     finite harness models must be consumed exactly; pass
-    ``assert_exhausted=False`` for open-ended or live runs.
+    ``assert_exhausted=False`` for open-ended or live runs. Every event also
+    flows to ``on_event`` when given (the artifacts recorder always sees it
+    too).
     """
     if model is None:
         if script is None:
@@ -873,7 +876,13 @@ def run_scenario(
             raise ValueError("run_scenario needs env= or tmp_path=")
         env = LocalEnvironment(output_dir=tmp_path)
     recorder = EventRecorder()
-    agent = Agent(model, env, max_turns=max_turns, on_event=recorder)
+
+    def callback(event: events.Event) -> None:
+        recorder(event)
+        if on_event is not None:
+            on_event(event)
+
+    agent = Agent(model, env, max_turns=max_turns, on_event=callback)
     result = run(agent.run(prompt, run_id=run_id))
     if assert_exhausted:
         check = getattr(model, "assert_exhausted", None)

--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -18,6 +18,7 @@ from harness import (
     ModelQuery,
     ReplayHarness,
     Response,
+    WarmEnvironment,
     calls,
     run_scenario,
     text,
@@ -25,7 +26,6 @@ from harness import (
 )
 
 from mini_articraft.agent.events import AssistantMessage, RunFinished, RunStarted, ToolStarted
-from mini_articraft.environments.local import LocalEnvironment
 
 BROKEN_NO_RUN_TESTS = """
 from build123d import Box
@@ -107,7 +107,7 @@ def event_signal_codes(recorder: EventRecorder) -> list[str]:
 
 
 def test_agent_repairs_a_missing_run_tests_with_real_signals(tmp_path: Path) -> None:
-    env = LocalEnvironment(output_dir=tmp_path)
+    env = WarmEnvironment(output_dir=tmp_path)
 
     def repair(query: ModelQuery) -> Response:
         signals = compile_signals_shown(query.tool_outputs())
@@ -129,12 +129,13 @@ def test_agent_repairs_a_missing_run_tests_with_real_signals(tmp_path: Path) -> 
 
     assert artifacts.record.status == "success"
     assert artifacts.result["message"] == "done"
+    assert env.compile_count == 2
     codes = event_signal_codes(artifacts.recorder)
     assert "COMPILE_MISSING_RUN_TESTS" in codes
 
 
 def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> None:
-    env = LocalEnvironment(output_dir=tmp_path)
+    env = WarmEnvironment(output_dir=tmp_path)
 
     artifacts = run_scenario(
         "a box",
@@ -154,6 +155,7 @@ def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> No
     )
 
     assert artifacts.record.status == "success"
+    assert env.compile_count == 4
     signals = compile_signals_shown(artifacts.tool_outputs())
     assert len(signals) == 4
     assert "matches the previous compile attempt" not in signals[0]
@@ -162,7 +164,7 @@ def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> No
 
 
 def test_overlap_allowance_flows_through_the_real_worker(tmp_path: Path) -> None:
-    env = LocalEnvironment(output_dir=tmp_path)
+    env = WarmEnvironment(output_dir=tmp_path)
 
     def allow_the_overlap(query: ModelQuery) -> Response:
         signals = compile_signals_shown(query.tool_outputs())
@@ -183,6 +185,7 @@ def test_overlap_allowance_flows_through_the_real_worker(tmp_path: Path) -> None
     )
 
     assert artifacts.record.status == "success"
+    assert env.compile_count == 2
     codes = event_signal_codes(artifacts.recorder)
     assert "QC_REAL_OVERLAP" in codes
     assert "NOTE_ALLOWED_OVERLAP" in codes
@@ -194,7 +197,7 @@ def test_event_stream_is_ordered_and_complete(tmp_path: Path) -> None:
     artifacts = run_scenario(
         "a box",
         [write_main(GOOD_MAIN_PY), compile_workspace(), text("done")],
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
 
     stream = artifacts.recorder.events
@@ -222,7 +225,7 @@ def test_hand_authored_cassette_drives_a_real_run(
     artifacts = run_scenario(
         "a box",
         model=replay_harness.replay("authored-box"),
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
 
     assert artifacts.record.status == "success"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -81,6 +82,83 @@ def test_normalized_responses_do_not_mutate_step_dicts() -> None:
     model = ScriptedModel([step])
     run(model.query([]))
     assert step == {"text": "hi", "tool_calls": []}
+
+
+def test_model_query_contains_matches_a_single_message() -> None:
+    query = ModelQuery(
+        turn=1,
+        messages=[
+            {"role": "user", "content": "alpha only"},
+            {"role": "user", "content": "alpha and beta"},
+        ],
+        tools=[],
+    )
+    assert query.contains("alpha")
+    assert query.contains("alpha", "beta")  # both needles in one message
+    assert not query.contains("beta", "gamma")
+    # needles split across messages do not match: containment is per message
+    split = ModelQuery(
+        turn=1,
+        messages=[{"role": "user", "content": "alpha"}, {"role": "user", "content": "beta"}],
+        tools=[],
+    )
+    assert not split.contains("alpha", "beta")
+    with pytest.raises(ValueError, match="at least one needle"):
+        query.contains()
+
+
+def test_model_query_tool_outputs_parses_only_tool_results() -> None:
+    query = ModelQuery(
+        turn=1,
+        messages=[
+            {"role": "assistant", "content": "working"},
+            {"type": "function_call_output", "output": '{"result": {"path": "main.py"}}'},
+        ],
+        tools=[],
+    )
+    assert query.tool_outputs() == [{"result": {"path": "main.py"}}]
+
+
+def test_tool_call_ids_are_unique_and_explicit_ids_win() -> None:
+    first, second = tool_call("read"), tool_call("read")
+    assert first["id"] != second["id"]
+    assert tool_call("read", call_id="chosen")["id"] == "chosen"
+    assert json.loads(tool_call("write", {"path": "a.py"})["arguments"]) == {"path": "a.py"}
+
+
+def test_text_and_calls_carry_optional_fields() -> None:
+    usage = {"input_tokens": 1, "output_tokens": 2}
+    assert text("hi", cost=0.5, token_usage=usage)["cost"] == 0.5
+    response = calls(tool_call("compile"), token_usage=usage)
+    assert response["token_usage"] == usage
+    assert response["tool_calls"][0]["name"] == "compile"
+
+
+def test_non_dict_steps_are_a_clear_type_error() -> None:
+    model = ScriptedModel([["not", "a", "dict"]])  # type: ignore[list-item]
+    with pytest.raises(TypeError, match="model responses must be dicts"):
+        run(model.query([]))
+
+
+def test_async_steps_are_awaited() -> None:
+    async def slow(query: ModelQuery) -> Response:
+        await asyncio.sleep(0)
+        return text("late")
+
+    model = ScriptedModel([slow])
+    assert run(model.query([]))["text"] == "late"
+
+
+def test_model_identity_is_configurable() -> None:
+    model = ScriptedModel(
+        [],
+        model_name="gpt-custom",
+        reasoning_effort="minimal",
+        context_window_tokens=1234,
+    )
+    assert model.config.openai_model == "gpt-custom"
+    assert model.config.openai_reasoning_effort == "minimal"
+    assert model.context_window_tokens == 1234
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -410,6 +410,7 @@ def test_run_scenario_returns_deep_artifacts(tmp_path: Path) -> None:
     assert finished is not None
     assert finished.status == "success"
     assert artifacts.tool_outputs()[0]["result"]["path"] == "main.py"
+    assert isinstance(artifacts.model, ScriptedModel)
     assert artifacts.model.queries[-1].turn == 3
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -10,11 +10,13 @@ from harness import (
     GOOD_MAIN_PY,
     CassetteError,
     CassetteMismatchError,
+    CompileServerError,
     ModelQuery,
     ReplayHarness,
     Response,
     ScriptedModel,
     ScriptExhaustedError,
+    WarmEnvironment,
     calls,
     run,
     run_scenario,
@@ -24,6 +26,7 @@ from harness import (
 
 from mini_articraft.agent.events import TurnStarted
 from mini_articraft.environments.local import LocalEnvironment
+from mini_articraft.record import Record
 
 
 def write_good_main() -> Response:
@@ -78,6 +81,187 @@ def test_normalized_responses_do_not_mutate_step_dicts() -> None:
     model = ScriptedModel([step])
     run(model.query([]))
     assert step == {"text": "hi", "tool_calls": []}
+
+
+# ---------------------------------------------------------------------------
+# WarmEnvironment
+# ---------------------------------------------------------------------------
+
+
+def test_warm_environment_compiles_via_the_shared_worker(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "success"
+    assert payload["returncode"] == 0
+    assert env.compile_count == 1
+    assert Path(payload["usdz"]).is_file()
+    assert payload["compile_report"]["status"] == "success"
+    assert Record.load(run_dir / "record.json").attempts == 1
+
+
+def test_warm_environment_surfaces_failures_with_signals(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("broken")
+    (run_dir / "workspace" / "main.py").write_text(
+        "object_model = 'not a model'\n", encoding="utf-8"
+    )
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert payload["returncode"] == 1
+    report = payload["compile_report"]
+    codes = {signal["code"] for signal in report["signal_bundle"]["signals"]}
+    assert codes == {"COMPILE_RUNTIME_FAILURE"}
+    assert "compile_runtime" in report["signals_text"]
+
+
+def test_warm_environment_requires_main_py(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("empty")
+    (run_dir / "workspace" / "main.py").unlink()
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert "workspace/main.py is required" in payload["error"]
+    assert env.compile_count == 0
+
+
+def test_warm_environment_matches_the_cold_subprocess_contract(tmp_path: Path) -> None:
+    outcomes = {}
+    environments = {
+        "cold": LocalEnvironment(output_dir=tmp_path / "cold"),
+        "warm": WarmEnvironment(output_dir=tmp_path / "warm"),
+    }
+    for lane, env in environments.items():
+        run_dir = env.create_run("box")
+        (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+        payload = env.compile_path(run_dir)
+        outcomes[lane] = (
+            payload["status"],
+            payload["compile_report"]["status"],
+            Path(payload["usdz"]).is_file(),
+        )
+    assert outcomes["cold"] == outcomes["warm"] == ("success", "success", True)
+
+
+HELPER_MAIN = """
+import helper
+
+from build123d import Box
+
+from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+
+print(f"helper says {helper.VALUE}")
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("box")
+    base = model.part("base")
+    base.add(Box(0.2, 0.2, 0.1), name="body")
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    return TestContext(object_model).report()
+"""
+
+
+def _compile_helper_run(env: WarmEnvironment, run_id: str, value: str) -> dict:
+    run_dir = env.create_run(run_id)
+    workspace = run_dir / "workspace"
+    workspace.joinpath("helper.py").write_text(f'VALUE = "{value}"\n', encoding="utf-8")
+    workspace.joinpath("main.py").write_text(HELPER_MAIN, encoding="utf-8")
+    return env.compile_path(run_dir)
+
+
+def test_warm_environment_isolates_workspace_modules_between_runs(tmp_path: Path) -> None:
+    """Two runs may both define helper.py; each compile must see its own."""
+    env = WarmEnvironment(output_dir=tmp_path)
+
+    first = _compile_helper_run(env, "first", "first-run")
+    second = _compile_helper_run(env, "second", "second-run")
+
+    assert first["status"] == second["status"] == "success"
+    assert "helper says first-run" in first["stdout"]
+    assert "helper says second-run" in second["stdout"]
+
+
+def test_warm_environment_survives_workspace_code_that_exits(tmp_path: Path) -> None:
+    """os._exit in workspace code kills the worker, not the test process."""
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("selfish")
+    (run_dir / "workspace" / "main.py").write_text("import os\nos._exit(1)\n", encoding="utf-8")
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert "exited mid-compile" in payload["error"]
+
+    healthy = env.create_run("healthy")
+    (healthy / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    assert env.compile_path(healthy)["status"] == "success"  # a fresh worker took over
+
+
+def test_compile_server_ignores_stale_generation_lines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Lines from a killed worker generation can never pose as the response."""
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    server = env._shared_server()
+    monkeypatch.setattr(server, "_drain_stale_lines", lambda: None)
+    server._lines.put((-1, '{"status": "stale"}'))
+    server._lines.put((-1, None))
+
+    status, payload = server.compile(run_dir, timeout_seconds=30)
+
+    assert status == "ok"
+    assert payload is not None
+    assert payload["status"] == "success"
+
+
+def test_compile_server_rejects_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A protocol violation is an infrastructure error, not a compile result."""
+    env = WarmEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    (run_dir / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    server = env._shared_server()
+    monkeypatch.setattr(server, "_drain_stale_lines", lambda: None)
+    status, _ = server.compile(run_dir, timeout_seconds=30)  # worker at a known generation
+    assert status == "ok"
+    server._lines.put((server._generation, "this is not json"))
+
+    with pytest.raises(CompileServerError, match="invalid JSON"):
+        server.compile(run_dir, timeout_seconds=30)
+
+
+def test_warm_environment_enforces_the_timeout_contract(tmp_path: Path) -> None:
+    env = WarmEnvironment(output_dir=tmp_path, timeout_seconds=0.5)
+    run_dir = env.create_run("slow")
+    (run_dir / "workspace" / "main.py").write_text(
+        "import time\ntime.sleep(30)\n", encoding="utf-8"
+    )
+
+    payload = env.compile_path(run_dir)
+
+    assert payload["status"] == "error"
+    assert "timed out after 0.5s" in payload["error"]
+
+    healthy = env.create_run("healthy")
+    (healthy / "workspace" / "main.py").write_text(GOOD_MAIN_PY, encoding="utf-8")
+    assert env.compile_path(healthy)["status"] == "success"  # a fresh worker took over
 
 
 # ---------------------------------------------------------------------------
@@ -214,7 +398,7 @@ def test_run_scenario_returns_deep_artifacts(tmp_path: Path) -> None:
     artifacts = run_scenario(
         "a box",
         [write_good_main(), calls(tool_call("compile")), text("done")],
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
 
     assert artifacts.record.status == "success"
@@ -238,7 +422,7 @@ def test_reactive_steps_can_assert_on_tool_outputs(tmp_path: Path) -> None:
     artifacts = run_scenario(
         "a box",
         [write_good_main(), check_write, text("done")],
-        env=LocalEnvironment(output_dir=tmp_path),
+        env=WarmEnvironment(output_dir=tmp_path),
     )
     assert artifacts.record.status == "success"
 
@@ -248,7 +432,7 @@ def test_run_scenario_fails_when_the_script_is_not_consumed(tmp_path: Path) -> N
         run_scenario(
             "a box",
             [text("done"), text("extra")],
-            env=LocalEnvironment(output_dir=tmp_path),
+            env=WarmEnvironment(output_dir=tmp_path),
             max_turns=1,
         )
 
@@ -270,14 +454,14 @@ def test_captured_cassette_replays_a_full_scenario(
         captured = run_scenario(
             "a box",
             model=recording,
-            env=LocalEnvironment(output_dir=tmp_path / "a"),
+            env=WarmEnvironment(output_dir=tmp_path / "a"),
         )
     assert captured.record.status == "success"
 
     replayed = run_scenario(
         "a box",
         model=replay_harness.replay("box"),
-        env=LocalEnvironment(output_dir=tmp_path / "b"),
+        env=WarmEnvironment(output_dir=tmp_path / "b"),
     )
     assert replayed.record.status == "success"
     assert replayed.result["message"] == "done"

--- a/tests/test_live_generation.py
+++ b/tests/test_live_generation.py
@@ -1,11 +1,12 @@
 """Live/e2e generation tests backed by the cassette lane.
 
-Default: replay the committed cassettes offline, for free. Re-record them
-with a real model when the trajectory intentionally changes:
+Default: always live (real model). Cassettes are opt-in via flags:
 
-    OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+    uv run pytest tests/test_live_generation.py --replay
+    OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 
-Cassette names default to the test function name.
+Cassette names default to the test function name
+(``cassette_model("latest")`` for an explicit name).
 """
 
 from __future__ import annotations

--- a/tests/test_live_generation.py
+++ b/tests/test_live_generation.py
@@ -1,0 +1,26 @@
+"""Live/e2e generation tests backed by the cassette lane.
+
+Default: replay the committed cassettes offline, for free. Re-record them
+with a real model when the trajectory intentionally changes:
+
+    OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record-cassettes
+
+Cassette names default to the test function name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness import WarmEnvironment, run_scenario
+
+
+def test_box_generation(cassette_model, tmp_path: Path) -> None:
+    with cassette_model() as model:
+        artifacts = run_scenario(
+            "a simple box",
+            model=model,
+            env=WarmEnvironment(output_dir=tmp_path),
+        )
+    assert artifacts.record.status == "success"
+    assert artifacts.record.result.endswith(".usdz")

--- a/tests/test_tape_cli.py
+++ b/tests/test_tape_cli.py
@@ -1,0 +1,93 @@
+"""Tests for the tape CLI (scripts/tape.py)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from harness import GOOD_MAIN_PY, ReplayHarness, calls, text, tool_call
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / "scripts" / "tape.py"
+
+
+def cli(*args: str, root: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI), *args, "--root", str(root)],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.fixture
+def library_root(tmp_path: Path) -> Path:
+    root = tmp_path / "cassettes"
+    library = ReplayHarness(root)
+    library.set(
+        "box",
+        [
+            {"meta": {"prompt": "a simple box"}},
+            calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY})),
+            calls(tool_call("compile")),
+            text("done", cost=0.25),
+        ],
+    )
+    library.set("promptless", [text("hi")])
+    return root
+
+
+def test_list_shows_recordings_and_prompts(library_root: Path, tmp_path: Path) -> None:
+    result = cli("list", root=library_root, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "box: 3 exchange(s)" in result.stdout
+    assert "prompt='a simple box'" in result.stdout
+    assert "promptless: 1 exchange(s)" in result.stdout
+
+
+def test_show_prints_exchanges(library_root: Path, tmp_path: Path) -> None:
+    result = cli("show", "box", root=library_root, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert 'meta: {"prompt": "a simple box"}' in result.stdout
+    assert "tools=['write']" in result.stdout
+    assert "tools=['compile']" in result.stdout
+    assert "text='done'" in result.stdout
+
+
+def test_replay_replays_a_recorded_generation(library_root: Path, tmp_path: Path) -> None:
+    result = cli(
+        "replay", "box", "--output-dir", str(tmp_path / "runs"), root=library_root, cwd=tmp_path
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "turns=3" in result.stdout
+    assert "status=success" in result.stdout
+    assert "cost=$0.2500" in result.stdout
+    run_dirs = list((tmp_path / "runs").glob("tape-box-*"))
+    assert len(run_dirs) == 1
+    assert (run_dirs[0] / "result" / "usdz" / "0000.usdz").is_file()
+
+
+def test_replay_requires_a_prompt_without_metadata(library_root: Path, tmp_path: Path) -> None:
+    result = cli("replay", "promptless", root=library_root, cwd=tmp_path)
+
+    assert result.returncode != 0
+    assert "no recorded prompt" in result.stderr
+
+
+def test_erase_removes_a_recording(library_root: Path, tmp_path: Path) -> None:
+    result = cli("erase", "promptless", root=library_root, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "erased promptless" in result.stdout
+    assert not (library_root / "promptless.jsonl").exists()
+
+    missing = cli("erase", "promptless", root=library_root, cwd=tmp_path)
+    assert missing.returncode != 0
+    assert "unknown tape" in missing.stderr


### PR DESCRIPTION
Replacement for #25 (which merged into its base branch instead of the stack). Behavior-preserving coverage for the harness primitives every other lane builds on: ModelQuery single-message containment and tool-output parsing, tool_call id uniqueness, text/calls passthrough, non-mutating normalization, non-dict and async scripted steps, configurable model identity.

Verified: gates green; full suite passes with --replay.