### PR TITLE
Harden installed worker process boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,13 @@ jobs:
           assert result.manifest.is_file()
           assert result.usdz.is_file()
           "
-          mkdir -p /tmp/smoke-run/workspace /tmp/smoke-run/result
-          cp examples/mesh_knob/main.py /tmp/smoke-run/workspace/main.py
-          /tmp/smoke/bin/python -m mini_articraft.environments.worker /tmp/smoke-run > /tmp/smoke-out.json
           /tmp/smoke/bin/python -c "
-          import json
-          payload = json.load(open('/tmp/smoke-out.json'))
+          import shutil
+          from pathlib import Path
+          from mini_articraft.environments import LocalEnvironment
+          env = LocalEnvironment(output_dir=Path('/tmp'))
+          run_dir = env.create_run('smoke-run')
+          shutil.copyfile('examples/mesh_knob/main.py', run_dir / 'workspace' / 'main.py')
+          payload = env.compile_path(run_dir)
           assert payload['status'] == 'success', payload
           "

--- a/src/mini_articraft/_child_process.py
+++ b/src/mini_articraft/_child_process.py
@@ -1,0 +1,19 @@
+"""Environment hygiene for processes that run model-authored code."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+
+def child_environment(overrides: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Copy the host environment without API credentials.
+
+    This keeps model-authored code from receiving provider credentials by
+    default. It is hygiene, not isolation: child processes still run with the
+    user's OS identity and inherit the remaining environment.
+    """
+    env = {key: value for key, value in os.environ.items() if not key.endswith("_API_KEY")}
+    if overrides:
+        env.update(overrides)
+    return env

--- a/src/mini_articraft/_child_process.py
+++ b/src/mini_articraft/_child_process.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
 
 
-def child_environment(overrides: Mapping[str, str] | None = None) -> dict[str, str]:
+def child_environment() -> dict[str, str]:
     """Copy the host environment without API credentials.
 
     This keeps model-authored code from receiving provider credentials by
     default. It is hygiene, not isolation: child processes still run with the
     user's OS identity and inherit the remaining environment.
     """
-    env = {key: value for key, value in os.environ.items() if not key.endswith("_API_KEY")}
-    if overrides:
-        env.update(overrides)
-    return env
+    return {key: value for key, value in os.environ.items() if not key.endswith("_API_KEY")}

--- a/src/mini_articraft/agent/tools/_exec.py
+++ b/src/mini_articraft/agent/tools/_exec.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from mini_articraft._child_process import child_environment
 from mini_articraft.agent.tools._paths import scoped_path
 
 DEFAULT_YIELD_TIME_MS = 10_000
@@ -326,7 +327,7 @@ def _cwd(workspace: Path, raw: object) -> Path:
 
 
 def _env(run_dir: Path, workspace: Path, shell: str) -> dict[str, str]:
-    env = os.environ.copy()
+    env = child_environment()
     env.setdefault("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
     env["SHELL"] = shell
     env["MINI_ARTICRAFT_RUN_DIR"] = str(run_dir)

--- a/src/mini_articraft/environments/local.py
+++ b/src/mini_articraft/environments/local.py
@@ -13,6 +13,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from mini_articraft import package_dir
+from mini_articraft._child_process import child_environment
 from mini_articraft.compile_feedback import build_compile_report_from_payload, empty_compile_payload
 from mini_articraft.record import Record
 from mini_articraft.settings import DEFAULT_COMPILE_TIMEOUT_SECONDS, DEFAULT_OUTPUT_DIR
@@ -86,7 +87,7 @@ class LocalEnvironment:
         ]
         completed = _run_isolated_process(
             args,
-            cwd=_project_root(),
+            cwd=run_dir.resolve(),
             timeout_seconds=self.config.timeout_seconds,
         )
         compile_stats = _read_compile_progress(run_dir)
@@ -149,10 +150,6 @@ def _validate_run_id(run_id: str) -> str:
     return value
 
 
-def _project_root() -> Path:
-    return Path(__file__).resolve().parents[3]
-
-
 def _link_sdk_docs(workspace: Path) -> None:
     docs_dir = workspace / "docs"
     docs_dir.mkdir()
