### PR TITLE
Make the SDK a leaf import boundary

### DIFF
--- a/src/mini_articraft/errors.py
+++ b/src/mini_articraft/errors.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-
-class MiniArticraftError(Exception):
-    """Base error for mini-articraft."""
-
-
-class SDKError(MiniArticraftError):
-    """Base error for the mini-articraft SDK."""
-
-
-class ValidationError(SDKError):
-    """Raised when an articulated object definition is invalid."""
+from mini_articraft.sdk.errors import MiniArticraftError, SDKError, ValidationError
 
 
 class ModelError(MiniArticraftError):
     """Raised when the model response cannot be used."""
+
+
+__all__ = ["MiniArticraftError", "ModelError", "SDKError", "ValidationError"]

--- a/src/mini_articraft/sdk/__init__.py
+++ b/src/mini_articraft/sdk/__init__.py
@@ -11,7 +11,6 @@ One canonical import path per category:
 
 from __future__ import annotations
 
-from mini_articraft.errors import SDKError, ValidationError
 from mini_articraft.sdk._mesh_core import (
     BoxGeometry,
     CapsuleGeometry,
@@ -34,6 +33,7 @@ from mini_articraft.sdk._mesh_sweeps import (
     SweepGeometry,
     WirePolylineGeometry,
 )
+from mini_articraft.sdk.errors import SDKError, ValidationError
 from mini_articraft.sdk.joints import (
     Articulation,
     ArticulationType,

--- a/src/mini_articraft/sdk/_collision.py
+++ b/src/mini_articraft/sdk/_collision.py
@@ -10,8 +10,8 @@ import numpy as np
 import trimesh
 from build123d.topology import Shape
 
-from mini_articraft.errors import ValidationError
 from mini_articraft.sdk._mesh_core import MeshGeometry
+from mini_articraft.sdk.errors import ValidationError
 from mini_articraft.sdk.joints import Articulation, ArticulationType, Origin
 from mini_articraft.sdk.object import ArticulatedObject, Geometry
 

--- a/src/mini_articraft/sdk/_mesh_core.py
+++ b/src/mini_articraft/sdk/_mesh_core.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, SupportsIndex, TypeAlias, cast
 import numpy as np
 import trimesh
 
-from mini_articraft.errors import ValidationError
+from mini_articraft.sdk.errors import ValidationError
 
 if TYPE_CHECKING:
     from build123d.topology import Shape

--- a/src/mini_articraft/sdk/_section_loft.py
+++ b/src/mini_articraft/sdk/_section_loft.py
@@ -8,7 +8,6 @@ from typing import Literal, cast
 import numpy as np
 import trimesh
 
-from mini_articraft.errors import ValidationError
 from mini_articraft.sdk._mesh_boolean import boolean_union
 from mini_articraft.sdk._mesh_core import LoftGeometry, MeshGeometry
 from mini_articraft.sdk._mesh_sweeps import (
@@ -16,6 +15,7 @@ from mini_articraft.sdk._mesh_sweeps import (
     _path_frames,
     _validated_up_hint,
 )
+from mini_articraft.sdk.errors import ValidationError
 
 Vec3 = tuple[float, float, float]
 RepairMode = Literal["off", "mesh"]

--- a/src/mini_articraft/sdk/_shell_partition.py
+++ b/src/mini_articraft/sdk/_shell_partition.py
@@ -4,9 +4,9 @@ import math
 from dataclasses import dataclass, replace
 from typing import Any, Literal, cast
 
-from mini_articraft.errors import ValidationError
 from mini_articraft.sdk._mesh_boolean import boolean_difference, boolean_intersection
 from mini_articraft.sdk._mesh_core import BoxGeometry, MeshGeometry
+from mini_articraft.sdk.errors import ValidationError
 
 ShellSide = Literal["full", "left", "right", "center"]
 

--- a/src/mini_articraft/sdk/errors.py
+++ b/src/mini_articraft/sdk/errors.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class MiniArticraftError(Exception):
+    """Base error for mini-articraft."""
+
+
+class SDKError(MiniArticraftError):
+    """Base error for the mini-articraft SDK."""
+
+
+class ValidationError(SDKError):
+    """Raised when an articulated object definition is invalid."""

--- a/src/mini_articraft/sdk/joints.py
+++ b/src/mini_articraft/sdk/joints.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TypeAlias, cast
 
-from mini_articraft.errors import ValidationError
+from mini_articraft.sdk.errors import ValidationError
 
 Vec3: TypeAlias = tuple[float, float, float]
 

--- a/src/mini_articraft/sdk/object.py
+++ b/src/mini_articraft/sdk/object.py
@@ -7,8 +7,8 @@ from typing import TypeAlias
 
 from build123d.topology import Shape
 
-from mini_articraft.errors import ValidationError
 from mini_articraft.sdk._mesh_core import MeshGeometry
+from mini_articraft.sdk.errors import ValidationError
 from mini_articraft.sdk.joints import (
     Articulation,
     ArticulationType,

--- a/src/mini_articraft/sdk/testing.py
+++ b/src/mini_articraft/sdk/testing.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import ClassVar, cast
 
-from mini_articraft.errors import ValidationError
 from mini_articraft.sdk._collision import (
     Bounds,
     CollisionQuery,
@@ -18,6 +17,7 @@ from mini_articraft.sdk._collision import (
     Vec3,
     _pair_key,
 )
+from mini_articraft.sdk.errors import ValidationError
 from mini_articraft.sdk.joints import Articulation, ArticulationType
 from mini_articraft.sdk.object import ArticulatedObject, Part, PartRef
 

--- a/tests/test_sdk_docs.py
+++ b/tests/test_sdk_docs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 import runpy
 import tomllib
@@ -8,7 +9,9 @@ from pathlib import Path
 import mini_articraft.sdk as sdk
 import mini_articraft.sdk.mesh as sdk_mesh
 from mini_articraft import package_dir
+from mini_articraft.errors import MiniArticraftError
 from mini_articraft.sdk import ArticulatedObject, TestReport
+from mini_articraft.sdk.errors import SDKError, ValidationError
 
 
 def detailed_reference_paths(sdk_docs: Path) -> list[str]:
@@ -64,6 +67,33 @@ def test_root_and_mesh_export_disjoint_surfaces() -> None:
     """One canonical import path per category: geometry classes and the object
     API at the root, mesh operations and recipes under ``mini_articraft.sdk.mesh``."""
     assert set(sdk.__all__).isdisjoint(sdk_mesh.__all__)
+
+
+def test_sdk_is_a_leaf_package_with_compatible_errors() -> None:
+    sdk_root = package_dir / "sdk"
+    outside_imports: list[tuple[str, str]] = []
+
+    for path in sdk_root.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                modules = [node.module]
+            else:
+                continue
+            outside_imports.extend(
+                (path.name, module)
+                for module in modules
+                if module.startswith("mini_articraft.")
+                and not module.startswith("mini_articraft.sdk")
+            )
+
+    assert not outside_imports
+    assert sdk.SDKError is SDKError
+    assert sdk.ValidationError is ValidationError
+    assert issubclass(ValidationError, SDKError)
+    assert issubclass(SDKError, MiniArticraftError)
 
 
 def test_key_apis_are_documented_by_their_owner_pages() -> None:


### PR DESCRIPTION
## Summary
- move SDK errors under mini_articraft.sdk while preserving compatibility imports and exception identities
- keep SDK implementation imports inside the SDK package
- add a source-level import-direction contract test

## Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest -q tests/test_sdk_docs.py tests/test_sdk.py tests/test_testing_sdk.py

Stacked on #47.