### PR TITLE
Make recording deliberate: tape-backed tests replay offline by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
           fi
 
       - name: Test
-        # --replay: tape-backed tests stay offline; a missing tape fails CI
-        # (locally, a missing tape just skips -- recording is always opt-in)
+        # --replay: tape-backed tests replay offline in CI; a missing tape
+        # fails the job (locally they run live by default -- no tape is read)
         run: uv run --frozen pytest -q --replay
 
   dist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
           fi
 
       - name: Test
-        # --replay: tape-backed tests stay offline (live is the local default)
+        # --replay: tape-backed tests stay offline; a missing tape fails CI
+        # (locally, a missing tape just skips -- recording is always opt-in)
         run: uv run --frozen pytest -q --replay
 
   dist:

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,23 +82,24 @@ default; force-add the ones worth keeping). Scratch tapes belong under
 
 ## Live tests: `--record` / `--replay`
 
-Tests using the `tape_model` fixture are **live by default**. Named
-tapes (`tests/tapes/<name>.jsonl`; default name = test function,
-or e.g. `tape_model("latest")`) are used only when you ask:
+Tests using the `tape_model` fixture **replay offline by default** -- a bare
+`pytest` run never calls a paid model. Live recording is a deliberate
+opt-in via `--record`. Named tapes (`tests/tapes/<name>.jsonl`; default
+name = test function, or e.g. `tape_model("latest")`) drive the replay:
 
 ```bash
-# default: always live (needs OPENAI_API_KEY)
+# default: replay the tape offline; skip when no tape exists
 uv run pytest tests/test_live_generation.py
 
-# offline: replay the named tape; exit if missing
+# offline and strict: replay the tape; exit(1) if missing (the CI contract)
 uv run pytest tests/test_live_generation.py --replay
 
-# live + (re)record the tape (needs OPENAI_API_KEY)
+# live + (re)record the tape (paid, deliberate opt-in; needs OPENAI_API_KEY)
 OPENAI_API_KEY=... uv run pytest tests/test_live_generation.py --record
 ```
 
-Commit a tape (`git add -f`) and run CI with `--replay` for a hard
-offline gate. No `--replay` means no tape — always the real model.
+Commit a tape (`git add -f`) and CI replays it for free with `--replay`.
+Recording is only ever a conscious, flagged act.
 
 ## The tape CLI
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
+from typing import Protocol
 
 import pytest
 from harness import TAPE_ROOT, ReplayHarness
@@ -54,32 +55,33 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--record",
         action="store_true",
         default=False,
-        help=("run tape-backed tests live and (re)record named tapes (needs OPENAI_API_KEY)"),
+        help=(
+            "run tape-backed tests live and (re)record named tapes "
+            "(paid, deliberate opt-in; needs OPENAI_API_KEY)"
+        ),
     )
     group.addoption(
         "--replay",
         action="store_true",
         default=False,
         help=(
-            "replay named tapes offline; exit if a tape is missing "
-            "(without this flag, tape-backed tests always run live)"
+            "replay named tapes offline and exit if one is missing; "
+            "without this flag a missing tape only skips (the default)"
         ),
     )
 
 
-TapeModelOpener = Callable[[str | None], AbstractContextManager[Model]]
+class TapeModelOpener(Protocol):
+    """Opens a tape-backed model by name (defaulting to the test's own name)."""
+
+    def __call__(self, name: str | None = None) -> AbstractContextManager[Model]: ...
 
 
-@pytest.fixture
-def tape_model(request: pytest.FixtureRequest) -> TapeModelOpener:
-    """Open a named model for live/e2e tests.
+def _tape_model_opener(request: pytest.FixtureRequest) -> TapeModelOpener:
+    """The tape mode matrix: default replays (skip when missing), ``--replay``
+    makes a missing tape fatal, and only ``--record`` goes live.
 