@@ -176,6 +173,7 @@ def _run_isolated_process(
     proc = subprocess.Popen(
         args,
         cwd=cwd,
+        env=child_environment(),
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import os
 import shlex
@@ -273,6 +274,26 @@ def test_exec_command_reports_output_and_return_code(tmp_path) -> None:
     assert result["session_id"] is None
     assert result["running"] is False
     assert not ctx.run_dir.joinpath(".tmp").exists()
+
+
+def test_exec_command_does_not_receive_api_credentials(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setenv("EXAMPLE_API_KEY", "example-secret")
+    monkeypatch.setenv("VISIBLE_SETTING", "visible")
+    ctx = context(tmp_path)
+    command = (
+        f"{shlex.quote(sys.executable)} -c "
+        "'import json, os; print(json.dumps({key: os.environ.get(key) for key in "
+        '["OPENAI_API_KEY", "EXAMPLE_API_KEY", "VISIBLE_SETTING"]}))\''
+    )
+
+    result = run(get("exec_command").run(ctx, {"command": command}))
+
+    assert json.loads(result["stdout"]) == {
+        "OPENAI_API_KEY": None,
+        "EXAMPLE_API_KEY": None,
+        "VISIBLE_SETTING": "visible",
+    }
 
 
 def test_exec_command_reports_timeout(tmp_path) -> None:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+import mini_articraft.environments.local as local_module
 from mini_articraft.environments.local import (
     DEFAULT_MAIN_PY,
     LocalEnvironment,
@@ -164,6 +165,67 @@ def run_tests() -> TestReport:
     )
 
     assert env.compile_path(run_dir)["status"] == "success"
+
+
+def test_compile_worker_runs_from_run_dir_without_api_credentials(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setenv("EXAMPLE_API_KEY", "example-secret")
+    monkeypatch.setenv("VISIBLE_SETTING", "visible")
+    env = LocalEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("worker-boundary")
+    write_main(
+        run_dir,
+        """import json
+import os
+from pathlib import Path
+from build123d import Box
+from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+
+Path("worker-boundary.json").write_text(json.dumps({
+    "cwd": str(Path.cwd()),
+    "openai": os.environ.get("OPENAI_API_KEY"),
+    "example": os.environ.get("EXAMPLE_API_KEY"),
+    "visible": os.environ.get("VISIBLE_SETTING"),
+}), encoding="utf-8")
+object_model = ArticulatedObject("boundary")
+object_model.part("body").add(Box(0.1, 0.1, 0.1), name="shell")
+
+def run_tests() -> TestReport:
+    return TestContext(object_model).report()
+""",
+    )
+
+    result = env.compile_path(run_dir)
+    assert result["status"] == "success", result
+    child = json.loads(
+        run_dir.joinpath("workspace", "worker-boundary.json").read_text(encoding="utf-8")
+    )
+
+    assert child == {
+        "cwd": str(run_dir.joinpath("workspace").resolve()),
+        "openai": None,
+        "example": None,
+        "visible": "visible",
+    }
+
+
+def test_local_environment_starts_worker_from_run_dir(monkeypatch, tmp_path) -> None:
+    env = LocalEnvironment(output_dir=tmp_path)
+    run_dir = env.create_run("worker-cwd")
+    captured: dict[str, Path] = {}
+
+    def run_worker(args, *, cwd, timeout_seconds):
+        captured["cwd"] = cwd
+        return local_module._ProcessResult(
+            stdout=json.dumps({"status": "success"}),
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(local_module, "_run_isolated_process", run_worker)
+
+    assert env._run_worker(run_dir)["status"] == "success"
+    assert captured["cwd"] == run_dir.resolve()
 
 
 def test_create_run_requires_a_new_simple_run_id(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- launch compile workers from the run directory so installed wheels do not depend on checkout layout
- remove API credentials from compile and exec child environments while preserving ordinary settings
- exercise LocalEnvironment through the clean-wheel CI smoke

Environment filtering is credential hygiene, not a sandbox.

## Verification
- uv run ruff format --check .
- uv run ruff check .
- focused compile and exec child-process tests

Stacked on Make USDZ export a public SDK capability.