### PR TITLE
Add two canonical examples and use them as compile probes

### DIFF
--- a/examples/hinged_box/main.py
+++ b/examples/hinged_box/main.py
@@ -1,0 +1,70 @@
+"""Canonical articulated example: a box whose lid opens on a real hinge.
+
+Two parts, one REVOLUTE articulation, and an authored contact check. The
+hinge axis sits exactly on the edge where the lid meets the base, so the
+parts stay in contact through the whole motion range -- the property the
+compiler's articulation-separation check verifies.
+
+Compile it:  python -m mini_articraft.environments.worker <run_dir>
+"""
+
+from __future__ import annotations
+
+from build123d import Box
+
+from mini_articraft.sdk import (
+    ArticulatedObject,
+    ArticulationType,
+    MotionLimits,
+    Origin,
+    TestContext,
+    TestReport,
+)
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("hinged_box")
+
+    base = model.part("base")
+    base.add(Box(0.10, 0.08, 0.04), name="body", color=(0.24, 0.25, 0.28))
+
+    lid = model.part("lid")
+    lid.add(
+        # Part geometry is authored in the part's LOCAL frame; the hinge
+        # origin (0, -0.04, 0.02) maps it into the parent. Local (0, 0.04,
+        # 0.007) therefore lands the lid at world (0, 0, 0.027): its knuckle
+        # edge sits 0.5 mm into the base, a small designed embed that keeps
+        # the parts physically connected (declared below with allow_overlap).
+        Box(0.10, 0.08, 0.015).translate((0.0, 0.04, 0.007)),
+        name="body",
+        color=(0.62, 0.45, 0.16, 1.0),
+    )
+
+    model.articulation(
+        "lid_hinge",
+        ArticulationType.REVOLUTE,
+        base,
+        lid,
+        # The hinge line is the lid/base contact edge: rotating around it
+        # keeps the parts touching instead of pulling the lid off the box.
+        origin=Origin(xyz=(0.0, -0.04, 0.02)),
+        axis=(1.0, 0.0, 0.0),
+        motion_limits=MotionLimits(lower=0.0, upper=1.5708),
+    )
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    ctx = TestContext(object_model)
+    ctx.allow_overlap(
+        "base",
+        "lid",
+        reason="hinge knuckle embedded in the base",
+        shape_a="body",
+        shape_b="body",
+    )
+    ctx.expect_contact("base", "lid")
+    return ctx.report()

--- a/examples/mesh_knob/main.py
+++ b/examples/mesh_knob/main.py
@@ -1,0 +1,55 @@
+"""Canonical procedural-mesh example: a lathe-turned knob, single part.
+
+One MeshGeometry, built from a closed (radius, z) silhouette, with an
+authored custom check that the result is watertight -- the property that
+makes it safe for booleans, export, and printing.
+
+Compile it:  python -m mini_articraft.environments.worker <run_dir>
+"""
+
+from __future__ import annotations
+
+from mini_articraft.sdk import (
+    ArticulatedObject,
+    LatheGeometry,
+    TestContext,
+    TestReport,
+    boolean_union,
+)
+
+PROFILE = [
+    (0.000, 0.000),
+    (0.016, 0.000),
+    (0.020, 0.006),
+    (0.020, 0.014),
+    (0.016, 0.020),
+    (0.000, 0.020),
+]
+
+RIDGE_PROFILE = [
+    (0.000, 0.006),
+    (0.022, 0.006),
+    (0.024, 0.008),
+    (0.022, 0.010),
+    (0.000, 0.010),
+]
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("knob")
+    knob = model.part("knob")
+
+    body = LatheGeometry(PROFILE)
+    ridge = LatheGeometry(RIDGE_PROFILE)
+    knob.add(boolean_union(body, ridge), name="body", color=(0.16, 0.34, 0.55, 1.0))
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    ctx = TestContext(object_model)
+    body = object_model.get_part("knob").get_shape("body")
+    ctx.check("body_is_watertight", body.is_watertight, "the union must stay watertight")
+    return ctx.report()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,42 @@
+"""The canonical examples compile cleanly and ship a USDZ.
+
+These pin the intended public SDK path end to end (object model, authored
+tests, baseline physical checks, export) and double as the compile
+performance probe: watch them with ``--durations`` to spot compile-time
+regressions before they reach the agent loop.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from harness import WarmEnvironment
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+EXAMPLES = ("hinged_box", "mesh_knob")
+
+
+def compile_example(env: WarmEnvironment, name: str) -> tuple[dict[str, Any], float]:
+    run_dir = env.create_run(name)
+    shutil.copy(EXAMPLES_DIR / name / "main.py", run_dir / "workspace" / "main.py")
+    started = time.perf_counter()
+    payload = env.compile_path(run_dir)
+    return payload, time.perf_counter() - started
+
+
+@pytest.mark.parametrize("name", EXAMPLES)
+def test_example_compiles_cleanly(tmp_path: Path, name: str) -> None:
+    env = WarmEnvironment(output_dir=tmp_path)
+
+    payload, duration = compile_example(env, name)
+
+    assert payload["status"] == "success", payload["compile_report"]["signals_text"]
+    assert Path(payload["usdz"]).is_file()
+    counts = payload["compile_report"]["counts"]
+    assert counts["failures"] == 0, payload["compile_report"]["signals_text"]
+    assert counts["warnings"] == 0, payload["compile_report"]["signals_text"]
+    print(f"\n{name} compiled in {duration:.2f}s")


### PR DESCRIPTION
Add two canonical examples and use them as compile probes

examples/hinged_box: two parts, one revolute hinge, an authored contact
check, and a declared 0.5 mm knuckle embed -- the canonical articulation
pattern, including why part geometry is authored in the local frame and
when allow_overlap is the right tool.

examples/mesh_knob: one procedural lathe mesh with a boolean ridge and an
authored watertight check -- the canonical single-part mesh pattern.

tests/test_examples.py compiles both through the real worker on the warm
lane, asserting a clean compile and a USDZ. They double as the compile
performance probe: run with --durations to catch compile-time regressions.
