### PR TITLE
Classify test failures by producer-owned kinds, not prose substrings

### DIFF
--- a/src/mini_articraft/compile_feedback.py
+++ b/src/mini_articraft/compile_feedback.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
 
-from mini_articraft.sdk import TestReport
+from mini_articraft.sdk import FailureKind, TestReport
 
 Severity = Literal["failure", "warning", "note"]
 Status = Literal["success", "failure"]
@@ -196,10 +196,7 @@ def _signals_from_report(report: dict[str, Any]) -> list[CompileSignal]:
         _warning_signal(str(item)) for item in report.get("warnings", []) if str(item).strip()
     ]
     signals += [_allowance_signal(str(a)) for a in report.get("allowances", []) if str(a).strip()]
-    signals += [
-        _failure_signal(str(f["name"]), str(f.get("details") or ""))
-        for f in report.get("failures", [])
-    ]
+    signals += [_failure_signal(f) for f in report.get("failures", [])]
     return signals
 
 
@@ -274,98 +271,93 @@ def _warning_signal(text: str) -> CompileSignal:
     )
 
 
-def _failure_signal(name: str, details: str) -> CompileSignal:
-    lower = f"{name}\n{details}".lower()
-    if name == "check_model_valid":
-        return _failure(
-            "model_validity",
-            "QC_MODEL_VALIDITY",
-            "Compiler model validation failed.",
-            name,
-            details,
-            source="compiler",
-            group="build",
-        )
-    if name == "check_single_root_part":
-        return _failure(
-            "single_root_policy",
-            "QC_SINGLE_ROOT_POLICY",
-            "The model must have exactly one root part.",
-            name,
-            details,
-            source="compiler",
-            group="build",
-        )
-    if "missing exact geometry" in lower or "missing named geometry" in lower:
-        return _failure(
-            "missing_exact_geometry",
-            "TEST_MISSING_EXACT_GEOMETRY",
-            "A check references named geometry that is not present.",
-            name,
-            details,
-        )
-    if (
-        "disconnected geometry islands" not in lower
-        and "contact_tol=" in lower
-        and ("distance=" in lower or "min_distance=" in lower)
-    ):
-        return _failure(
-            "exact_contact_gap",
-            "TEST_EXACT_CONTACT_GAP",
-            "A contact check found a gap where contact was expected.",
-            name,
-            details,
-        )
-    if (
-        name in {"fail_if_isolated_parts", "fail_if_isolated_parts()"}
-        or name.startswith("fail_if_isolated_parts(")
-        or "isolated parts detected" in lower
-    ):
-        source = (
-            "compiler"
-            if name in {"fail_if_isolated_parts", "fail_if_isolated_parts()"}
-            else "tests"
-        )
-        code = "QC_ISOLATED_PART" if source == "compiler" else "TEST_ISOLATED_PART"
-        return _failure(
-            "isolated_part",
-            code,
-            "Floating or disconnected parts were found.",
-            name,
-            details,
-            source=source,
-        )
-    if any(
-        marker in lower
-        for marker in (
-            "part overlaps detected",
-            "collided=true",
-            "fail_if_parts_overlap",
-        )
-    ):
-        source = (
-            "compiler"
-            if name
-            in {
-                "fail_if_parts_overlap_in_current_pose()",
-            }
-            else "tests"
-        )
-        code = "QC_REAL_OVERLAP" if source == "compiler" else "TEST_REAL_OVERLAP"
-        return _failure(
-            "real_overlap",
-            code,
-            "A mesh check found overlapping parts.",
-            name,
-            details,
-            source=source,
-        )
-    return _failure(
+@dataclass(frozen=True)
+class _FailureSpec:
+    signal_kind: str
+    code_suffix: str
+    summary: str
+    compiler_summary: str | None = None
+    compiler_group: SignalGroup = "qc"
+
+
+# Failure semantics have one owner. Provenance only selects the QC/TEST code
+# prefix and the few compiler-specific presentation fields.
+_FAILURE_SPECS: dict[FailureKind, _FailureSpec] = {
+    FailureKind.MODEL_VALIDITY: _FailureSpec(
+        "model_validity",
+        "MODEL_VALIDITY",
+        "Model validation failed.",
+        compiler_summary="Compiler model validation failed.",
+        compiler_group="build",
+    ),
+    FailureKind.SINGLE_ROOT: _FailureSpec(
+        "single_root_policy",
+        "SINGLE_ROOT_POLICY",
+        "The model must have exactly one root part.",
+        compiler_group="build",
+    ),
+    FailureKind.ISOLATED_PART: _FailureSpec(
+        "isolated_part",
+        "ISOLATED_PART",
+        "Floating or disconnected parts were found.",
+    ),
+    FailureKind.DISCONNECTED_GEOMETRY: _FailureSpec(
+        "disconnected_geometry",
+        "DISCONNECTED_GEOMETRY",
+        "A part contains disconnected geometry islands.",
+    ),
+    FailureKind.OVERLAP: _FailureSpec(
+        "real_overlap",
+        "REAL_OVERLAP",
+        "A mesh check found overlapping parts.",
+    ),
+    FailureKind.CONTACT: _FailureSpec(
+        "exact_contact_gap",
+        "EXACT_CONTACT_GAP",
+        "A contact check found a gap where contact was expected.",
+    ),
+    FailureKind.ARTICULATION_SEPARATION: _FailureSpec(
+        "articulation_separation",
+        "ARTICULATION_SEPARATION",
+        "A hinge or pivot pulls its child away from its parent during motion.",
+    ),
+    FailureKind.AUTHORED: _FailureSpec(
         "test_failure",
-        "TEST_FAILURE",
-        f"Authored test failed: {name}",
+        "FAILURE",
+        "",
+    ),
+}
+
+
+def _failure_signal(failure: dict[str, Any]) -> CompileSignal:
+    name = str(failure["name"])
+    details = str(failure.get("details") or "")
+    try:
+        kind = FailureKind(str(failure.get("kind") or FailureKind.AUTHORED))
+    except ValueError:
+        kind = FailureKind.AUTHORED
+    source = str(failure.get("source") or "tests")
+    if source not in {"compiler", "tests"}:
+        source = "tests"
+    spec = _FAILURE_SPECS[kind]
+    compiler_owned = source == "compiler"
+    prefix = "QC" if compiler_owned else "TEST"
+    if kind is FailureKind.AUTHORED:
+        owner = "Compiler check" if compiler_owned else "Authored test"
+        summary = f"{owner} failed: {name}"
+    else:
+        summary = (
+            spec.compiler_summary if compiler_owned and spec.compiler_summary else spec.summary
+        )
+    group = spec.compiler_group if compiler_owned else "qc"
+    return _failure(
+        spec.signal_kind,
+        f"{prefix}_{spec.code_suffix}",
+        summary,
         name,
         details,
+        source=source,
+        group=group,
     )
 
 
@@ -528,6 +520,8 @@ def _primary_issue(signal: CompileSignal) -> str:
         "real_overlap": "mesh checks found overlapping parts that need classification.",
         "missing_exact_geometry": "a check references missing named geometry.",
         "exact_contact_gap": "a contact check found separation where contact was expected.",
+        "disconnected_geometry": "a part contains disconnected geometry islands.",
+        "articulation_separation": "an articulation separates its child part during motion.",
         "test_failure": "a required authored test failed.",
     }
     return issues.get(signal.kind, signal.summary)
