### PR TITLE
Deepen signal-pipeline and agent-loop coverage

### DIFF
--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -163,6 +163,56 @@ def test_repeat_failure_guidance_escalates_across_compiles(tmp_path: Path) -> No
     assert "compile failure 3 in a row" in signals[2]
 
 
+def test_a_cached_success_does_not_recompile(tmp_path: Path) -> None:
+    """Reads and no-op inspections keep a fresh compile: no second worker call."""
+    env = WarmEnvironment(output_dir=tmp_path)
+
+    artifacts = run_scenario(
+        "a box",
+        [
+            write_main(GOOD_MAIN_PY),
+            compile_workspace(),
+            calls(tool_call("read", {"path": "main.py"})),
+            text("done"),
+        ],
+        env=env,
+        max_turns=4,
+    )
+
+    assert artifacts.record.status == "success"
+    assert env.compile_count == 1
+
+
+def test_failure_streak_resets_after_a_successful_compile(tmp_path: Path) -> None:
+    """A success clears the streak: the next failure is not flagged as repeated."""
+    env = WarmEnvironment(output_dir=tmp_path)
+
+    artifacts = run_scenario(
+        "a box",
+        [
+            write_main(BROKEN_NO_RUN_TESTS),
+            compile_workspace(),
+            write_main(GOOD_MAIN_PY),
+            compile_workspace(),
+            write_main(BROKEN_NO_RUN_TESTS),
+            compile_workspace(),
+            write_main(GOOD_MAIN_PY),
+            compile_workspace(),
+            text("done"),
+        ],
+        env=env,
+        max_turns=9,
+    )
+
+    assert artifacts.record.status == "success"
+    # the final write restores the exact content of the earlier successful
+    # compile, so the freshness cache serves it without a worker call
+    assert env.compile_count == 3
+    signals = compile_signals_shown(artifacts.tool_outputs())
+    assert "matches the previous compile attempt" not in signals[0]
+    assert "matches the previous compile attempt" not in signals[2]
+
+
 def test_overlap_allowance_flows_through_the_real_worker(tmp_path: Path) -> None:
     env = WarmEnvironment(output_dir=tmp_path)
 