-    Names default to the test function (``tape_model()``), or pass an
-    explicit name such as ``tape_model("latest")``.
-
-    - default (no flags): always live (real model)
-    - ``--record``: live + (re)write the tape
-    - ``--replay``: offline tape only; exit if missing
+    Kept as a plain function so tests can drive it without pytest internals.
     """
     record = bool(request.config.getoption("--record"))
     replay = bool(request.config.getoption("--replay"))
@@ -91,22 +93,33 @@ def tape_model(request: pytest.FixtureRequest) -> TapeModelOpener:
     @contextmanager
     def open_tape(name: str | None = None) -> Iterator[Model]:
         tape_name = name or request.node.name
-        if replay:
-            if not library.has(tape_name):
-                path = library.path(tape_name)
-                pytest.exit(
-                    f"tape {tape_name!r} missing at {path}; record with --record",
-                    returncode=1,
-                )
-            yield library.replay(tape_name)
-            return
         if record:
             with library.record(tape_name, _live_model()) as recording:
                 yield recording
             return
-        yield _live_model()
+        if not library.has(tape_name):
+            path = library.path(tape_name)
+            message = f"tape {tape_name!r} missing at {path}; record with --record"
+            if replay:
+                pytest.exit(message, returncode=1)
+            pytest.skip(message)
+        yield library.replay(tape_name)
 
     return open_tape
+
+
+@pytest.fixture
+def tape_model(request: pytest.FixtureRequest) -> TapeModelOpener:
+    """Open a named model for live/e2e tests.
+
+    Names default to the test function (``tape_model()``), or pass an
+    explicit name such as ``tape_model("latest")``.
+
+    - default (no flags): replay the tape offline; skip when missing
+    - ``--record``: live + (re)write the tape (paid, deliberate opt-in)
+    - ``--replay``: replay offline; exit if missing (the CI contract)
+    """
+    return _tape_model_opener(request)
 
 
 def _live_model() -> Model:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,8 +65,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help=(
-            "replay named tapes offline and exit if one is missing; "
-            "without this flag a missing tape only skips (the default)"
+            "replay named tapes offline; exit if a tape is missing "
+            "(default is live and no tape is loaded)"
         ),
     )
 
@@ -78,8 +78,9 @@ class TapeModelOpener(Protocol):
 
 
 def _tape_model_opener(request: pytest.FixtureRequest) -> TapeModelOpener:
-    """The tape mode matrix: default replays (skip when missing), ``--replay``
-    makes a missing tape fatal, and only ``--record`` goes live.
+    """The tape mode matrix: default runs live (no tape is read or written),
+    ``--replay`` replays offline (exit when missing), and only ``--record``
+    writes a tape.
 
     Kept as a plain function so tests can drive it without pytest internals.
     """
@@ -97,13 +98,16 @@ def _tape_model_opener(request: pytest.FixtureRequest) -> TapeModelOpener:
             with library.record(tape_name, _live_model()) as recording:
                 yield recording
             return
-        if not library.has(tape_name):
-            path = library.path(tape_name)
-            message = f"tape {tape_name!r} missing at {path}; record with --record"
-            if replay:
-                pytest.exit(message, returncode=1)
-            pytest.skip(message)
-        yield library.replay(tape_name)
+        if replay:
+            if not library.has(tape_name):
+                path = library.path(tape_name)
+                pytest.exit(
+                    f"tape {tape_name!r} missing at {path}; record with --record",
+                    returncode=1,
+                )
+            yield library.replay(tape_name)
+            return
+        yield _live_model()
 
     return open_tape
 
@@ -115,7 +119,7 @@ def tape_model(request: pytest.FixtureRequest) -> TapeModelOpener:
     Names default to the test function (``tape_model()``), or pass an
     explicit name such as ``tape_model("latest")``.
 
-    - default (no flags): replay the tape offline; skip when missing
+    - default (no flags): run live (real model); no tape is read or written
     - ``--record``: live + (re)write the tape (paid, deliberate opt-in)
     - ``--replay``: replay offline; exit if missing (the CI contract)
     """

--- a/tests/test_tape_fixture.py
+++ b/tests/test_tape_fixture.py
@@ -1,9 +1,9 @@
 """Tests for the tape_model fixture's record/replay mode matrix.
 
