### PR TITLE
Make USDZ export a public SDK capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,20 @@ jobs:
           assert (package_dir / 'viewer.html').is_file()
           assert (package_dir / 'sdk' / 'docs' / 'common' / '00_quickstart.md').is_file()
           "
+          mkdir -p /tmp/sdk-smoke
+          cp examples/hinged_box/main.py /tmp/sdk-smoke/main.py
+          /tmp/smoke/bin/python -c "
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, '/tmp/sdk-smoke')
+          from main import object_model, run_tests
+          from mini_articraft.sdk.export import export_object
+          object_model.validate()
+          assert run_tests().passed
+          result = export_object(object_model, Path('/tmp/sdk-smoke/output'))
+          assert result.manifest.is_file()
+          assert result.usdz.is_file()
+          "
           mkdir -p /tmp/smoke-run/workspace /tmp/smoke-run/result
           cp examples/mesh_knob/main.py /tmp/smoke-run/workspace/main.py
           /tmp/smoke/bin/python -m mini_articraft.environments.worker /tmp/smoke-run > /tmp/smoke-out.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,38 @@ uv run python benchmarks/sdk_benchmark.py --suite extended
 
 See [benchmarks/README.md](benchmarks/README.md) for saved comparisons and smaller suites.
 
+## Use the Python SDK
+
+Add mini-articraft directly from GitHub while the package is pre-release:
+
+```bash
+uv add "mini-articraft @ git+https://github.com/mattzh72/mini-articraft"
+```
+
+The root SDK owns object modeling, geometry, articulations, and physical checks. Mesh operations
+live in `mini_articraft.sdk.mesh`; USDZ publication is explicit so a normal SDK import does not
+eagerly load OpenUSD.
+
+```python
+from build123d import Box
+
+from mini_articraft.sdk import ArticulatedObject, TestContext
+from mini_articraft.sdk.export import export_object
+
+model = ArticulatedObject("box")
+model.part("body").add(Box(0.1, 0.1, 0.1), name="shell")
+model.validate()
+
+report = TestContext(model).report()
+assert report.passed
+
+result = export_object(model, "output")
+print(result.usdz)
+```
+
+See the [hinged box](examples/hinged_box/main.py) and
+[procedural mesh knob](examples/mesh_knob/main.py) for complete examples.
+
 ## Run
 
 Generate a model:

--- a/src/mini_articraft/environments/worker.py
+++ b/src/mini_articraft/environments/worker.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from mini_articraft.compile_feedback import build_compile_report_from_payload, empty_compile_payload
-from mini_articraft.environments.export import export_object
 from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+from mini_articraft.sdk.export import export_object
 
 T = TypeVar("T", bound=Hashable)
 _COMPILE_PROGRESS_FILE = ".compile-progress.json"

--- a/src/mini_articraft/sdk/__init__.py
+++ b/src/mini_articraft/sdk/__init__.py
@@ -7,6 +7,8 @@ One canonical import path per category:
 - Advanced mesh authoring and repair recipes (booleans, welds, snapping,
   profile/wire sampling, sweep helpers, section lofts, shell partitioning,
   refinement) live under ``mini_articraft.sdk.mesh``.
+- USDZ publication lives under ``mini_articraft.sdk.export`` so importing the
+  root SDK does not eagerly load OpenUSD.
 """
 
 from __future__ import annotations

--- a/src/mini_articraft/sdk/docs/common/50_usdz_export.md
+++ b/src/mini_articraft/sdk/docs/common/50_usdz_export.md
@@ -2,8 +2,20 @@
 
 The compile worker exports one USDZ package after it runs the authored tests and compiler owned
 checks. It saves the package when the object can be exported, even if a check fails. In an agent
-run, use the `compile` tool. Do not call an environment export helper from `main.py`, because that
+run, use the `compile` tool. Do not call `export_object` from generated `main.py`, because that
 would bypass the compiler owned checks and publication rules.
+
+Code using mini-articraft as a regular Python SDK can export directly:
+
+```python
+from mini_articraft.sdk.export import export_object
+
+result = export_object(object_model, "output")
+print(result.usdz)
+```
+
+The explicit `mini_articraft.sdk.export` import keeps the OpenUSD dependency out of a plain
+`mini_articraft.sdk` import until export is requested.
 
 The exporter validates the object and tessellates build123d shapes with a default tolerance of
 `0.001` meter.

--- a/src/mini_articraft/sdk/export.py
+++ b/src/mini_articraft/sdk/export.py
@@ -1,3 +1,5 @@
+"""Publish articulated objects as validated USDZ packages."""
+
 from __future__ import annotations
 
 import json
@@ -14,6 +16,8 @@ from mini_articraft.sdk._collision import MeshCollisionKernel, _geometry_to_mesh
 from mini_articraft.sdk.joints import Articulation, ArticulationType, MotionLimits
 from mini_articraft.sdk.object import ArticulatedObject, Geometry
 from mini_articraft.sdk.testing import DEFAULT_MESH_TOLERANCE
+
+__all__ = ["ExportResult", "export_object"]
 
 
 @dataclass(frozen=True)

--- a/tests/test_sdk_export.py
+++ b/tests/test_sdk_export.py
@@ -7,8 +7,7 @@ import pytest
 from build123d import Box, Pos
 from pxr import Gf, Usd, UsdGeom, UsdPhysics, UsdValidation
 
-import mini_articraft.environments.export as export_module
-from mini_articraft.environments.export import export_object
+import mini_articraft.sdk.export as export_module
 from mini_articraft.sdk import (
     ArticulatedObject,
     ArticulationType,
@@ -16,6 +15,7 @@ from mini_articraft.sdk import (
     MotionLimits,
     Origin,
 )
+from mini_articraft.sdk.export import export_object
 
 
 def test_export_writes_rigid_part_bodies_and_named_child_meshes(tmp_path) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -10,8 +10,8 @@ from typing import Any, cast
 import pytest
 from build123d import Box
 
-from mini_articraft.environments.export import export_object
 from mini_articraft.sdk import ArticulatedObject, ArticulationType, MotionLimits, Origin
+from mini_articraft.sdk.export import export_object
 from mini_articraft.viewer import _handler, load_viewer_run
 
 


### PR DESCRIPTION
## Summary
- move USDZ publication from environments.export to the explicit mini_articraft.sdk.export surface
- document a normal installed-library author, test, and export flow
- extend the wheel smoke to exercise that public consumer path

## Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest -q tests/test_sdk_export.py tests/test_viewer.py tests/test_examples.py tests/test_sdk_docs.py

Stacked on Make the SDK a leaf import boundary.