### PR TITLE
Fix CI workflow: dedupe the permissions block, guard against repeats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 permissions:
   contents: read
   actions: read
-  actions: read
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -2,19 +2,55 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
+
+import yaml
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """A SafeLoader that rejects duplicate mapping keys."""
+
+
+def _reject_duplicate_keys(loader: yaml.Loader, node: yaml.MappingNode) -> dict:
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=True)
+        if key in mapping:
+            raise yaml.YAMLError(f"duplicate key {key!r} at line {key_node.start_mark.line + 1}")
+        mapping[key] = loader.construct_object(value_node, deep=True)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _reject_duplicate_keys,
+)
 
 
 def main() -> int:
+    workflow_errors = _check_workflows()
+    for error in workflow_errors:
+        print(error)
+
     tracked_files = _tracked_files()
     violations = [path for path in tracked_files if _is_forbidden(path)]
-    if not violations:
+    if not violations and not workflow_errors:
         return 0
 
-    print("Tracked generated, local, or build files are not allowed:")
     for path in violations:
         print(f"  {path}")
     return 1
+
+
+def _check_workflows() -> list[str]:
+    errors: list[str] = []
+    for path in sorted(Path(".github/workflows").glob("*.yml")):
+        try:
+            with path.open(encoding="utf-8") as file:
+                yaml.load(file, Loader=_UniqueKeyLoader)
+        except yaml.YAMLError as exc:
+            errors.append(f"invalid workflow file {path}: {exc}")
+    return errors
 
 
 def _tracked_files() -> list[str]:


### PR DESCRIPTION
A duplicate actions:read key in ci.yml made GitHub reject the whole workflow file, so no jobs ran on main. Removes the duplicate and teaches check_repo_hygiene.py to reject duplicate YAML keys in workflow files with a clear message, so this fails loudly in a PR instead of silently breaking main.