### PR TITLE
Close the record/replay loop in CI and prove the distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  actions: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -51,6 +53,70 @@ jobs:
       - name: Type check
         run: uv run --frozen basedpyright
 
+      - name: Download latest recorded cassettes (best effort)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=$(gh run list --workflow record-cassettes.yml --status success \
+            --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          if [ -n "$run_id" ]; then
+            mkdir -p /tmp/ci-cassettes
+            gh run download "$run_id" --name cassettes --dir /tmp/ci-cassettes || true
+            cp /tmp/ci-cassettes/*.jsonl tests/cassettes/ 2>/dev/null || true
+          fi
+
       - name: Test
         # --replay: cassette-backed tests stay offline (live is the local default)
         run: uv run --frozen pytest -q --replay
+
+  dist:
+    name: dist (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.17"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check distributions
+        run: uvx twine check dist/*
+
+      - name: Smoke-test the wheel in a clean environment
+        run: |
+          uv venv /tmp/smoke
+          uv pip install --python /tmp/smoke/bin/python dist/*.whl
+          /tmp/smoke/bin/python -c "
+          import mini_articraft
+          from mini_articraft import package_dir
+          from mini_articraft.sdk import ArticulatedObject, TestContext
+          assert (package_dir / 'prompts' / 'system.md').is_file()
+          assert (package_dir / 'viewer.html').is_file()
+          assert (package_dir / 'sdk' / 'docs' / 'common' / '00_quickstart.md').is_file()
+          "
+          mkdir -p /tmp/smoke-run/workspace /tmp/smoke-run/result
+          cp examples/mesh_knob/main.py /tmp/smoke-run/workspace/main.py
+          /tmp/smoke/bin/python -m mini_articraft.environments.worker /tmp/smoke-run > /tmp/smoke-out.json
+          /tmp/smoke/bin/python -c "
+          import json
+          payload = json.load(open('/tmp/smoke-out.json'))
+          assert payload['status'] == 'success', payload
+          "

--- a/.github/workflows/record-cassettes.yml
+++ b/.github/workflows/record-cassettes.yml
@@ -1,0 +1,57 @@
+name: record-cassettes
+
+# Records the live generation tests into cassettes and uploads them as the
+# `cassettes` artifact. The main CI workflow downloads the latest artifact
+# and replays it offline, so replay coverage tracks the real model without
+# paying on every PR. Run by hand any time; also weekly.
+# Requires the OPENAI_API_KEY repository secret.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: record-cassettes
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: record
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.17"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --group dev --frozen
+
+      - name: Record live generations into cassettes
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: uv run --frozen pytest tests/test_live_generation.py --record -q
+
+      - name: Upload cassettes
+        uses: actions/upload-artifact@v4
+        with:
+          name: cassettes
+          path: tests/cassettes/*.jsonl
+          retention-days: 30
+          if-no-files-found: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,16 @@ description = "A small reference agent for generating articulated build123d obje
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
-authors = [{ name = "mini-articraft contributors" }]
+authors = [{ name = "Matthew Zhou" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+keywords = ["build123d", "agent", "cad", "articulation", "usd"]
 dependencies = [
     "build123d>=0.11.0",
     "gpytoolbox>=0.3.7,<0.4",
@@ -28,6 +37,10 @@ dependencies = [
     "usd-core>=26.5",
     "websockets>=15.0.0",
 ]
+
+[project.urls]
+Repository = "https://github.com/mattzh72/mini-articraft"
+Issues = "https://github.com/mattzh72/mini-articraft/issues"
 
 [dependency-groups]
 dev = [

--- a/tests/README.md
+++ b/tests/README.md
@@ -116,6 +116,22 @@ uv run python scripts/tape.py erase box
 replays against. `--root` points at another library (the default is
 `tests/cassettes/`).
 
+## CI: record once, replay everywhere
+
+Two workflows close the loop:
+
+- `record-cassettes.yml` (weekly + `workflow_dispatch`, needs the
+  `OPENAI_API_KEY` secret) runs the live generation tests with `--record`
+  and uploads `tests/cassettes/` as the `cassettes` artifact.
+- `ci.yml` downloads the latest `cassettes` artifact before running
+  `pytest --replay`, so replay coverage tracks the real model for free;
+  with no artifact present it falls back to the committed cassettes.
+
+The `dist` job also builds the sdist/wheel on 3.11 and 3.12, runs
+`twine check`, installs the wheel into a clean venv, and smoke-tests the
+compile worker against `examples/mesh_knob` -- the distribution, not just
+the checkout.
+
 ## Known platform flakes
 
 On macOS, a few exec-output timing tests can fail with empty captured output


### PR DESCRIPTION
Close the record/replay loop in CI and prove the distribution

record-cassettes.yml (weekly + manual, OPENAI_API_KEY secret) records the
live generation tests and uploads the cassettes artifact; ci.yml downloads
the latest artifact before pytest --replay, so replay coverage tracks the
real model for free (committed cassettes remain the fallback).

The new dist job builds sdist+wheel on 3.11 and 3.12, runs twine check,
installs the wheel into a clean venv, verifies packaged assets, and runs
the compile worker against examples/mesh_knob -- testing the distribution,
not only the checkout. pyproject gains urls, classifiers, and keywords.