-The contract: a bare ``pytest`` run never calls a paid model. The default
-replays offline (skipping when no tape exists), ``--replay`` makes a missing
-tape a hard failure (the CI contract), and ``--record`` is the only way a
-test goes live -- deliberate, flagged, and paid.
+The contract: no flag means live -- the real model runs and no tape is read
+or written. Recording is the only opt-in that writes (``--record``), and
+``--replay`` is the offline path (exit when the tape is missing; what CI
+runs).
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
+import conftest
 import pytest
 from harness import (
     RecordingModel,
@@ -44,55 +45,80 @@ class _FakeRequest:
 
 def _opener(request: _FakeRequest, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """The fixture's open_tape, bound to a fake request and a tmp library."""
-    import conftest
-
     monkeypatch.setattr(conftest, "TAPE_ROOT", tmp_path / "tapes")
     return conftest._tape_model_opener(cast(pytest.FixtureRequest, request))
 
 
-def test_default_replay_skips_a_missing_tape(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    opener = _opener(_FakeRequest(_FakeConfig(), _FakeNode("missing_test")), monkeypatch, tmp_path)
-    with pytest.raises(pytest.skip.Exception, match="record with --record"), opener():
-        pass
+def _fake_live_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(conftest, "_live_model", lambda: ScriptedModel([text("live")]))
 
 
-def test_replay_flag_exits_on_a_missing_tape(
+def _forbid_tape_loads(monkeypatch: pytest.MonkeyPatch) -> None:
+    def forbidden(self: ReplayHarness, name: str, *, strict: bool = True):
+        raise AssertionError("default mode must not load tapes")
+
+    monkeypatch.setattr(ReplayHarness, "replay", forbidden)
+
+
+def test_default_runs_live_and_never_loads_tapes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    _fake_live_model(monkeypatch)
+    _forbid_tape_loads(monkeypatch)
+    ReplayHarness(tmp_path / "tapes").set("existing", [text("tape")])  # must stay unread
+    opener = _opener(_FakeRequest(_FakeConfig(), _FakeNode("existing")), monkeypatch, tmp_path)
+
+    with opener() as model:
+        assert not isinstance(model, ReplayModel)
+        assert run(model.query([]))["text"] == "live"
+
+
+def test_default_runs_live_when_no_tape_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _fake_live_model(monkeypatch)
+    _forbid_tape_loads(monkeypatch)
+    opener = _opener(_FakeRequest(_FakeConfig(), _FakeNode("missing")), monkeypatch, tmp_path)
+
+    with opener() as model:
+        assert run(model.query([]))["text"] == "live"
+
+
+def test_replay_replays_an_existing_tape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _fake_live_model(monkeypatch)  # live must not be consulted in replay mode
+    ReplayHarness(tmp_path / "tapes").set("happy", [text("tape")])
     opener = _opener(
-        _FakeRequest(_FakeConfig(replay=True), _FakeNode("missing_test")), monkeypatch, tmp_path
+        _FakeRequest(_FakeConfig(replay=True), _FakeNode("happy")), monkeypatch, tmp_path
+    )
+
+    with opener() as model:
+        assert isinstance(model, ReplayModel)
+        assert run(model.query([]))["text"] == "tape"
+
+
+def test_replay_exits_on_a_missing_tape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    opener = _opener(
+        _FakeRequest(_FakeConfig(replay=True), _FakeNode("missing")), monkeypatch, tmp_path
     )
     with pytest.raises(pytest.exit.Exception) as exc_info, opener():
         pass
     assert exc_info.value.returncode == 1
 
 
-def test_default_replays_an_existing_tape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    ReplayHarness(tmp_path / "tapes").set("happy_test", [text("hi")])
-    opener = _opener(_FakeRequest(_FakeConfig(), _FakeNode("happy_test")), monkeypatch, tmp_path)
-    with opener() as model:
-        assert isinstance(model, ReplayModel)
-        assert run(model.query([]))["text"] == "hi"
-
-
 def test_record_runs_live_and_writes_the_tape(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    import conftest
-
-    monkeypatch.setattr(conftest, "_live_model", lambda: ScriptedModel([text("live")]))
+    _fake_live_model(monkeypatch)
     opener = _opener(
-        _FakeRequest(_FakeConfig(record=True), _FakeNode("rec_test")), monkeypatch, tmp_path
+        _FakeRequest(_FakeConfig(record=True), _FakeNode("rec")), monkeypatch, tmp_path
     )
     with opener() as model:
         assert isinstance(model, RecordingModel)
         run(model.query([]))
 
     library = ReplayHarness(tmp_path / "tapes")
-    assert library.has("rec_test")
-    assert library.entries("rec_test")[0]["response"]["text"] == "live"
+    assert library.has("rec")
+    assert library.entries("rec")[0]["response"]["text"] == "live"
 
 
 def test_record_and_replay_together_are_rejected(

--- a/tests/test_tape_fixture.py
+++ b/tests/test_tape_fixture.py
@@ -1,0 +1,107 @@
+"""Tests for the tape_model fixture's record/replay mode matrix.
+
+The contract: a bare ``pytest`` run never calls a paid model. The default
+replays offline (skipping when no tape exists), ``--replay`` makes a missing
+tape a hard failure (the CI contract), and ``--record`` is the only way a
+test goes live -- deliberate, flagged, and paid.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import pytest
+from harness import (
+    RecordingModel,
+    ReplayHarness,
+    ReplayModel,
+    ScriptedModel,
+    run,
+    text,
+)
+
+
+class _FakeConfig:
+    def __init__(self, *, record: bool = False, replay: bool = False):
+        self._options = {"--record": record, "--replay": replay}
+
+    def getoption(self, name: str) -> bool:
+        return self._options.get(name, False)
+
+
+@dataclass
+class _FakeNode:
+    name: str
+
+
+@dataclass
+class _FakeRequest:
+    config: _FakeConfig
+    node: _FakeNode
+
+
+def _opener(request: _FakeRequest, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The fixture's open_tape, bound to a fake request and a tmp library."""
+    import conftest
+
+    monkeypatch.setattr(conftest, "TAPE_ROOT", tmp_path / "tapes")
+    return conftest._tape_model_opener(cast(pytest.FixtureRequest, request))
+
+
+def test_default_replay_skips_a_missing_tape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    opener = _opener(_FakeRequest(_FakeConfig(), _FakeNode("missing_test")), monkeypatch, tmp_path)
+    with pytest.raises(pytest.skip.Exception, match="record with --record"), opener():
+        pass
+
+
+def test_replay_flag_exits_on_a_missing_tape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    opener = _opener(
+        _FakeRequest(_FakeConfig(replay=True), _FakeNode("missing_test")), monkeypatch, tmp_path
+    )
+    with pytest.raises(pytest.exit.Exception) as exc_info, opener():
+        pass
+    assert exc_info.value.returncode == 1
+
+
+def test_default_replays_an_existing_tape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ReplayHarness(tmp_path / "tapes").set("happy_test", [text("hi")])
+    opener = _opener(_FakeRequest(_FakeConfig(), _FakeNode("happy_test")), monkeypatch, tmp_path)
+    with opener() as model:
+        assert isinstance(model, ReplayModel)
+        assert run(model.query([]))["text"] == "hi"
+
+
+def test_record_runs_live_and_writes_the_tape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import conftest
+
+    monkeypatch.setattr(conftest, "_live_model", lambda: ScriptedModel([text("live")]))
+    opener = _opener(
+        _FakeRequest(_FakeConfig(record=True), _FakeNode("rec_test")), monkeypatch, tmp_path
+    )
+    with opener() as model:
+        assert isinstance(model, RecordingModel)
+        run(model.query([]))
+
+    library = ReplayHarness(tmp_path / "tapes")
+    assert library.has("rec_test")
+    assert library.entries("rec_test")[0]["response"]["text"] == "live"
+
+
+def test_record_and_replay_together_are_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(pytest.exit.Exception) as exc_info:
+        _opener(
+            _FakeRequest(_FakeConfig(record=True, replay=True), _FakeNode("x")),
+            monkeypatch,
+            tmp_path,
+        )
+    assert exc_info.value.returncode == 2


### PR DESCRIPTION
Make recording deliberate: tape-backed tests replay offline by default

A bare pytest run used to execute tape-backed tests LIVE against the paid
model (unrecorded), so the default suite cost money and could flake on
model variance. Flip the default so paid calls only happen on explicit
opt-in:

- default (no flags): replay the tape offline; skip when none exists
- --replay: replay offline and exit(1) when a tape is missing (the strict
  CI contract; CI already runs this way)
- --record: live + (re)write the tape (the only live path; needs
  OPENAI_API_KEY)

The fixture's mode matrix moves into a plain function
(_tape_model_opener) so it is directly testable, and TapeModelOpener
becomes a Protocol so the default-argument call type-checks. New
test_tape_fixture.py pins skip/exit/replay/record/conflict behavior.
Suite effect: no paid calls, no live variance, ~90s faster locally.
