### PR TITLE
Detect tangent contact: touching is not fusion

### DIFF
--- a/src/mini_articraft/agent/tools/_core.py
+++ b/src/mini_articraft/agent/tools/_core.py
@@ -176,6 +176,10 @@ def _ignore_workspace_path(path: Path, *, is_directory: bool, is_symlink: bool) 
     name = path.name
     if path.parts[0] == "docs":
         return True
+    if path.parts == ("junctions.md",):
+        # Compiler output, not authored content: writing it must not mark the
+        # workspace as changed since the last successful compile.
+        return True
     if (is_directory or is_symlink) and (
         name in IGNORED_WORKSPACE_DIRECTORIES or name.endswith((".egg-info", ".dist-info"))
     ):

--- a/src/mini_articraft/compile_feedback.py
+++ b/src/mini_articraft/compile_feedback.py
@@ -75,6 +75,7 @@ def build_compile_report_from_payload(payload: dict[str, Any]) -> dict[str, Any]
         stderr=str(payload.get("stderr") or ""),
         returncode=payload.get("returncode"),
         test_report=payload.get("test_report"),
+        junction_count=int(payload.get("junction_count") or 0),
     )
 
 
@@ -87,6 +88,7 @@ def build_compile_report(
     stderr: str = "",
     returncode: object = None,
     test_report: object = None,
+    junction_count: int = 0,
 ) -> dict[str, Any]:
     report = _report_dict(test_report)
     bundle = _bundle(status, error, report, traceback_text=traceback_text)
@@ -100,7 +102,8 @@ def build_compile_report(
         "counts": _counts(bundle.signals),
         "test_report": report,
         "signal_bundle": asdict(bundle),
-        "signals_text": render_compile_signals(bundle),
+        "junction_count": junction_count,
+        "signals_text": render_compile_signals(bundle, junction_count=junction_count),
     }
 
 
@@ -115,6 +118,7 @@ def render_compile_report(
         _bundle_from_dict(report["signal_bundle"]),
         repeated=repeated,
         failure_streak=failure_streak,
+        junction_count=int(report.get("junction_count") or 0),
     )
     return rendered
 
@@ -142,6 +146,7 @@ def render_compile_signals(
     *,
     repeated: bool = False,
     failure_streak: int = 0,
+    junction_count: int = 0,
 ) -> str:
     failures = _failures(bundle.signals)
     warnings = _ordered_signals(bundle.signals, "warning")
@@ -162,6 +167,7 @@ def render_compile_signals(
         has_warnings=bool(warnings),
         repeated=repeated,
         failure_streak=failure_streak,
+        junction_count=junction_count,
     )
     if rules:
         parts += [
@@ -522,21 +528,29 @@ def _primary_issue(signal: CompileSignal) -> str:
     return issues.get(signal.kind, signal.summary)
 
 
+_JUNCTION_RULE = (
+    "- This compile wrote `junctions.md`: every attachment junction with the pair's "
+    "shared overlap volume, flagging TANGENT CONTACT -- pieces that touch at a point, "
+    "line, or bare surface with no real overlap, instead of being embedded past the "
+    "surface and welded. Read it and fix or justify every flag before concluding."
+)
+
+
 def _rules(
     failures: list[CompileSignal],
     *,
     has_warnings: bool,
     repeated: bool,
     failure_streak: int,
+    junction_count: int = 0,
 ) -> list[str]:
     if not failures:
-        return (
-            [
+        rules = [_JUNCTION_RULE] if junction_count else []
+        if has_warnings:
+            rules.append(
                 "- Warnings are design evidence. Do not remove or simplify prompt-critical geometry just to clear them."
-            ]
-            if has_warnings
-            else []
-        )
+            )
+        return rules
     kind = failures[0].kind
     if kind in {"compile_runtime", "missing_run_tests", "invalid_run_tests_report"}:
         rules = [

--- a/src/mini_articraft/environments/worker.py
+++ b/src/mini_articraft/environments/worker.py
@@ -14,6 +14,7 @@ from typing import Any, TypeVar, cast
 
 from mini_articraft.compile_feedback import build_compile_report_from_payload, empty_compile_payload
 from mini_articraft.environments.export import export_object
+from mini_articraft.junction_report import write_junction_report
 from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
 
 T = TypeVar("T", bound=Hashable)
@@ -56,6 +57,9 @@ def _compile_workspace(workspace: Path, export_dir: Path) -> dict[str, Any]:
                     "usdz": str(result.usdz),
                 }
             )