--- a/tests/test_compile_feedback.py
+++ b/tests/test_compile_feedback.py
@@ -8,6 +8,16 @@ from mini_articraft.compile_feedback import (
 from mini_articraft.sdk import TestFailure, TestReport
 
 
+def _failing_report(*failures: TestFailure, warnings: tuple[str, ...] = ()) -> TestReport:
+    return TestReport(
+        passed=False,
+        checks_run=len(failures),
+        checks=tuple(failure.name for failure in failures),
+        failures=failures,
+        warnings=warnings,
+    )
+
+
 def test_compile_report_clean_success_uses_articraft_style_block() -> None:
     report = build_compile_report(status="success")
 
@@ -201,3 +211,127 @@ def test_compile_failure_signature_and_rendering_are_stable() -> None:
     assert "This failure matches the previous compile attempt." in rendered
     assert "This is compile failure 3 in a row." in rendered
     assert "`exec_command` inspection" in rendered
+
+
+def test_contact_gap_is_classified_as_a_gap_not_an_overlap() -> None:
+    report = build_compile_report(
+        status="failure",
+        test_report=_failing_report(
+            TestFailure(
+                name="expect_contact(base,lid)",
+                details="pair=('base','lid') distance=0.0032 collided=False contact_tol=0.001",
+            )
+        ),
+    )
+
+    signal = report["signal_bundle"]["signals"][0]
+    assert signal["kind"] == "exact_contact_gap"
+    assert signal["code"] == "TEST_EXACT_CONTACT_GAP"
+    assert signal["source"] == "tests"
+    assert "a gap, not an overlap" in report["signals_text"]
+
+
+def test_compiler_owned_checks_keep_their_codes_and_sources() -> None:
+    report = build_compile_report(
+        status="failure",
+        test_report=_failing_report(
+            TestFailure(name="check_model_valid", details="ValidationError: bad shape"),
+            TestFailure(
+                name="check_single_root_part",
+                details="Expected exactly one root part, found 2: ['a', 'b']",
+            ),
+            TestFailure(name="fail_if_isolated_parts()", details="Isolated parts detected"),
+            TestFailure(
+                name="fail_if_parts_overlap_in_current_pose()",
+                details="Part overlaps detected",
+            ),
+        ),
+    )
+
+    by_name = {s["check_name"]: s for s in report["signal_bundle"]["signals"]}
+    assert by_name["check_model_valid"]["code"] == "QC_MODEL_VALIDITY"
+    assert by_name["check_model_valid"]["source"] == "compiler"
+    assert by_name["check_single_root_part"]["code"] == "QC_SINGLE_ROOT_POLICY"
+    assert by_name["check_single_root_part"]["group"] == "build"
+    assert by_name["fail_if_isolated_parts()"]["code"] == "QC_ISOLATED_PART"
+    assert by_name["fail_if_isolated_parts()"]["source"] == "compiler"
+    assert by_name["fail_if_parts_overlap_in_current_pose()"]["code"] == "QC_REAL_OVERLAP"
+
+
+def test_authored_checks_with_the_same_findings_map_to_test_codes() -> None:
+    report = build_compile_report(
+        status="failure",
+        test_report=_failing_report(
+            TestFailure(
+                name="fail_if_isolated_parts(tight)",
+                details="isolated parts detected: ['antenna']",
+            ),
+            TestFailure(
+                name="expect_no_collision(base,lid)",
+                details="pair=('base','lid') collided=true overlap_volume=1e-6",
+            ),
+        ),
+    )
+
+    kinds = {signal["kind"]: signal for signal in report["signal_bundle"]["signals"]}
+    assert kinds["isolated_part"]["code"] == "TEST_ISOLATED_PART"
+    assert kinds["isolated_part"]["source"] == "tests"
+    assert kinds["real_overlap"]["code"] == "TEST_REAL_OVERLAP"
+    assert kinds["real_overlap"]["source"] == "tests"
+
+
+def test_invalid_run_tests_return_type_is_a_build_signal() -> None:
+    report = build_compile_report(
+        status="failure",
+        error="ValueError: run_tests() must return TestReport (got dict)",
+    )
+
+    signal = report["signal_bundle"]["signals"][0]
+    assert signal["kind"] == "invalid_run_tests_report"
+    assert signal["code"] == "COMPILE_INVALID_RUN_TESTS_REPORT"
+    assert signal["group"] == "build"
+
+
+def test_repeat_and_streak_guidance_escalates() -> None:
+    report = build_compile_report(
+        status="failure",
+        test_report=_failing_report(TestFailure(name="expect_contact(a,b)", details="d")),
+    )
+
+    rendered = render_compile_report(report, repeated=True, failure_streak=3)
+
+    assert "This failure matches the previous compile attempt." in rendered["signals_text"]
+    assert "This is compile failure 3 in a row." in rendered["signals_text"]
+    assert "exec_command" in rendered["signals_text"]
+
+
+def test_failure_signature_ignores_warning_only_reports() -> None:
+    report = build_compile_report(
+        status="success",
+        test_report=TestReport(
+            passed=True,
+            checks_run=1,
+            checks=("check_model_valid",),
+            failures=(),
+            warnings=("Scale warning: geometry outlier dimensions",),
+        ),
+    )
+
+    assert compile_failure_signature(report) is None
+    codes = {signal["code"] for signal in report["signal_bundle"]["signals"]}
+    assert codes == {"WARN_GEOMETRY_SCALE"}
+
+
+def test_traceback_location_prefers_the_last_workspace_frame() -> None:
+    report = build_compile_report(
+        status="failure",
+        error="ValueError: boom",
+        traceback_text=(
+            '  File "/opt/venv/lib/python3.11/site-packages/build123d/x.py", line 1, in f\n'
+            '  File "/private/runs/demo/workspace/main.py", line 9, in build\n'
+            '  File "/private/runs/demo/workspace/parts/lid.py", line 42, in hinge\n'
+        ),
+    )
+
+    signal = report["signal_bundle"]["signals"][0]
+    assert signal["details"] == "location=parts/lid.py:42 in hinge"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -235,6 +235,30 @@ def test_warm_environment_matches_the_cold_subprocess_contract(tmp_path: Path) -
     assert outcomes["cold"] == outcomes["warm"] == ("success", "success", True)
 
 
+def test_cold_and_warm_lanes_fail_identically(tmp_path: Path) -> None:
+    """Failure payloads also match across lanes: status, signals, and codes."""
+    outcomes = {}
+    environments = {
+        "cold": LocalEnvironment(output_dir=tmp_path / "cold"),
+        "warm": WarmEnvironment(output_dir=tmp_path / "warm"),
+    }
+    for lane, env in environments.items():
+        run_dir = env.create_run("broken")
+        (run_dir / "workspace" / "main.py").write_text(
+            "object_model = 'not a model'\n", encoding="utf-8"
+        )
+        payload = env.compile_path(run_dir)
+        bundle = payload["compile_report"]["signal_bundle"]
+        outcomes[lane] = (
+            payload["status"],
+            payload["compile_report"]["status"],
+            tuple(signal["code"] for signal in bundle["signals"]),
+        )
+    assert outcomes["cold"] == outcomes["warm"]
+    assert outcomes["cold"][0] == "error"
+    assert outcomes["cold"][2] == ("COMPILE_RUNTIME_FAILURE",)
+
+
 HELPER_MAIN = """
 import helper
 


### PR DESCRIPTION
Deepen signal-pipeline and agent-loop coverage

Signal pipeline (compile_feedback): exact-contact-gap vs overlap kinds,
compiler-owned codes and sources, authored-check mappings, invalid
run_tests_report, repeat/streak escalation, signature ignoring
warning-only reports, and last-workspace-frame traceback locations.

Agent loop (scenarios): a cached success never recompiles (compile_count
stays 1), the failure streak resets after a successful compile, and
cold/warm lanes fail with identical payloads and signal codes.
