### PR TITLE
Cover scenario runner options and agent-loop error paths

### DIFF
--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -214,6 +214,33 @@ def test_event_stream_is_ordered_and_complete(tmp_path: Path) -> None:
         assert started < stream.index(finished)
 
 
+def test_agent_hitting_max_turns_is_a_terminal_error(tmp_path: Path) -> None:
+    artifacts = run_scenario(
+        "a box",
+        [write_main(GOOD_MAIN_PY), compile_workspace()],
+        env=WarmEnvironment(output_dir=tmp_path),
+        max_turns=2,
+    )
+
+    assert artifacts.record.status == "error"
+    assert artifacts.record.error == "agent hit max turns limit"
+    finished = artifacts.recorder.finished
+    assert finished is not None
+    assert finished.turns == 2
+
+
+def test_script_exhaustion_surfaces_as_a_model_failure(tmp_path: Path) -> None:
+    artifacts = run_scenario(
+        "a box",
+        [text("no compile happened")],
+        env=WarmEnvironment(output_dir=tmp_path),
+        max_turns=3,
+    )
+
+    assert artifacts.record.status == "error"
+    assert "ScriptExhaustedError" in artifacts.record.error
+
+
 def test_hand_authored_cassette_drives_a_real_run(
     tmp_path: Path, replay_harness: ReplayHarness
 ) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -23,13 +23,16 @@ from harness import (
     ScriptExhaustedError,
     WarmEnvironment,
     calls,
+    compile_success_tool,
     run,
     run_scenario,
+    stub_schema,
     text,
     tool_call,
 )
 
 from mini_articraft.agent.events import TurnStarted
+from mini_articraft.agent.tools import ToolContext
 from mini_articraft.environments.local import LocalEnvironment
 from mini_articraft.record import Record
 
@@ -835,6 +838,66 @@ def test_run_scenario_validates_its_arguments() -> None:
         run_scenario("a box", [text("x")], model=ScriptedModel([text("y")]))
     with pytest.raises(ValueError, match="env= or tmp_path="):
         run_scenario("a box", [text("x")])
+
+
+def test_run_scenario_allows_open_ended_scripts(tmp_path: Path) -> None:
+    artifacts = run_scenario(
+        "a box",
+        [write_good_main(), calls(tool_call("compile")), text("done"), text("unused")],
+        env=WarmEnvironment(output_dir=tmp_path),
+        assert_exhausted=False,
+    )
+    assert artifacts.record.status == "success"
+    assert isinstance(artifacts.model, ScriptedModel)
+    assert len(artifacts.model.queries) == 3
+
+
+def test_run_scenario_honors_run_id(tmp_path: Path) -> None:
+    artifacts = run_scenario(
+        "a box",
+        [write_good_main(), calls(tool_call("compile")), text("done")],
+        env=WarmEnvironment(output_dir=tmp_path),
+        run_id="custom-run",
+    )
+    assert artifacts.run_dir.name == "custom-run"
+    assert artifacts.record.run_id == "custom-run"
+
+
+def test_replay_leftovers_fail_the_scenario(tmp_path: Path, replay_harness: ReplayHarness) -> None:
+    replay_harness.set(
+        "long",
+        [write_good_main(), calls(tool_call("compile")), text("done"), text("unused")],
+    )
+    with pytest.raises(AssertionError, match="cassette row"):
+        run_scenario(
+            "a box",
+            model=replay_harness.replay("long"),
+            env=WarmEnvironment(output_dir=tmp_path),
+        )
+
+
+def test_compile_success_tool_mints_a_usdz_and_marks_freshness(tmp_path: Path) -> None:
+    env = LocalEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("box")
+    context = ToolContext(env, run_dir, run_dir / "workspace")
+
+    result = run(compile_success_tool().run(context, {}))
+
+    assert result["status"] == "success"
+    assert Path(result["usdz"]).is_file()
+    assert context.refresh_compile_freshness()
+
+
+def test_stub_schema_has_the_function_wire_shape() -> None:
+    schema = stub_schema("compile")
+    assert schema["type"] == "function"
+    assert schema["name"] == "compile"
+    assert schema["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
 
 
 def test_captured_cassette_replays_a_full_scenario(


### PR DESCRIPTION
Replacement for #28. Behavior-preserving tests: run_scenario allows open-ended scripts, honors run_id, surfaces leftover cassette rows; compile_success_tool mints a USDZ and marks freshness; stub_schema has the wire shape; the agent loop records terminal errors on max turns and surfaces script exhaustion as a model failure.

Verified: gates green; full suite passes with --replay (287 passed).