+            with contextlib.suppress(Exception):
+                # Best-effort: a failed junction report must not fail the compile.
+                payload["junction_count"] = write_junction_report(object_model, workspace)
 
         payload.update(
             {

--- a/src/mini_articraft/junction_report.py
+++ b/src/mini_articraft/junction_report.py
@@ -1,0 +1,90 @@
+"""Write a junction report: every attachment junction, measured for tangent contact.
+
+An overall impression hides bad joints -- a partially attached handle, a floating
+hinge block. After a successful compile this module lists every pair of touching (or
+nearly touching) shapes with their shared overlap volume, and flags TANGENT CONTACT:
+pieces that touch at a point, line, or bare surface (near-zero overlap volume)
+instead of being embedded past the surface and welded. Touching is not fusion --
+fused pieces share material, so their volumes must overlap.
+
+Pairs that span an articulation's parent/child interface are listed but never
+flagged: a hinge barrel in its sleeve needs running clearance -- tangency there is
+the mechanism, not a defect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mini_articraft.sdk import ArticulatedObject
+from mini_articraft.sdk._collision import (
+    MeshCollisionKernel,
+    _distance_entries,
+    _mesh_intersection_volume,
+)
+
+JUNCTION_FILE = "junctions.md"
+_JUNCTION_GAP_TOL = 0.002  # a pair this close is an attachment junction
+_MAX_LISTED = 40
+# Fused pieces share material: overlap below this volume is tangency, not fusion.
+# 20 mm^3 is a ~2.7 mm cube -- far below any deliberate embed, far above the
+# sliver overlaps that mesh tessellation produces at grazing contact.
+_FUSION_VOLUME = 2.0e-8  # m^3
+
+
+def write_junction_report(model: ArticulatedObject, workspace: Path) -> int:
+    """Write ``junctions.md`` into the workspace; return the junction count."""
+    kernel = MeshCollisionKernel(model, mesh_tolerance=0.0012)
+    entries = kernel._all_entries({})
+    junctions: list[tuple[float, str, str, str, bool]] = []
+    for index, entry_a in enumerate(entries):
+        for entry_b in entries[index + 1 :]:
+            query = _distance_entries(entry_a, entry_b, max_contacts=4)
+            if query.distance > _JUNCTION_GAP_TOL:
+                continue
+            name_a = f"{entry_a.part_name}/{entry_a.shape_name}"
+            name_b = f"{entry_b.part_name}/{entry_b.shape_name}"
+            overlap, tangent = _overlap(entry_a, entry_b)
+            junctions.append((query.distance, name_a, name_b, overlap, tangent))
+
+    junctions.sort(key=lambda item: item[0])
+    # Pairs spanning an articulation are kinematic interfaces with intended clearance.
+    kinematic_pairs = {
+        frozenset((articulation.parent, articulation.child))
+        for articulation in getattr(model, "articulations", [])
+    }
+    flags = [
+        f"- TANGENT CONTACT: {name_a} <-> {name_b} ({overlap}) -- it touches at a point, "
+        "line, or bare surface, which is touching, not fusion. Embed the piece past the "
+        "surface so the volumes overlap, then weld; the bead fills the seam"
+        for _, name_a, name_b, overlap, tangent in junctions
+        if tangent
+        and frozenset((name_a.split("/")[0], name_b.split("/")[0])) not in kinematic_pairs
+    ]
+    lines = [
+        "# Junction report (rest pose)",
+        "",
+        f"{len(junctions)} junctions. A whole-object impression hides bad joints -- check",
+        "each junction below, and fix or justify every flag, before you conclude the",
+        "object is done:",
+        "",
+    ]
+    if flags:
+        lines += ["## Flags (fix or justify these)", "", *flags, ""]
+    for distance, name_a, name_b, overlap, _ in junctions[:_MAX_LISTED]:
+        contact = overlap if distance <= 0.0 else f"gap {distance * 1000:.1f}mm"
+        lines.append(f"- {name_a} <-> {name_b} ({contact})")
+    if len(junctions) > _MAX_LISTED:
+        lines.append(f"- ... {len(junctions) - _MAX_LISTED} more omitted (closest listed first)")
+    (workspace / JUNCTION_FILE).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return len(junctions)
+
+
+def _overlap(entry_a, entry_b) -> tuple[str, bool]:
+    """The pair's shared overlap volume, and whether it is tangency (no real overlap)."""
+    volume = _mesh_intersection_volume(entry_a.world_mesh, entry_b.world_mesh)
+    if volume is None:
+        return "contact", False  # non-watertight mesh: cannot judge, fail open
+    if volume < _FUSION_VOLUME:
+        return f"overlap {volume * 1e9:.0f}mm3 -- effectively none", True
+    return f"overlap {volume * 1e9:.0f}mm3", False

--- a/tests/test_junction_report.py
+++ b/tests/test_junction_report.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mini_articraft.agent.tools._core import workspace_digest
+from mini_articraft.junction_report import write_junction_report
+from mini_articraft.sdk import ArticulatedObject, BoxGeometry
+
+
+def _model() -> ArticulatedObject:
+    model = ArticulatedObject("t")
+    body = model.part("body")
+    body.add(BoxGeometry((0.10, 0.10, 0.10)), name="cube", color=(0.5, 0.5, 0.6))
+    # Touching neighbour: one junction. Far shape: no junction.
+    body.add(BoxGeometry((0.04, 0.04, 0.04)).translate(0.07, 0.0, 0.0), name="nub")
+    body.add(BoxGeometry((0.02, 0.02, 0.02)).translate(0.5, 0.0, 0.0), name="far")
+    return model
+
+
+def test_write_junction_report_lists_touching_pairs(tmp_path: Path) -> None:
+    count = write_junction_report(_model(), tmp_path)
+    text = (tmp_path / "junctions.md").read_text(encoding="utf-8")
+    assert count == 1
+    assert "body/cube <-> body/nub" in text
+    assert "far" not in text  # 0.4m away: not a junction
+
+
+def test_kinematic_interfaces_are_not_flagged_as_tangent_contact(tmp_path: Path) -> None:
+    from mini_articraft.sdk import ArticulationType, CylinderGeometry, MotionLimits, Origin
+
+    model = ArticulatedObject("t")
+    body = model.part("body")
+    body.add(BoxGeometry((0.10, 0.10, 0.02)), name="plate", color=(0.5, 0.5, 0.6))
+    lid = model.part("lid")
+    # A barrel resting tangent on the plate: grazing, but across an articulation.
+    # (Child geometry is authored relative to the joint origin.)
+    lid.add(CylinderGeometry(0.01, 0.06).rotate_y(1.5708), name="barrel")
+    model.articulation(
+        "hinge",
+        ArticulationType.REVOLUTE,
+        body,
+        lid,
+        origin=Origin(xyz=(0.0, 0.0, 0.02)),
+        axis=(1.0, 0.0, 0.0),
+        motion_limits=MotionLimits(effort=1.0, velocity=1.0, lower=0.0, upper=1.0),
+    )
+    write_junction_report(model, tmp_path)
+    text = (tmp_path / "junctions.md").read_text(encoding="utf-8")
+    assert "body/plate <-> lid/barrel" in text  # listed as a junction
+    assert "TANGENT CONTACT" not in text  # but not flagged: kinematic clearance
+
+
+def test_junctions_file_does_not_change_workspace_digest(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    before = workspace_digest(tmp_path)
+    (tmp_path / "junctions.md").write_text("# Junction report\n", encoding="utf-8")
+    assert workspace_digest(tmp_path) == before
+
+
+def test_flush_contact_flags_and_embedded_passes(tmp_path: Path) -> None:
+    from mini_articraft.sdk import CylinderGeometry
+
+    # A long leg flush against a top: zero overlap volume -> tangent, regardless of
+    # how small the contact is relative to the leg's total surface.
+    flush = ArticulatedObject("t")
+    table = flush.part("table")
+    table.add(BoxGeometry((0.60, 0.40, 0.02)).translate(0, 0, 0.71), name="top")
+    table.add(CylinderGeometry(0.025, 0.70).translate(0.25, 0.15, 0.35), name="leg")
+    write_junction_report(flush, tmp_path)
+    assert "TANGENT CONTACT" in (tmp_path / "junctions.md").read_text(encoding="utf-8")
+
+    # The same leg embedded 10mm into the top: real shared volume -> passes.
+    embedded = ArticulatedObject("t")
+    table = embedded.part("table")
+    table.add(BoxGeometry((0.60, 0.40, 0.02)).translate(0, 0, 0.71), name="top")
+    table.add(CylinderGeometry(0.025, 0.71).translate(0.25, 0.15, 0.355), name="leg")
+    write_junction_report(embedded, tmp_path)
+    text = (tmp_path / "junctions.md").read_text(encoding="utf-8")
+    assert "TANGENT CONTACT" not in text
+    assert "overlap" in text


### PR DESCRIPTION
One check, one invariant: **tangent contact is not attachment.**

The root cause under every "stuck-on" defect -- grazing handles, floating hinge blocks, perched pads -- is a piece touching a surface at a point or a line: zero area, which the existing connectivity check accepts as "connected". This is a spec bug in connectivity, not a new heuristic: two pieces that are one part must share volume. The cure is always the same -- embed the piece past the surface so the volumes overlap, then weld; the bead fills the seam.

## What it does
Every successful compile writes `junctions.md`: each pair of touching shapes with how much of the smaller piece actually seats (surface-sample fraction; seated = on or inside the partner), flagging:

```
TANGENT CONTACT: weighted_base/raised_bowl_seat <-> weighted_base/bowl_clip_1
  (barely touching: 1% of surface seats) -- embed the piece past the surface
  so the volumes overlap, then weld; the bead fills the seam
```

Pairs spanning an articulation's parent/child interface are listed but **never flagged**: a hinge barrel in its sleeve needs running clearance -- tangency there is the mechanism, not a defect. Compile feedback points at the report. The file is compiler output (digest-ignored, best-effort, cannot fail a compile); flags are non-blocking -- fix or justify.

## Calibration and validation
- A grazing handle flags at 2% seated; cords, connectors, and embedded windows pass clean.
- Traced live on gpt-5.5 and gpt-5.6: agents saw same-part tangent flags mid-run (bowl seat against its clip, hinge neck grazing its knuckle) and eliminated them within one compile cycle, while correctly justifying kinematic clearances. On gpt-5.6 the flags still fired -- better models repair faster, but still produce the defect; the check's firing rate over time is exactly the metric that will show when it becomes unnecessary.

## Scope
5 files, ~180 lines, no dependencies on any other open PR. The companion housing example lives on `jchiu/housing-example` (PR later, if wanted); the vision-stack PRs (#17/#19) are parked as drafts and evaluated separately.

