### PR TITLE
Close the model websocket at the end of every agent run

### DIFF
--- a/src/mini_articraft/agent/harness.py
+++ b/src/mini_articraft/agent/harness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import time
@@ -164,6 +165,11 @@ class Agent:
                 hit_max_turns = True
         finally:
             await context.exec_sessions.aclose()
+            # The agent owns the model for the run's duration, so a finished
+            # run never leaves a live websocket behind. Close failures are
+            # inconsequential teardown noise and must not change the outcome.
+            with contextlib.suppress(Exception):
+                await self.model.close()
 
         workspace_is_compiled = _latest_workspace_is_compiled(context)
         record = Record.load(record_path)

--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -101,6 +101,8 @@ async def _generate(
             agent_kwargs["on_event"] = on_event
         return await Agent(model_client, env, **agent_kwargs).run(prompt)
     finally:
+        # Agent.run closes the model too; close() is idempotent, and this
+        # finally covers failures before the agent loop starts.
         await model_client.close()
 
 

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -198,6 +198,7 @@ class QueuedModel(Generic[Item]):
     ):
         self._queue = list(items)
         self.queries: list[ModelQuery] = []
+        self.close_calls = 0
         self.config = ModelIdentity(model_name, reasoning_effort)
         self.context_window_tokens = context_window_tokens
 
@@ -221,7 +222,7 @@ class QueuedModel(Generic[Item]):
             )
 
     async def close(self) -> None:
-        pass
+        self.close_calls += 1
 
 
 class ScriptedModel(QueuedModel[Step]):

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -480,6 +480,55 @@ def test_agent_records_model_query_failure(tmp_path) -> None:
     assert result["error"] == "model query failed: RuntimeError: socket closed"
 
 
+def test_agent_closes_the_model_after_a_successful_run(tmp_path) -> None:
+    model = ScriptedModel(
+        [
+            calls(tool_call("write", {"path": "main.py", "content": GOOD_MAIN_PY})),
+            calls(tool_call("compile")),
+            text("done"),
+        ]
+    )
+
+    result = run(Agent(model, LocalEnvironment(output_dir=tmp_path), max_turns=3).run("box"))
+
+    assert result["status"] == "success"
+    assert model.close_calls == 1
+
+
+def test_agent_closes_the_model_after_a_model_failure(tmp_path) -> None:
+    def fail(query: ModelQuery) -> Response:
+        raise RuntimeError("socket closed")
+
+    model = ScriptedModel([fail])
+
+    run(Agent(model, LocalEnvironment(output_dir=tmp_path), max_turns=3).run("box"))
+
+    assert model.close_calls == 1
+
+
+def test_agent_closes_the_model_on_cancellation(tmp_path) -> None:
+    waiting = asyncio.Event()
+
+    async def block_forever(query: ModelQuery) -> Response:
+        waiting.set()
+        pending: asyncio.Future[None] = asyncio.Future()
+        await pending
+        raise AssertionError("blocking query unexpectedly completed")
+
+    model = ScriptedModel([block_forever])
+
+    async def exercise() -> None:
+        env = LocalEnvironment(output_dir=tmp_path)
+        task = asyncio.create_task(Agent(model, env, max_turns=3).run("box", run_id="cancel"))
+        await asyncio.wait_for(waiting.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    run(exercise())
+    assert model.close_calls == 1
+
+
 def test_agent_emits_run_events(tmp_path) -> None:
     model = ScriptedModel(
         [

--- a/tests/test_openai_model.py
+++ b/tests/test_openai_model.py
@@ -435,3 +435,15 @@ def test_openai_model_returns_completed_reasoning_only_response(
     assert result["text"] == ""
     assert "reasoning" not in result
     assert result["tool_calls"] == []
+
+
+def test_close_closes_the_websocket_and_is_idempotent(monkeypatch) -> None:
+    socket = FakeWebSocket([response_event("result")])
+    patch_websocket(monkeypatch, socket)
+    model = openai_model()
+
+    run(model.query([{"role": "user", "content": "hi"}]))
+    run(model.close())
+
+    assert socket.closed is True
+    run(model.close())  # idempotent: nothing left to close


### PR DESCRIPTION
Close the model websocket at the end of every agent run

Agent.run terminated exec sessions in its finally block but never closed
the model, so any caller that drove Agent directly (the test harness's
live path, scripts/tape.py capture, future consumers) leaked the OpenAI
websocket transport until GC (an unclosed-SSL-transport ResourceWarning).
The CLI was the only caller that remembered to close.

Agent.run now closes the model after exec teardown; close failures are
suppressed as inconsequential teardown noise that must not change the
run's outcome. The CLI keeps its own finally-close (idempotent; covers
failures before the agent loop starts), and OpenAIModel reconnects
lazily, so a reused model simply pays a reconnect.

Tests: the harness's QueuedModel counts close calls, and agent-contract
tests pin close-after-success, close-after-model-failure, and
close-on-cancellation; the OpenAI adapter gains a close() test proving
the websocket itself is closed and the call is idempotent.