@@ -576,6 +570,14 @@ def _rules(
     elif kind == "exact_contact_gap":
         rules = [
             "- This is a gap, not an overlap. Verify the tested pair, then repair its geometry or placement."
+        ]
+    elif kind == "disconnected_geometry":
+        rules = [
+            "- Move or extend the disconnected piece so its own body overlaps the nearest piece by a few mm -- overlap within a part is free and counts as connected. Do not add a separate bridging piece."
+        ]
+    elif kind == "articulation_separation":
+        rules = [
+            "- Place the articulation origin and axis so the child stays connected to the parent throughout the motion range."
         ]
     else:
         rules = ["- Fix the named failing check before adding more geometry or tests."]
@@ -638,6 +640,8 @@ def _signal_sort_key(signal: CompileSignal) -> tuple[int, int, str, str, str, st
         "model_validity": 1,
         "single_root_policy": 1,
         "isolated_part": 2 if signal.source == "compiler" else 6,
+        "disconnected_geometry": 2 if signal.source == "compiler" else 6,
+        "articulation_separation": 2 if signal.source == "compiler" else 6,
         "real_overlap": 2 if signal.source == "compiler" else 5,
         "missing_exact_geometry": 3,
         "exact_contact_gap": 4,

--- a/src/mini_articraft/environments/worker.py
+++ b/src/mini_articraft/environments/worker.py
@@ -11,7 +11,7 @@ import traceback
 from collections.abc import Hashable, Iterable
 from dataclasses import asdict, replace
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from mini_articraft.compile_feedback import build_compile_report_from_payload, empty_compile_payload
 from mini_articraft.environments.export import export_object
@@ -114,7 +114,10 @@ def _compile_workspace(
                 authored_report = _run_required_tests(globals_dict)
             baseline_report = _run_baseline_tests(object_model, authored_report, tracker=tracker)
             test_report = _merge_test_reports(authored_report, baseline_report)
-            payload["test_report"] = _serialize_test_report(test_report)
+            payload["test_report"] = _serialize_test_report(
+                test_report,
+                compiler_failure_names={failure.name for failure in baseline_report.failures},
+            )
             with tracker.phase("exporting and validating the USDZ file"):
                 result = export_object(object_model, export_dir)
             payload.update(
@@ -131,15 +134,16 @@ def _compile_workspace(
             }
         )
     except BaseException as exc:
-        test_report = getattr(exc, "test_report", None)
+        test_report = exc.test_report if isinstance(exc, TestReportError) else None
+        serialized_test_report = payload.get("test_report")
+        if serialized_test_report is None and isinstance(test_report, TestReport):
+            serialized_test_report = _serialize_test_report(test_report)
         payload.update(
             {
                 "status": "error",
                 "error": f"{type(exc).__name__}: {exc}",
                 "traceback": traceback.format_exc(),
-                "test_report": _serialize_test_report(test_report)
-                if isinstance(test_report, TestReport)
-                else payload.get("test_report"),
+                "test_report": serialized_test_report,
             }
         )
     finally:
@@ -209,6 +213,7 @@ def _run_baseline_tests(
 
 
 def _without_allowance_notes(report: TestReport) -> TestReport:
+    """Strip baseline-only allowance bookkeeping before reports are merged."""
     return replace(
         report,
         allowances=(),
@@ -255,22 +260,40 @@ def _ordered_unique(items: Iterable[T]) -> tuple[T, ...]:
     return tuple(unique)
 
 
+class TestReportError(ValueError):
+    """Raised when SDK checks fail; carries the failed report for the payload."""
+
+    def __init__(self, report: TestReport) -> None:
+        self.test_report = report
+        lines = ["SDK tests failed:"]
+        lines.extend(f"- {failure.name}: {failure.details}" for failure in report.failures[:10])
+        if len(report.failures) > 10:
+            lines.append(f"... ({len(report.failures) - 10} more)")
+        super().__init__("\n".join(lines))
+
+
 def _raise_for_failed_test_report(report: TestReport) -> None:
-    if report.passed:
-        return
-    lines = ["SDK tests failed:"]
-    lines.extend(f"- {failure.name}: {failure.details}" for failure in report.failures[:10])
-    if len(report.failures) > 10:
-        lines.append(f"... ({len(report.failures) - 10} more)")
-    exc = ValueError("\n".join(lines))
-    cast(Any, exc).test_report = report
-    raise exc
+    if not report.passed:
+        raise TestReportError(report)
 
 
-def _serialize_test_report(report: TestReport | None) -> dict[str, Any] | None:
+def _serialize_test_report(
+    report: TestReport | None,
+    *,
+    compiler_failure_names: set[str] | frozenset[str] = frozenset(),
+) -> dict[str, Any] | None:
     if report is None:
         return None
-    return _jsonable(asdict(report))
+    serialized = _jsonable(asdict(report))
+    for failure, serialized_failure in zip(
+        report.failures,
+        serialized["failures"],
+        strict=True,
+    ):
+        serialized_failure["source"] = (
+            "compiler" if failure.name in compiler_failure_names else "tests"
+        )
+    return serialized
 
 
 def _jsonable(value: Any) -> Any:

--- a/src/mini_articraft/sdk/__init__.py
+++ b/src/mini_articraft/sdk/__init__.py
@@ -44,6 +44,7 @@ from mini_articraft.sdk.object import ArticulatedObject, Part
 from mini_articraft.sdk.testing import (
     AllowedOverlap,
     DistanceFinding,
+    FailureKind,
     TestContext,
     TestFailure,
     TestReport,
@@ -63,6 +64,7 @@ __all__ = [
     "DomeGeometry",
     "ExtrudeGeometry",
     "ExtrudeWithHolesGeometry",
+    "FailureKind",
     "LatheGeometry",
     "LoftGeometry",
     "MeshGeometry",

--- a/src/mini_articraft/sdk/docs/common/40_testing.md
+++ b/src/mini_articraft/sdk/docs/common/40_testing.md
@@ -56,10 +56,15 @@ given part. A missing part or shape raises `ValidationError`.
 ### `TestFailure`
 
 ```python
-TestFailure(name: str, details: str)
+TestFailure(name: str, details: str, kind: FailureKind = FailureKind.AUTHORED)
 ```
 
-Each blocking failure has the recorded check name and a detail string.
+Each blocking failure has the recorded check name and a detail string. `kind` is a
+machine-readable `FailureKind` assigned by the check method (for example `OVERLAP`,
+`CONTACT`, or `ISOLATED_PART`); checks authored with `check()`/`fail()` always record
+`FailureKind.AUTHORED`. When the compile worker merges authored checks with its baseline,
+it adds `source="tests"` or `source="compiler"` to the serialized failure. Provenance is
+owned by that boundary rather than by model-authored test code.
 
 ### `AllowedOverlap`
 

--- a/src/mini_articraft/sdk/testing.py
+++ b/src/mini_articraft/sdk/testing.py
@@ -5,6 +5,7 @@ import statistics
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import ClassVar, cast
 
 from mini_articraft.errors import ValidationError
@@ -26,12 +27,32 @@ DEFAULT_OVERLAP_TOLERANCE = 0.005
 DEFAULT_OVERLAP_VOLUME_TOLERANCE = 5e-7
 
 
+class FailureKind(StrEnum):
+    """Machine-readable category of a recorded test failure.
+
+    The producer (the check method) assigns the kind when recording; consumers
+    such as the compile-signal pipeline map it directly to guidance instead of
+    re-classifying failure prose. Authored checks via ``check()``/``fail()``
+    always record ``AUTHORED``.
+    """
+
+    MODEL_VALIDITY = "model_validity"
+    SINGLE_ROOT = "single_root"
+    ISOLATED_PART = "isolated_part"
+    DISCONNECTED_GEOMETRY = "disconnected_geometry"
+    OVERLAP = "overlap"
+    CONTACT = "contact"
+    ARTICULATION_SEPARATION = "articulation_separation"
+    AUTHORED = "authored"
+
+
 @dataclass(frozen=True)
 class TestFailure:
     __test__: ClassVar[bool] = False
 
     name: str
     details: str
+    kind: FailureKind = FailureKind.AUTHORED
 
 
 @dataclass(frozen=True)
@@ -224,7 +245,9 @@ class TestContext:
     ) -> bool:
         query = self._collision_query(part_a, part_b, shape_a=shape_a, shape_b=shape_b)
         check_name = name or _check_name("expect_no_collision", query)
-        return self._record(check_name, not query.collided, _collision_details(query))
+        return self._record(
+            check_name, not query.collided, _collision_details(query), kind=FailureKind.OVERLAP
+        )
 
     def expect_collision(
         self,
@@ -237,7 +260,9 @@ class TestContext:
     ) -> bool:
         query = self._collision_query(part_a, part_b, shape_a=shape_a, shape_b=shape_b)
         check_name = name or _check_name("expect_collision", query)
-        return self._record(check_name, query.collided, _collision_details(query))
+        return self._record(
+            check_name, query.collided, _collision_details(query), kind=FailureKind.CONTACT
+        )
 
     def expect_contact(
         self,
@@ -256,6 +281,7 @@ class TestContext:
             check_name,
             result.collided or result.distance <= contact_tol,
             f"{_distance_details(result)} contact_tol={contact_tol:.6g}",
+            kind=FailureKind.CONTACT,
         )
 
     def expect_distance(
@@ -404,7 +430,12 @@ class TestContext:
         try:
             self.model.validate()
         except Exception as exc:
-            return self._record("check_model_valid", False, f"{type(exc).__name__}: {exc}")
+            return self._record(
+                "check_model_valid",
+                False,
+                f"{type(exc).__name__}: {exc}",
+                kind=FailureKind.MODEL_VALIDITY,
+            )
         return self._record("check_model_valid", True)
 
     def check_single_root_part(self) -> bool:
@@ -414,6 +445,7 @@ class TestContext:
                 "check_single_root_part",
                 False,
                 f"Expected exactly one root part, found {len(roots)}: {roots!r}",
+                kind=FailureKind.SINGLE_ROOT,
             )
         return self._record("check_single_root_part", True)
 
@@ -480,6 +512,7 @@ class TestContext:
             check_name,
             False,
             "Isolated parts detected (physically disconnected from the root):\n" + "\n".join(lines),
+            kind=FailureKind.ISOLATED_PART,
         )
 
     def fail_if_part_contains_disconnected_geometry_islands(
@@ -556,7 +589,7 @@ class TestContext:
             "child stays connected to the parent throughout its motion range:\n"
             + "\n".join(findings)
         )
-        return self._record(check_name, False, details)
+        return self._record(check_name, False, details, kind=FailureKind.ARTICULATION_SEPARATION)
 
     def warn_if_absurd_dimensions(
         self,
@@ -639,6 +672,7 @@ class TestContext:
             "Part overlaps detected "
             f"(overlap_tol={overlap_tol:.4g}, overlap_volume_tol={volume_tol:.4g}):\n"
             + "\n".join(details[:10]),
+            kind=FailureKind.OVERLAP,
         )
 
     def _check_disconnected_geometry(
@@ -663,7 +697,7 @@ class TestContext:
         if warn:
             self.warn(details)
             return self._record(check_name, True)
-        return self._record(check_name, False, details)
+        return self._record(check_name, False, details, kind=FailureKind.DISCONNECTED_GEOMETRY)
 
     def _collision_query(
         self,
@@ -715,11 +749,18 @@ class TestContext:
                 return True
         return False
 
-    def _record(self, name: str, ok: bool, details: str = "") -> bool:
+    def _record(
+        self,
+        name: str,
+        ok: bool,
+        details: str = "",
+        *,
+        kind: FailureKind = FailureKind.AUTHORED,
+    ) -> bool:
         self.checks_run += 1
         self._checks.append(name)
         if not ok:
-            self._failures.append(TestFailure(name=name, details=details))
+            self._failures.append(TestFailure(name=name, details=details, kind=kind))
         return ok
 
     def _kernel(self) -> MeshCollisionKernel:
@@ -890,6 +931,7 @@ def _overlap_rank(query: CollisionQuery) -> tuple[float, float]:
 __all__ = [
     "AllowedOverlap",
     "DistanceFinding",
+    "FailureKind",
     "TestContext",
     "TestFailure",
     "TestReport",

--- a/tests/test_articulation_motion.py
+++ b/tests/test_articulation_motion.py
@@ -4,6 +4,7 @@ from mini_articraft.sdk import (
     ArticulatedObject,
     ArticulationType,
     BoxGeometry,
+    FailureKind,
     MotionLimits,
     Origin,
     TestContext,
@@ -53,6 +54,7 @@ def test_separation_check_fails_a_lid_that_lifts_off() -> None:
     report = ctx.report()
     assert not report.passed
     assert "lid_hinge" in report.failures[0].details
+    assert report.failures[0].kind is FailureKind.ARTICULATION_SEPARATION
 
 
 def test_separation_check_ignores_prismatic_liftoff() -> None:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -14,7 +14,7 @@ from mini_articraft.environments.local import (
     LocalEnvironment,
     _run_isolated_process,
 )
-from mini_articraft.environments.worker import _merge_test_reports
+from mini_articraft.environments.worker import _merge_test_reports, _serialize_test_report
 from mini_articraft.record import Record, read_conversation
 from mini_articraft.sdk import TestFailure, TestReport
 
@@ -403,3 +403,23 @@ def test_merge_test_reports_keeps_distinct_same_named_authored_failures() -> Non
     merged = _merge_test_reports(authored, baseline)
 
     assert merged.failures == authored.failures
+
+
+def test_serialize_test_report_assigns_failure_provenance_at_worker_boundary() -> None:
+    report = TestReport(
+        passed=False,
+        checks_run=2,
+        checks=("authored", "baseline"),
+        failures=(
+            TestFailure("authored", "authored result"),
+            TestFailure("baseline", "compiler result"),
+        ),
+    )
+
+    serialized = _serialize_test_report(report, compiler_failure_names={"baseline"})
+
+    assert serialized is not None
+    assert [failure["source"] for failure in serialized["failures"]] == [
+        "tests",
+        "compiler",
+    ]

--- a/tests/test_compile_feedback.py
+++ b/tests/test_compile_feedback.py
@@ -1,20 +1,43 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+from typing import Any
+
 from mini_articraft.compile_feedback import (
     build_compile_report,
     compile_failure_signature,
     render_compile_report,
 )
-from mini_articraft.sdk import TestFailure, TestReport
+from mini_articraft.sdk import FailureKind, TestFailure, TestReport
 
 
-def _failing_report(*failures: TestFailure, warnings: tuple[str, ...] = ()) -> TestReport:
-    return TestReport(
-        passed=False,
-        checks_run=len(failures),
-        checks=tuple(failure.name for failure in failures),
-        failures=failures,
-        warnings=warnings,
+def _serialized_report(
+    report: TestReport,
+    *,
+    sources: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    serialized = asdict(report)
+    source_values = sources or ("tests",) * len(report.failures)
+    assert len(source_values) == len(report.failures)
+    for failure, source in zip(serialized["failures"], source_values, strict=True):
+        failure["source"] = source
+    return serialized
+
+
+def _failing_report(
+    *failures: TestFailure,
+    warnings: tuple[str, ...] = (),
+    sources: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    return _serialized_report(
+        TestReport(
+            passed=False,
+            checks_run=len(failures),
+            checks=tuple(failure.name for failure in failures),
+            failures=failures,
+            warnings=warnings,
+        ),
+        sources=sources,
     )
 
 
@@ -110,21 +133,25 @@ def test_compile_report_classifies_runtime_unknown_shape_as_missing_geometry() -
 
 
 def test_compile_report_maps_test_failures_warnings_and_allowances() -> None:
-    test_report = TestReport(
-        passed=False,
-        checks_run=3,
-        checks=("prompt check", "fail_if_parts_overlap_in_current_pose()"),
-        failures=(
-            TestFailure("prompt check", "missing handle"),
-            TestFailure(
-                "fail_if_parts_overlap_in_current_pose()",
-                "'drawer' vs 'frame': collided=True contacts=1",
+    test_report = _serialized_report(
+        TestReport(
+            passed=False,
+            checks_run=3,
+            checks=("prompt check", "fail_if_parts_overlap_in_current_pose()"),
+            failures=(
+                TestFailure("prompt check", "missing handle"),
+                TestFailure(
+                    "fail_if_parts_overlap_in_current_pose()",
+                    "'drawer' vs 'frame': collided=True contacts=1",
+                    kind=FailureKind.OVERLAP,
+                ),
+            ),
+            warnings=("thin wall",),
+            allowances=(
+                "allow_overlap('shaft', 'hub', shape_a='steel', shape_b='liner'): intentional capture",
             ),
         ),
-        warnings=("thin wall",),
-        allowances=(
-            "allow_overlap('shaft', 'hub', shape_a='steel', shape_b='liner'): intentional capture",
-        ),
+        sources=("tests", "compiler"),
     )
 
     report = build_compile_report(status="failure", test_report=test_report)
@@ -158,17 +185,17 @@ def test_compile_report_maps_disconnected_geometry_warning() -> None:
     assert signal["blocking"] is False
 
 
-def test_compile_report_classifies_named_geometry_contact_and_scale() -> None:
+def test_compile_report_classifies_contact_and_scale() -> None:
     test_report = TestReport(
         passed=False,
-        checks_run=2,
-        checks=("contact", "named shape"),
+        checks_run=1,
+        checks=("contact",),
         failures=(
             TestFailure(
                 "contact",
                 "'lid' vs 'body': distance=0.015 collided=False contact_tol=1e-06",
+                kind=FailureKind.CONTACT,
             ),
-            TestFailure("named shape", "missing exact geometry for shape_b='boss'"),
         ),
         warnings=("Scale warning:\nabsurd dimension: 'base'/'body' spans 2000m",),
     )
@@ -177,11 +204,10 @@ def test_compile_report_classifies_named_geometry_contact_and_scale() -> None:
     signals = report["signal_bundle"]["signals"]
 
     assert [signal["kind"] for signal in signals] == [
-        "missing_exact_geometry",
         "exact_contact_gap",
         "geometry_scale",
     ]
-    assert signals[2]["group"] == "design"
+    assert signals[1]["group"] == "design"
 
 
 def test_compile_failure_signature_and_rendering_are_stable() -> None:
@@ -220,6 +246,7 @@ def test_contact_gap_is_classified_as_a_gap_not_an_overlap() -> None:
             TestFailure(
                 name="expect_contact(base,lid)",
                 details="pair=('base','lid') distance=0.0032 collided=False contact_tol=0.001",
+                kind=FailureKind.CONTACT,
             )
         ),
     )
@@ -235,16 +262,27 @@ def test_compiler_owned_checks_keep_their_codes_and_sources() -> None:
     report = build_compile_report(
         status="failure",
         test_report=_failing_report(
-            TestFailure(name="check_model_valid", details="ValidationError: bad shape"),
+            TestFailure(
+                name="check_model_valid",
+                details="ValidationError: bad shape",
+                kind=FailureKind.MODEL_VALIDITY,
+            ),
             TestFailure(
                 name="check_single_root_part",
                 details="Expected exactly one root part, found 2: ['a', 'b']",
+                kind=FailureKind.SINGLE_ROOT,
             ),
-            TestFailure(name="fail_if_isolated_parts()", details="Isolated parts detected"),
+            TestFailure(
+                name="fail_if_isolated_parts()",
+                details="Isolated parts detected",
+                kind=FailureKind.ISOLATED_PART,
+            ),
             TestFailure(
                 name="fail_if_parts_overlap_in_current_pose()",
                 details="Part overlaps detected",
+                kind=FailureKind.OVERLAP,
             ),
+            sources=("compiler",) * 4,
         ),
     )
 
@@ -265,10 +303,12 @@ def test_authored_checks_with_the_same_findings_map_to_test_codes() -> None:
             TestFailure(
                 name="fail_if_isolated_parts(tight)",
                 details="isolated parts detected: ['antenna']",
+                kind=FailureKind.ISOLATED_PART,
             ),
             TestFailure(
                 name="expect_no_collision(base,lid)",
                 details="pair=('base','lid') collided=true overlap_volume=1e-6",
+                kind=FailureKind.OVERLAP,
             ),
         ),
     )
@@ -278,6 +318,68 @@ def test_authored_checks_with_the_same_findings_map_to_test_codes() -> None:
     assert kinds["isolated_part"]["source"] == "tests"
     assert kinds["real_overlap"]["code"] == "TEST_REAL_OVERLAP"
     assert kinds["real_overlap"]["source"] == "tests"
+
+
+def test_every_failure_kind_maps_to_a_specific_signal() -> None:
+    expected_kinds = {
+        FailureKind.MODEL_VALIDITY: "model_validity",
+        FailureKind.SINGLE_ROOT: "single_root_policy",
+        FailureKind.ISOLATED_PART: "isolated_part",
+        FailureKind.DISCONNECTED_GEOMETRY: "disconnected_geometry",
+        FailureKind.OVERLAP: "real_overlap",
+        FailureKind.CONTACT: "exact_contact_gap",
+        FailureKind.ARTICULATION_SEPARATION: "articulation_separation",
+        FailureKind.AUTHORED: "test_failure",
+    }
+    assert set(FailureKind) == set(expected_kinds)
+    for kind, signal_kind in expected_kinds.items():
+        for source, prefix in (("tests", "TEST"), ("compiler", "QC")):
+            report = build_compile_report(
+                status="failure",
+                test_report=_failing_report(
+                    TestFailure(name="some_check", details="d", kind=kind),
+                    sources=(source,),
+                ),
+            )
+            signal = report["signal_bundle"]["signals"][0]
+            assert signal["kind"] == signal_kind, (kind, source)
+            assert signal["code"].startswith(f"{prefix}_"), (kind, source)
+
+
+def test_new_kinds_carry_their_own_codes_and_guidance() -> None:
+    report = build_compile_report(
+        status="failure",
+        test_report=_failing_report(
+            TestFailure(
+                name="fail_if_part_contains_disconnected_geometry_islands(contact_tol=1e-06)",
+                details="Disconnected geometry islands detected",
+                kind=FailureKind.DISCONNECTED_GEOMETRY,
+            ),
+            TestFailure(
+                name="fail_if_articulation_separates_child(gap_tol=0.003)",
+                details="articulation='lid_hinge' rest_gap=0m max_gap=0.02m",
+                kind=FailureKind.ARTICULATION_SEPARATION,
+            ),
+            sources=("tests", "compiler"),
+        ),
+    )
+
+    by_kind = {s["kind"]: s for s in report["signal_bundle"]["signals"]}
+    assert by_kind["disconnected_geometry"]["code"] == "TEST_DISCONNECTED_GEOMETRY"
+    assert by_kind["articulation_separation"]["code"] == "QC_ARTICULATION_SEPARATION"
+    assert "throughout the motion range" in report["signals_text"]
+
+    disconnected_only = build_compile_report(
+        status="failure",
+        test_report=_failing_report(
+            TestFailure(
+                name="fail_if_part_contains_disconnected_geometry_islands(contact_tol=1e-06)",
+                details="Disconnected geometry islands detected",
+                kind=FailureKind.DISCONNECTED_GEOMETRY,
+            ),
+        ),
+    )
+    assert "overlaps the nearest piece" in disconnected_only["signals_text"]
 
 
 def test_invalid_run_tests_return_type_is_a_build_signal() -> None:

--- a/tests/test_testing_sdk.py
+++ b/tests/test_testing_sdk.py
@@ -9,6 +9,7 @@ from mini_articraft.sdk import (
     ArticulatedObject,
     ArticulationType,
     BoxGeometry,
+    FailureKind,
     MotionLimits,
     Origin,
     TestContext,
@@ -285,6 +286,55 @@ def test_disconnected_geometry_warns_by_default_and_can_be_authored_as_blocking(
     blocking_ctx = TestContext(model)
     assert not blocking_ctx.fail_if_part_contains_disconnected_geometry_islands()
     assert not blocking_ctx.report().passed
+    assert blocking_ctx.report().failures[0].kind is FailureKind.DISCONNECTED_GEOMETRY
+
+
+def test_failing_checks_record_machine_readable_kinds() -> None:
+    model = ArticulatedObject("kinds")
+    base = model.part("base")
+    add_box(base, "body")
+    lid = model.part("lid")
+    add_box(lid, "body")
+    fixed(model, "mount", base, lid, xyz=(0.0, 0.0, 0.98))
+
+    ctx = TestContext(model)
+    assert not ctx.fail_if_parts_overlap_in_current_pose()
+    assert not ctx.expect_no_collision("base", "lid")
+    assert not ctx.check("custom_check", False, "authored detail")
+    failures = ctx.report().failures
+    assert [failure.kind for failure in failures] == [
+        FailureKind.OVERLAP,
+        FailureKind.OVERLAP,
+        FailureKind.AUTHORED,
+    ]
+
+
+def test_contact_and_isolation_checks_record_kinds() -> None:
+    model = ArticulatedObject("gap_kinds")
+    base = model.part("base")
+    add_box(base, "body")
+    floating = model.part("floating")
+    add_box(floating, "body")
+    fixed(model, "mount", base, floating, xyz=(3.0, 0.0, 0.0))
+
+    ctx = TestContext(model)
+    assert not ctx.expect_contact("base", "floating")
+    assert not ctx.fail_if_isolated_parts()
+    failures = ctx.report().failures
+    assert [failure.kind for failure in failures] == [
+        FailureKind.CONTACT,
+        FailureKind.ISOLATED_PART,
+    ]
+
+
+def test_single_root_check_records_kind() -> None:
+    model = ArticulatedObject("two_roots")
+    add_box(model.part("a"), "body")
+    add_box(model.part("b"), "body")
+
+    ctx = TestContext(model)
+    assert not ctx.check_single_root_part()
+    assert ctx.report().failures[0].kind is FailureKind.SINGLE_ROOT
 
 
 def test_nested_solid_shapes_are_connected_geometry() -> None:


### PR DESCRIPTION
## Why

Stacked on #46 (sdk-surface clarification); only the tip commit is new.

`TestFailure` carried prose: a check `name` and a `details` string. To turn a failed compile into model guidance, `compile_feedback._failure_signal` re-classified that prose — matching check names against hardcoded sets and scanning detail strings for markers like `"contact_tol=" in lower`, `"collided=true"`, and `"part overlaps detected"`.

That is the wrong direction of knowledge flow, and it costs the agent loop directly: **a misclassified failure means the model gets the wrong repair guidance and burns turns.** Concretely, before this PR:

- A `fail_if_articulation_separates_child` failure (a lid floating off its hinge when opened) surfaced as `TEST_FAILURE` — "Authored test failed: fail_if_articulation_separates_child(...)" — with the generic "fix the named check" rule instead of hinge-placement guidance.
- A blocking `fail_if_part_contains_disconnected_geometry_islands` likewise collapsed into the generic bucket, even though the repo has precise repair advice for it (extend the piece so its own body overlaps; never bridge with a third piece).
- An authored test calling `ctx.check_model_valid()` was misattributed to the *compiler* (`QC_*`, build group) purely because of its name.
- `expect_collision` failures (expected contact, found a gap) were generic test failures, not contact gaps.

The fix: the producer is the only place that knows what failed, so the producer says it.

## Producer side: `sdk/testing.py`

- New `FailureKind` (StrEnum): `MODEL_VALIDITY`, `SINGLE_ROOT`, `ISOLATED_PART`, `DISCONNECTED_GEOMETRY`, `OVERLAP`, `CONTACT`, `ARTICULATION_SEPARATION`, `AUTHORED`.
- `TestFailure` gains `kind` (default `AUTHORED`). Every SDK check method passes its kind to `_record`. Authored `check()`/`fail()` cannot set a kind, so custom checks always degrade safely to `AUTHORED` — the name stays the human summary, exactly as today.
- `kind` serializes through `TestReport` (`asdict` + JSON, since `StrEnum` is a string); the worker adds provenance only at the serialized merge boundary.
- Deliberately absent: a `MISSING_GEOMETRY` kind. Missing named geometry *raises* (`ValidationError` out of the kernel) rather than recording a failure, and `_runtime_signal` already classifies that error text. Two producers for one concept would be worse, not better.

## The boundary: `environments/worker.py`

- The baseline QC suite and authored `run_tests()` use the same `TestContext` methods, so kind alone cannot attribute `QC_*` vs `TEST_*` codes. The worker — the only component that knows which side ran — adds `source="compiler"` or `source="tests"` while serializing the merged report. `source` is not caller-controlled SDK state.
- Also replaced the monkey-patched `cast(Any, exc).test_report` with a typed `TestReportError(ValueError)` carrying the report. Same error text shape, no type-checker dodge.

## Consumer side: `compile_feedback.py`

- The whole substring classifier is gone, replaced by one auditable `FailureKind -> signal spec` table. Trusted worker provenance derives the `QC_`/`TEST_` prefix and compiler-specific presentation, so every kind/source combination is exhaustive without duplicating the table.
- New precise codes and guidance where the generic bucket used to be: `QC_/TEST_ARTICULATION_SEPARATION` ("place the articulation origin and axis so the child stays connected throughout the motion range") and `QC_/TEST_DISCONNECTED_GEOMETRY` (the extend-to-overlap repair rule, mirroring the existing warning guidance). `expect_collision` now classifies as `TEST_EXACT_CONTACT_GAP`, which is what it is.
- `_primary_issue`, `_rules`, and failure sort priorities gained entries for the two new signal kinds (compiler-owned structural failures still sort ahead of authored ones).

## What did not change (pinned)

Every code the scenario tests assert end-to-end — `QC_REAL_OVERLAP`, `TEST_REAL_OVERLAP`, `QC_/TEST_ISOLATED_PART`, `QC_MODEL_VALIDITY`, `QC_SINGLE_ROOT_POLICY`, `TEST_EXACT_CONTACT_GAP`, `NOTE_ALLOWED_OVERLAP` — is byte-identical. Warning and allowance classification (stable SDK-authored headline text) is untouched; kind-ifying warnings would churn `TestReport.warnings`'s shape for no signal-accuracy gain.

## Tests

- `test_testing_sdk.py` / `test_articulation_motion.py` — new producer tests assert each check records the right kind, so kinds cannot silently regress to `AUTHORED`.
- `test_compile_feedback.py` — serialized fixtures carry boundary-owned provenance; the completeness test covers every `FailureKind` for both compiler and authored sources, including compiler-owned contact failures; new-code guidance is pinned.
- `docs/common/40_testing.md` documents `FailureKind` and the worker-owned provenance boundary (the docs guard requires it; the model reads this page).

## Verification

- `ruff format --check .`, `ruff check .`, `basedpyright` (0 errors), `pytest -q --replay` — 328 passed.
- Investigated a live (non-replay) `test_box_generation` failure during development: transcript showed an ordinary model fumble plus heavy doc-reading exhausting the scenario's 10-turn cap — live-model variance against a tight cap, not a regression (the failing compile classified identically before and after).

## Deliberately not done

- Warning/allowance signals keep text classification (see above).
- No `Agent.stream()`, no registry of kinds — one enum, one table.

