### PR TITLE
Clarify the public SDK surface: one canonical import path per category

### DIFF
--- a/benchmarks/sdk_benchmark.py
+++ b/benchmarks/sdk_benchmark.py
@@ -30,16 +30,26 @@ from mini_articraft.sdk import (
     SphereGeometry,
     SuperellipsoidGeometry,
     SweepGeometry,
-    SweepSection,
     TestContext,
+)
+from mini_articraft.sdk._collision import MeshCollisionKernel
+from mini_articraft.sdk._mesh_boolean import _boolean_union_many
+from mini_articraft.sdk.mesh import (
+    LoftSection,
+    SectionLoftSpec,
+    ShellPartitionRegion,
+    ShellPartitionSpec,
+    SweepSection,
     boolean_difference,
     boolean_intersection,
     boolean_union,
     build123d_to_mesh,
+    partition_shell,
     refine_mesh,
     rounded_rect_profile,
     sample_catmull_rom_spline_3d,
     sample_cubic_bezier_spline_3d,
+    section_loft,
     smooth_difference,
     smooth_mesh,
     subdivide_mesh,
@@ -48,14 +58,6 @@ from mini_articraft.sdk import (
     tube_from_spline_points,
     tube_network_from_paths,
     weld,
-)
-from mini_articraft.sdk._collision import MeshCollisionKernel
-from mini_articraft.sdk._mesh_boolean import _boolean_union_many
-from mini_articraft.sdk.section_loft import LoftSection, SectionLoftSpec, section_loft
-from mini_articraft.sdk.shell_partition import (
-    ShellPartitionRegion,
-    ShellPartitionSpec,
-    partition_shell,
 )
 
 Result = object

--- a/examples/mesh_knob/main.py
+++ b/examples/mesh_knob/main.py
@@ -14,8 +14,8 @@ from mini_articraft.sdk import (
     LatheGeometry,
     TestContext,
     TestReport,
-    boolean_union,
 )
+from mini_articraft.sdk.mesh import boolean_union
 
 PROFILE = [
     (0.000, 0.000),

--- a/src/mini_articraft/sdk/__init__.py
+++ b/src/mini_articraft/sdk/__init__.py
@@ -1,14 +1,18 @@
+"""Public SDK for authoring and testing articulated objects.
+
+One canonical import path per category:
+
+- Object and articulation modeling, geometry classes, physical testing, and
+  errors live here at the package root.
+- Advanced mesh authoring and repair recipes (booleans, welds, snapping,
+  profile/wire sampling, sweep helpers, section lofts, shell partitioning,
+  refinement) live under ``mini_articraft.sdk.mesh``.
+"""
+
 from __future__ import annotations
 
 from mini_articraft.errors import SDKError, ValidationError
-from mini_articraft.sdk.joints import (
-    Articulation,
-    ArticulationType,
-    MotionLimits,
-    Origin,
-)
-from mini_articraft.sdk.mesh import (
-    ArcPipeGeometry,
+from mini_articraft.sdk._mesh_core import (
     BoxGeometry,
     CapsuleGeometry,
     ConeGeometry,
@@ -19,54 +23,24 @@ from mini_articraft.sdk.mesh import (
     LatheGeometry,
     LoftGeometry,
     MeshGeometry,
-    PipeGeometry,
     RoundedBoxGeometry,
-    SnapRefused,
     SphereGeometry,
     SuperellipsoidGeometry,
-    SweepGeometry,
-    SweepSection,
     TorusGeometry,
-    WirePath,
+)
+from mini_articraft.sdk._mesh_sweeps import (
+    ArcPipeGeometry,
+    PipeGeometry,
+    SweepGeometry,
     WirePolylineGeometry,
-    boolean_difference,
-    boolean_intersection,
-    boolean_union,
-    build123d_to_mesh,
-    cut_opening_on_face,
-    refine_mesh,
-    resample_side_sections,
-    rounded_rect_profile,
-    sample_arc_3d,
-    sample_catmull_rom_spline_2d,
-    sample_catmull_rom_spline_3d,
-    sample_cubic_bezier_spline_2d,
-    sample_cubic_bezier_spline_3d,
-    smooth_difference,
-    smooth_mesh,
-    snap_to,
-    split_superellipse_side_loft,
-    subdivide_mesh,
-    superellipse_profile,
-    superellipse_side_loft,
-    sweep_profile_along_spline,
-    tube_from_spline_points,
-    tube_network_from_paths,
-    weld,
-    wire_from_points,
+)
+from mini_articraft.sdk.joints import (
+    Articulation,
+    ArticulationType,
+    MotionLimits,
+    Origin,
 )
 from mini_articraft.sdk.object import ArticulatedObject, Part
-from mini_articraft.sdk.section_loft import (
-    LoftSection,
-    SectionLoftSpec,
-    repair_loft,
-    section_loft,
-)
-from mini_articraft.sdk.shell_partition import (
-    ShellPartitionRegion,
-    ShellPartitionSpec,
-    partition_shell,
-)
 from mini_articraft.sdk.testing import (
     AllowedOverlap,
     DistanceFinding,
@@ -91,7 +65,6 @@ __all__ = [
     "ExtrudeWithHolesGeometry",
     "LatheGeometry",
     "LoftGeometry",
-    "LoftSection",
     "MeshGeometry",
     "MotionLimits",
     "Origin",
@@ -99,47 +72,13 @@ __all__ = [
     "PipeGeometry",
     "RoundedBoxGeometry",
     "SDKError",
-    "SectionLoftSpec",
-    "ShellPartitionRegion",
-    "ShellPartitionSpec",
-    "SnapRefused",
     "SphereGeometry",
     "SuperellipsoidGeometry",
     "SweepGeometry",
-    "SweepSection",
     "TestContext",
     "TestFailure",
     "TestReport",
     "TorusGeometry",
     "ValidationError",
-    "WirePath",
     "WirePolylineGeometry",
-    "boolean_difference",
-    "boolean_intersection",
-    "boolean_union",
-    "build123d_to_mesh",
-    "cut_opening_on_face",
-    "partition_shell",
-    "refine_mesh",
-    "repair_loft",
-    "resample_side_sections",
-    "rounded_rect_profile",
-    "sample_arc_3d",
-    "sample_catmull_rom_spline_2d",
-    "sample_catmull_rom_spline_3d",
-    "sample_cubic_bezier_spline_2d",
-    "sample_cubic_bezier_spline_3d",
-    "section_loft",
-    "smooth_difference",
-    "smooth_mesh",
-    "snap_to",
-    "split_superellipse_side_loft",
-    "subdivide_mesh",
-    "superellipse_profile",
-    "superellipse_side_loft",
-    "sweep_profile_along_spline",
-    "tube_from_spline_points",
-    "tube_network_from_paths",
-    "weld",
-    "wire_from_points",
 ]

--- a/src/mini_articraft/sdk/_collision.py
+++ b/src/mini_articraft/sdk/_collision.py
@@ -11,8 +11,8 @@ import trimesh
 from build123d.topology import Shape
 
 from mini_articraft.errors import ValidationError
+from mini_articraft.sdk._mesh_core import MeshGeometry
 from mini_articraft.sdk.joints import Articulation, ArticulationType, Origin
-from mini_articraft.sdk.mesh import MeshGeometry
 from mini_articraft.sdk.object import ArticulatedObject, Geometry
 
 Vec3: TypeAlias = tuple[float, float, float]

--- a/src/mini_articraft/sdk/_section_loft.py
+++ b/src/mini_articraft/sdk/_section_loft.py
@@ -9,12 +9,13 @@ import numpy as np
 import trimesh
 
 from mini_articraft.errors import ValidationError
+from mini_articraft.sdk._mesh_boolean import boolean_union
+from mini_articraft.sdk._mesh_core import LoftGeometry, MeshGeometry
 from mini_articraft.sdk._mesh_sweeps import (
     _initial_frame,
     _path_frames,
     _validated_up_hint,
 )
-from mini_articraft.sdk.mesh import LoftGeometry, MeshGeometry, boolean_union
 
 Vec3 = tuple[float, float, float]
 RepairMode = Literal["off", "mesh"]

--- a/src/mini_articraft/sdk/_shell_partition.py
+++ b/src/mini_articraft/sdk/_shell_partition.py
@@ -5,12 +5,8 @@ from dataclasses import dataclass, replace
 from typing import Any, Literal, cast
 
 from mini_articraft.errors import ValidationError
-from mini_articraft.sdk.mesh import (
-    BoxGeometry,
-    MeshGeometry,
-    boolean_difference,
-    boolean_intersection,
-)
+from mini_articraft.sdk._mesh_boolean import boolean_difference, boolean_intersection
+from mini_articraft.sdk._mesh_core import BoxGeometry, MeshGeometry
 
 ShellSide = Literal["full", "left", "right", "center"]
 

--- a/src/mini_articraft/sdk/docs/examples/hollow_shell.py
+++ b/src/mini_articraft/sdk/docs/examples/hollow_shell.py
@@ -5,8 +5,8 @@ from mini_articraft.sdk import (
     BoxGeometry,
     TestContext,
     TestReport,
-    boolean_difference,
 )
+from mini_articraft.sdk.mesh import boolean_difference
 
 
 def build_object_model() -> ArticulatedObject:

--- a/src/mini_articraft/sdk/docs/examples/molded_mug.py
+++ b/src/mini_articraft/sdk/docs/examples/molded_mug.py
@@ -19,6 +19,8 @@ from mini_articraft.sdk import (
     LatheGeometry,
     TestContext,
     TestReport,
+)
+from mini_articraft.sdk.mesh import (
     rounded_rect_profile,
     sweep_profile_along_spline,
     weld,

--- a/src/mini_articraft/sdk/docs/examples/section_loft_with_wires.py
+++ b/src/mini_articraft/sdk/docs/examples/section_loft_with_wires.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from mini_articraft.sdk import (
     ArticulatedObject,
-    LoftSection,
-    SectionLoftSpec,
     TestContext,
     TestReport,
+)
+from mini_articraft.sdk.mesh import (
+    LoftSection,
+    SectionLoftSpec,
     section_loft,
     tube_from_spline_points,
 )

--- a/src/mini_articraft/sdk/docs/examples/variable_sweep_and_loft.py
+++ b/src/mini_articraft/sdk/docs/examples/variable_sweep_and_loft.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from mini_articraft.sdk import (
     ArticulatedObject,
+    TestContext,
+    TestReport,
+)
+from mini_articraft.sdk.mesh import (
     LoftSection,
     SectionLoftSpec,
     SweepSection,
-    TestContext,
-    TestReport,
     rounded_rect_profile,
     section_loft,
     superellipse_profile,

--- a/src/mini_articraft/sdk/docs/mesh/00_mesh_geometry.md
+++ b/src/mini_articraft/sdk/docs/mesh/00_mesh_geometry.md
@@ -30,8 +30,8 @@ from mini_articraft.sdk import (
     SphereGeometry,
     SuperellipsoidGeometry,
     TorusGeometry,
-    build123d_to_mesh,
 )
+from mini_articraft.sdk.mesh import build123d_to_mesh
 ```
 
 ## Choose a geometry type

--- a/src/mini_articraft/sdk/docs/mesh/10_profiles.md
+++ b/src/mini_articraft/sdk/docs/mesh/10_profiles.md
@@ -14,7 +14,7 @@ This page documents `rounded_rect_profile`, `superellipse_profile`,
 `resample_side_sections`.
 
 ```python
-from mini_articraft.sdk import (
+from mini_articraft.sdk.mesh import (
     resample_side_sections,
     rounded_rect_profile,
     sample_arc_3d,

--- a/src/mini_articraft/sdk/docs/mesh/20_wires_and_sweeps.md
+++ b/src/mini_articraft/sdk/docs/mesh/20_wires_and_sweeps.md
@@ -15,10 +15,12 @@ This page documents `SweepSection`, `SweepGeometry`, `PipeGeometry`,
 from mini_articraft.sdk import (
     ArcPipeGeometry,
     PipeGeometry,
-    SweepSection,
     SweepGeometry,
-    WirePath,
     WirePolylineGeometry,
+)
+from mini_articraft.sdk.mesh import (
+    SweepSection,
+    WirePath,
     sweep_profile_along_spline,
     tube_from_spline_points,
     tube_network_from_paths,
@@ -489,7 +491,7 @@ the hint along the complete path. Sweep sections use normalized distance along
 the sampled spline.
 
 ```python
-from mini_articraft.sdk import rounded_rect_profile
+from mini_articraft.sdk.mesh import rounded_rect_profile
 
 trim = sweep_profile_along_spline(
     [(-0.05, 0.0, 0.0), (0.0, 0.02, 0.03), (0.05, 0.0, 0.0)],

--- a/src/mini_articraft/sdk/docs/mesh/30_section_lofts.md
+++ b/src/mini_articraft/sdk/docs/mesh/30_section_lofts.md
@@ -11,7 +11,7 @@ This page documents `LoftSection`, `SectionLoftSpec`, `section_loft`, and
 `repair_loft`.
 
 ```python
-from mini_articraft.sdk import (
+from mini_articraft.sdk.mesh import (
     LoftSection,
     SectionLoftSpec,
     repair_loft,

--- a/src/mini_articraft/sdk/docs/mesh/40_booleans_and_shells.md
+++ b/src/mini_articraft/sdk/docs/mesh/40_booleans_and_shells.md
@@ -10,8 +10,8 @@ This page documents `boolean_union`, `boolean_difference`,
 `ShellPartitionSpec`, and `partition_shell`.
 
 ```python
-from mini_articraft.sdk import (
-    BoxGeometry,
+from mini_articraft.sdk import BoxGeometry
+from mini_articraft.sdk.mesh import (
     ShellPartitionRegion,
     ShellPartitionSpec,
     boolean_difference,

--- a/src/mini_articraft/sdk/docs/mesh/50_refinement_and_smoothing.md
+++ b/src/mini_articraft/sdk/docs/mesh/50_refinement_and_smoothing.md
@@ -9,7 +9,7 @@ the input mesh unchanged.
 This page documents `refine_mesh`, `subdivide_mesh`, and `smooth_mesh`.
 
 ```python
-from mini_articraft.sdk import refine_mesh, smooth_mesh, subdivide_mesh
+from mini_articraft.sdk.mesh import refine_mesh, smooth_mesh, subdivide_mesh
 ```
 
 ## Choose an operation

--- a/src/mini_articraft/sdk/mesh.py
+++ b/src/mini_articraft/sdk/mesh.py
@@ -1,3 +1,11 @@
+"""Advanced mesh authoring and repair toolkit.
+
+Geometry classes live at the package root (``mini_articraft.sdk``) with the
+rest of the object-authoring API. This module is the canonical home for mesh
+operations and recipe helpers: booleans, welds, snapping, profile and wire
+sampling, sweep helpers, section lofts, shell partitioning, and refinement.
+"""
+
 from __future__ import annotations
 
 from mini_articraft.sdk._mesh_boolean import (
@@ -6,23 +14,7 @@ from mini_articraft.sdk._mesh_boolean import (
     boolean_union,
     cut_opening_on_face,
 )
-from mini_articraft.sdk._mesh_core import (
-    BoxGeometry,
-    CapsuleGeometry,
-    ConeGeometry,
-    CylinderGeometry,
-    DomeGeometry,
-    ExtrudeGeometry,
-    ExtrudeWithHolesGeometry,
-    LatheGeometry,
-    LoftGeometry,
-    MeshGeometry,
-    RoundedBoxGeometry,
-    SphereGeometry,
-    SuperellipsoidGeometry,
-    TorusGeometry,
-    build123d_to_mesh,
-)
+from mini_articraft.sdk._mesh_core import build123d_to_mesh
 from mini_articraft.sdk._mesh_profiles import (
     WirePath,
     resample_side_sections,
@@ -38,46 +30,41 @@ from mini_articraft.sdk._mesh_profiles import (
 )
 from mini_articraft.sdk._mesh_refine import refine_mesh, smooth_mesh, subdivide_mesh
 from mini_articraft.sdk._mesh_sweeps import (
-    ArcPipeGeometry,
-    PipeGeometry,
-    SweepGeometry,
     SweepSection,
-    WirePolylineGeometry,
     sweep_profile_along_spline,
     tube_from_spline_points,
     tube_network_from_paths,
     wire_from_points,
 )
 from mini_articraft.sdk._mesh_weld import SnapRefused, smooth_difference, snap_to, weld
+from mini_articraft.sdk._section_loft import (
+    LoftSection,
+    SectionLoftSpec,
+    repair_loft,
+    section_loft,
+)
+from mini_articraft.sdk._shell_partition import (
+    ShellPartitionRegion,
+    ShellPartitionSpec,
+    partition_shell,
+)
 
 __all__ = [
-    "ArcPipeGeometry",
-    "BoxGeometry",
-    "CapsuleGeometry",
-    "ConeGeometry",
-    "CylinderGeometry",
-    "DomeGeometry",
-    "ExtrudeGeometry",
-    "ExtrudeWithHolesGeometry",
-    "LatheGeometry",
-    "LoftGeometry",
-    "MeshGeometry",
-    "PipeGeometry",
-    "RoundedBoxGeometry",
+    "LoftSection",
+    "SectionLoftSpec",
+    "ShellPartitionRegion",
+    "ShellPartitionSpec",
     "SnapRefused",
-    "SphereGeometry",
-    "SuperellipsoidGeometry",
-    "SweepGeometry",
     "SweepSection",
-    "TorusGeometry",
     "WirePath",
-    "WirePolylineGeometry",
     "boolean_difference",
     "boolean_intersection",
     "boolean_union",
     "build123d_to_mesh",
     "cut_opening_on_face",
+    "partition_shell",
     "refine_mesh",
+    "repair_loft",
     "resample_side_sections",
     "rounded_rect_profile",
     "sample_arc_3d",
@@ -85,6 +72,7 @@ __all__ = [
     "sample_catmull_rom_spline_3d",
     "sample_cubic_bezier_spline_2d",
     "sample_cubic_bezier_spline_3d",
+    "section_loft",
     "smooth_difference",
     "smooth_mesh",
     "snap_to",

--- a/src/mini_articraft/sdk/object.py
+++ b/src/mini_articraft/sdk/object.py
@@ -8,6 +8,7 @@ from typing import TypeAlias
 from build123d.topology import Shape
 
 from mini_articraft.errors import ValidationError
+from mini_articraft.sdk._mesh_core import MeshGeometry
 from mini_articraft.sdk.joints import (
     Articulation,
     ArticulationType,
@@ -17,7 +18,6 @@ from mini_articraft.sdk.joints import (
     _as_name,
     _coerce_part_name,
 )
-from mini_articraft.sdk.mesh import MeshGeometry
 
 Geometry: TypeAlias = Shape | MeshGeometry
 Color: TypeAlias = tuple[float, float, float, float]

--- a/tests/test_mesh_refinement.py
+++ b/tests/test_mesh_refinement.py
@@ -5,13 +5,8 @@ import math
 import numpy as np
 import pytest
 
-from mini_articraft.sdk import (
-    BoxGeometry,
-    MeshGeometry,
-    refine_mesh,
-    smooth_mesh,
-    subdivide_mesh,
-)
+from mini_articraft.sdk import BoxGeometry, MeshGeometry
+from mini_articraft.sdk.mesh import refine_mesh, smooth_mesh, subdivide_mesh
 
 
 def _bumpy_patch() -> MeshGeometry:

--- a/tests/test_mesh_sdk.py
+++ b/tests/test_mesh_sdk.py
@@ -8,7 +8,7 @@ import pytest
 from build123d import Box, Pos
 
 from mini_articraft.errors import ValidationError
-from mini_articraft.sdk.mesh import (
+from mini_articraft.sdk import (
     ArcPipeGeometry,
     BoxGeometry,
     CapsuleGeometry,
@@ -25,15 +25,23 @@ from mini_articraft.sdk.mesh import (
     SphereGeometry,
     SuperellipsoidGeometry,
     SweepGeometry,
-    SweepSection,
     TorusGeometry,
-    WirePath,
     WirePolylineGeometry,
+)
+from mini_articraft.sdk.mesh import (
+    LoftSection,
+    SectionLoftSpec,
+    ShellPartitionRegion,
+    ShellPartitionSpec,
+    SweepSection,
+    WirePath,
     boolean_difference,
     boolean_intersection,
     boolean_union,
     build123d_to_mesh,
     cut_opening_on_face,
+    partition_shell,
+    repair_loft,
     resample_side_sections,
     rounded_rect_profile,
     sample_arc_3d,
@@ -41,6 +49,7 @@ from mini_articraft.sdk.mesh import (
     sample_catmull_rom_spline_3d,
     sample_cubic_bezier_spline_2d,
     sample_cubic_bezier_spline_3d,
+    section_loft,
     split_superellipse_side_loft,
     superellipse_profile,
     superellipse_side_loft,
@@ -48,17 +57,6 @@ from mini_articraft.sdk.mesh import (
     tube_from_spline_points,
     tube_network_from_paths,
     wire_from_points,
-)
-from mini_articraft.sdk.section_loft import (
-    LoftSection,
-    SectionLoftSpec,
-    repair_loft,
-    section_loft,
-)
-from mini_articraft.sdk.shell_partition import (
-    ShellPartitionRegion,
-    ShellPartitionSpec,
-    partition_shell,
 )
 
 

--- a/tests/test_mesh_weld.py
+++ b/tests/test_mesh_weld.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mini_articraft.sdk import (
-    BoxGeometry,
-    CylinderGeometry,
+from mini_articraft.sdk import BoxGeometry, CylinderGeometry, SphereGeometry
+from mini_articraft.sdk.mesh import (
     SnapRefused,
-    SphereGeometry,
     boolean_difference,
     smooth_difference,
     snap_to,

--- a/tests/test_sdk_docs.py
+++ b/tests/test_sdk_docs.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 
 import mini_articraft.sdk as sdk
+import mini_articraft.sdk.mesh as sdk_mesh
 from mini_articraft import package_dir
 from mini_articraft.sdk import ArticulatedObject, TestReport
 
@@ -53,8 +54,16 @@ def test_every_public_sdk_symbol_is_documented() -> None:
         for path in sorted(sdk_docs.joinpath(folder).glob("*.md"))
     )
 
-    missing = sorted(name for name in sdk.__all__ if f"`{name}`" not in reference_text)
+    missing = sorted(
+        name for name in {*sdk.__all__, *sdk_mesh.__all__} if f"`{name}`" not in reference_text
+    )
     assert not missing
+
+
+def test_root_and_mesh_export_disjoint_surfaces() -> None:
+    """One canonical import path per category: geometry classes and the object
+    API at the root, mesh operations and recipes under ``mini_articraft.sdk.mesh``."""
+    assert set(sdk.__all__).isdisjoint(sdk_mesh.__all__)
 
 
 def test_key_apis_are_documented_by_their_owner_pages() -> None:


### PR DESCRIPTION
## Why

`mini_articraft.sdk` exported 66 names at the package root, and `mini_articraft.sdk.mesh` mirrored *most* — but not all — of the mesh half. Two consequences:

1. **For the model**: the docs are the interface. Two plausible paths for the same name means two patterns to imitate, and the incomplete mirror was an actual trap: `from mini_articraft.sdk.mesh import section_loft` was an ImportError, while `from mini_articraft.sdk import section_loft` worked. A model guessing the wrong one burned a turn and a compile cycle.
2. **For the reader**: with everything flat at the root, "what is the SDK" vs "what is the advanced mesh toolkit" was undiscoverable without reading five modules.

This PR assigns every public name to one category with one canonical path, and adds a test that keeps the two surfaces disjoint so they cannot drift back together.

The rule, stated in the `sdk/__init__.py` docstring:

- **Root** (31 names): object/articulation modeling, geometry classes, physical testing, errors.
- **`mini_articraft.sdk.mesh`** (35 names): mesh operations and repair recipes — booleans, welds, snapping, profile/wire sampling, sweep helpers, section lofts, shell partitioning, refinement.

No functions or classes were deleted; nothing was unused. Every moved name keeps working at its new home. No backward-compat aliases — this is a pre-1.0 reference, and aliases would defeat the point.

## Package surface

- **`sdk/__init__.py`** — root exports 66 → 31: `ArticulatedObject`, `Part`, `Articulation`, `ArticulationType`, `MotionLimits`, `Origin`; the 18 geometry classes; `TestContext`, `TestReport`, `TestFailure`, `AllowedOverlap`, `DistanceFinding`; `SDKError`, `ValidationError`. Geometry classes import directly from the owning private modules (`_mesh_core`, `_mesh_sweeps`).
- **`sdk/mesh.py`** — now the complete toolkit (35 names), newly including `section_loft`/`repair_loft`/`LoftSection`/`SectionLoftSpec` and `partition_shell`/`ShellPartitionRegion`/`ShellPartitionSpec`, which previously hung off the root only. The implementation modules are private (`_section_loft`, `_shell_partition`), so `mini_articraft.sdk.mesh` is the only public path for those recipes.

## Internal import direction

`_collision`, `object`, `_section_loft`, and `_shell_partition` each imported siblings *through* the `sdk.mesh` aggregator (e.g. `from mini_articraft.sdk.mesh import MeshGeometry`). The new layout made that a real circular import; they now import from the owning private modules (`_mesh_core`, `_mesh_boolean`). Leaf modules depending on the public aggregator was inverted regardless of this PR — the aggregator depends on the leaves, never the reverse.

## Agent-facing docs

The model writes code by imitating these pages, so they must teach canonical paths:

- **`mesh/10_profiles.md`, `30_section_lofts.md`, `50_refinement_and_smoothing.md`** — import examples switch wholesale to `from mini_articraft.sdk.mesh import ...`.
- **`mesh/20_wires_and_sweeps.md`, `40_booleans_and_shells.md`** — mixed pages split into two imports (classes from root, helpers from `sdk.mesh`); these are now the canonical illustration of the rule.
- **`mesh/00_mesh_geometry.md`** — only `build123d_to_mesh` moves to a `sdk.mesh` import; the geometry-class block stays at root by design.
- **`docs/examples/` (4 of 5 executable examples)** — same splits; a test executes these, and the model copies them verbatim.
- **Untouched, deliberately**: `common/00_quickstart.md` (preloaded every run) and the other `common/` pages — every name they use stayed at the root.

## Tests and guards

- `tests/test_mesh_sdk.py`, `test_mesh_weld.py`, `test_mesh_refinement.py`, `benchmarks/sdk_benchmark.py` — migrated to canonical paths (tests should demonstrate the paths we want copied).
- `tests/test_sdk_docs.py` — the doc-coverage guard now also checks `sdk.mesh.__all__`, and a new test asserts the root and mesh surfaces are **disjoint**. Without it, nothing stops the surfaces from re-merging over time.

## Verification

- `ruff format --check .`, `ruff check .`, `basedpyright` (0 errors), `pytest -q` — 322 passed.
- The committed tape (`tests/tapes/test_box_generation.jsonl`) replays unchanged — it only references root-stable names.

## Honest scope note

Token efficiency for the model is roughly neutral here (the model reads doc pages, not `__init__.py`; two pages gained a second import line). The reliability gain is real but modest: one imitable pattern, no incomplete-mirror trap, and docs mechanically pinned to the surface. The bigger model-facing wins are queued separately (producer-owned failure kinds; corpus curation).

## Deliberately not done

- No changes to what the SDK does — only to where names live.

