### PR TITLE
Add optional texture CLI postprocessing

### DIFF
--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -76,18 +76,15 @@ def generate(
     settings = _settings(provider, model, output_dir, reasoning_effort, compile_timeout)
     use_tui = tui if tui is not None else sys.stdout.isatty()
     try:
-        result = (
-            _generate_with_tui(settings, prompt, image)
-            if use_tui
-            else asyncio.run(_generate(settings, prompt, image_path=image))
+        result = _run_generation(
+            settings,
+            prompt,
+            image,
+            use_tui=use_tui,
         )
-        success = str(result.get("status")) == "success"
-        if success and textures:
+        if textures:
             _apply_textures(result)
-        if use_tui:
-            if not success:
-                raise typer.Exit(1)
-        else:
+        if not use_tui:
             _print_result(result)
     except (OSError, ValueError) as exc:
         typer.echo(str(exc), err=True)
@@ -181,9 +178,21 @@ async def _generate(
         await model_client.close()
 
 
+def _run_generation(
+    settings: Settings,
+    prompt: str,
+    image_path: Path | None,
+    *,
+    use_tui: bool,
+) -> dict[str, Any]:
+    if use_tui:
+        return _generate_with_tui(settings, prompt, image_path)
+    return asyncio.run(_generate(settings, prompt, image_path=image_path))
+
+
 def _generate_with_tui(settings: Settings, prompt: str, image_path: Path | None) -> dict[str, Any]:
     try:
-        return run_live(
+        result = run_live(
             lambda on_event: _generate(
                 settings,
                 prompt,
@@ -193,6 +202,9 @@ def _generate_with_tui(settings: Settings, prompt: str, image_path: Path | None)
         )
     except (KeyboardInterrupt, asyncio.CancelledError):
         raise typer.Exit(130) from None
+    if str(result.get("status")) != "success":
+        raise typer.Exit(1)
+    return result
 
 
 def _apply_textures(result: dict[str, Any]) -> None:
@@ -201,6 +213,8 @@ def _apply_textures(result: dict[str, Any]) -> None:
     A failure keeps the parametric result and does not change generation status.
     """
 
+    if str(result.get("status")) != "success":
+        return
     run = result.get("run")
     if not run:
         return

--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from mini_articraft.agent import Agent, events
 from mini_articraft.cli.tui import print_settings_error, replay_run, run_live
 from mini_articraft.environments import LocalEnvironment
+from mini_articraft.environments.worker import texture_run
 from mini_articraft.models import create_model
 from mini_articraft.models.anthropic import SUPPORTED_MODELS as ANTHROPIC_MODELS
 from mini_articraft.models.anthropic import anthropic_api_key_value
@@ -25,7 +26,7 @@ from mini_articraft.settings import DEFAULT_OUTPUT_DIR, Settings, get_settings
 from mini_articraft.viewer import serve_viewer
 
 app = typer.Typer(help="Generate articulated objects with mini-articraft.", add_completion=False)
-COMMANDS = {"generate", "replay", "view"}
+COMMANDS = {"generate", "replay", "view", "texture"}
 
 
 @app.command()
@@ -65,15 +66,29 @@ def generate(
         "--tui/--no-tui",
         help="Show the live run UI (default: on when attached to a terminal).",
     ),
+    textures: bool = typer.Option(
+        False,
+        "--textures",
+        help="Apply texture maps to the generated result.",
+    ),
 ) -> None:
     """Generate an object from a prompt."""
     settings = _settings(provider, model, output_dir, reasoning_effort, compile_timeout)
     use_tui = tui if tui is not None else sys.stdout.isatty()
     try:
-        if use_tui:
+        result = (
             _generate_with_tui(settings, prompt, image)
+            if use_tui
+            else asyncio.run(_generate(settings, prompt, image_path=image))
+        )
+        success = str(result.get("status")) == "success"
+        if success and textures:
+            _apply_textures(result)
+        if use_tui:
+            if not success:
+                raise typer.Exit(1)
         else:
-            _print_result(asyncio.run(_generate(settings, prompt, image_path=image)))
+            _print_result(result)
     except (OSError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from None
@@ -112,6 +127,37 @@ def view(
         raise typer.Exit(1) from None
 
 
+@app.command()
+def texture(
+    run: str = typer.Argument(
+        ..., help="Run id under the output directory, or a path to a run directory."
+    ),
+    output_dir: Path | None = typer.Option(None, "--output-dir", help="Run output directory."),
+) -> None:
+    """Apply texture maps to an already-generated run.
+
+    Re-exports the run's result with texture maps, so generation can stay local
+    and a completed run can be enhanced afterward.
+    """
+    run_dir = _resolve_run_dir(run, output_dir)
+    if not (run_dir / "workspace" / "main.py").is_file():
+        typer.echo(f"no generated run at {run_dir}", err=True)
+        raise typer.Exit(1)
+    outcome = texture_run(run_dir)
+    if outcome.applied:
+        typer.echo(
+            f"applied texture maps to {outcome.textured_shapes}/"
+            f"{outcome.requested_shapes} surfaces in {run_dir}"
+        )
+        for error in outcome.errors:
+            typer.echo(f"note: {error}", err=True)
+        typer.echo(f"view it:  uv run mini-articraft view {run}")
+    else:
+        detail = outcome.error or "; ".join(outcome.errors) or "no textures were requested"
+        typer.echo(f"could not apply texture maps to {run_dir}: {detail}", err=True)
+        raise typer.Exit(1)
+
+
 async def _generate(
     settings: Settings,
     prompt: str,
@@ -135,9 +181,9 @@ async def _generate(
         await model_client.close()
 
 
-def _generate_with_tui(settings: Settings, prompt: str, image_path: Path | None) -> None:
+def _generate_with_tui(settings: Settings, prompt: str, image_path: Path | None) -> dict[str, Any]:
     try:
-        result = run_live(
+        return run_live(
             lambda on_event: _generate(
                 settings,
                 prompt,
@@ -148,8 +194,28 @@ def _generate_with_tui(settings: Settings, prompt: str, image_path: Path | None)
     except (KeyboardInterrupt, asyncio.CancelledError):
         raise typer.Exit(130) from None
 
-    if str(result.get("status")) != "success":
-        raise typer.Exit(1)
+
+def _apply_textures(result: dict[str, Any]) -> None:
+    """Re-export a completed run with texture maps when available.
+
+    A failure keeps the parametric result and does not change generation status.
+    """
+
+    run = result.get("run")
+    if not run:
+        return
+    outcome = texture_run(Path(str(run)))
+    if outcome.applied:
+        if outcome.usdz is not None:
+            result["result"] = outcome.usdz.relative_to(Path(str(run)).resolve()).as_posix()
+        typer.echo(
+            f"applied texture maps to {outcome.textured_shapes}/{outcome.requested_shapes} surfaces"
+        )
+        for error in outcome.errors:
+            typer.echo(f"note: {error}", err=True)
+    else:
+        detail = outcome.error or "; ".join(outcome.errors) or "no textures were requested"
+        typer.echo(f"note: kept parametric result ({detail})", err=True)
 
 
 def _resolve_run_dir(run: str, output_dir: Path | None) -> Path:

--- a/src/mini_articraft/environments/worker.py
+++ b/src/mini_articraft/environments/worker.py
@@ -9,11 +9,12 @@ import sys
 import time
 import traceback
 from collections.abc import Hashable, Iterable
-from dataclasses import asdict, replace
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, TypeVar
 
 from mini_articraft.compile_result import CompileResult
+from mini_articraft.record import Record
 from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
 from mini_articraft.sdk.export import export_object
 
@@ -82,6 +83,85 @@ def compile_run(run_dir: Path, *, include_report: bool = True) -> dict[str, Any]
     result.compile_stats = tracker.finish()
     tracker.remove()
     return result.to_payload(include_report=include_report)
+
+
+@dataclass(frozen=True, slots=True)
+class TextureRunResult:
+    succeeded: bool
+    requested_shapes: int = 0
+    textured_shapes: int = 0
+    errors: tuple[str, ...] = ()
+    error: str | None = None
+    usdz: Path | None = None
+
+    @property
+    def applied(self) -> bool:
+        return self.textured_shapes > 0
+
+
+def texture_run(run_dir: Path) -> TextureRunResult:
+    """Re-export a compiled run's result with texture maps.
+
+    It rebuilds the final model, then re-exports a single textured USDZ in place
+    of the parametric attempt outputs. Any failure leaves the parametric result
+    untouched and is returned as data so it is never fatal to a run.
+    """
+
+    # Resolve before chdir: relative paths would otherwise break once the cwd
+    # moves into the workspace below.
+    run_dir = Path(run_dir).resolve()
+    workspace = run_dir / "workspace"
+    result_dir = run_dir / "result"
+    if not (workspace / "main.py").is_file():
+        return TextureRunResult(succeeded=False, error="workspace/main.py is required")
+
+    previous_cwd = Path.cwd()
+    sys.path.insert(0, str(workspace))
+    manifest = result_dir / "model.json"
+    previous_manifest = manifest.read_bytes() if manifest.is_file() else None
+    try:
+        os.chdir(workspace)
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            globals_dict = runpy.run_path(str(workspace / "main.py"), run_name="__main__")
+            object_model = globals_dict.get("object_model")
+            if not isinstance(object_model, ArticulatedObject):
+                return TextureRunResult(
+                    succeeded=False,
+                    error="main.py must define object_model as an ArticulatedObject",
+                )
+            export_result = export_object(object_model, result_dir, textured=True)
+
+            report = export_result.textures
+            if report.textured_shapes == 0:
+                if previous_manifest is None:
+                    manifest.unlink(missing_ok=True)
+                else:
+                    manifest_temp = manifest.with_name(f".{manifest.name}.texture-restore")
+                    manifest_temp.write_bytes(previous_manifest)
+                    manifest_temp.replace(manifest)
+                export_result.usdz.unlink(missing_ok=True)
+            else:
+                for stale in (result_dir / "usdz").glob("*.usdz"):
+                    if stale != export_result.usdz:
+                        stale.unlink()
+                record_path = run_dir / "record.json"
+                if record_path.is_file():
+                    record = Record.load(record_path)
+                    record.result = export_result.usdz.relative_to(run_dir).as_posix()
+                    record.save(record_path)
+        return TextureRunResult(
+            succeeded=True,
+            requested_shapes=report.requested_shapes,
+            textured_shapes=report.textured_shapes,
+            errors=report.errors,
+            usdz=export_result.usdz if report.textured_shapes > 0 else None,
+        )
+    except Exception as exc:
+        return TextureRunResult(succeeded=False, error=f"{type(exc).__name__}: {exc}")
+    finally:
+        os.chdir(previous_cwd)
+        with contextlib.suppress(ValueError):
+            sys.path.remove(str(workspace))
 
 
 def _compile_workspace(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 from typer.testing import CliRunner
 
 from mini_articraft.cli import mini
+from mini_articraft.environments.worker import TextureRunResult
 from mini_articraft.record import Record, append_conversation
 from mini_articraft.settings import Settings, get_settings
 
@@ -112,6 +113,50 @@ def test_cli_runs_agent_with_only_core_overrides(monkeypatch, tmp_path: Path) ->
     assert FakeAgent.instances[0].image_path is None
     assert "status: success" in result.output
     assert "run: /tmp/run" in result.output
+
+
+def test_cli_applies_textures_only_after_generation(monkeypatch) -> None:
+    reset_fakes()
+    monkeypatch.setattr(mini, "create_model", FakeOpenAIModel)
+    monkeypatch.setattr(mini, "LocalEnvironment", FakeEnvironment)
+    monkeypatch.setattr(mini, "Agent", FakeAgent)
+    monkeypatch.setattr(mini, "get_settings", lambda: Settings(openai_api_key="sk-test"))
+    applied: list[dict[str, Any]] = []
+    monkeypatch.setattr(mini, "_apply_textures", applied.append)
+
+    result = CliRunner().invoke(
+        mini.app,
+        ["generate", "make a steel ball", "--textures", "--no-tui"],
+    )
+
+    assert result.exit_code == 0
+    assert FakeAgent.instances[0].kwargs == {"max_turns": 100}
+    assert FakeAgent.instances[0].prompt == "make a steel ball"
+    assert applied == [FakeAgent.result]
+
+
+def test_apply_textures_updates_the_reported_result_path(monkeypatch, tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    final_usdz = run_dir / "result" / "usdz" / "0003.usdz"
+    monkeypatch.setattr(
+        mini,
+        "texture_run",
+        lambda _run: TextureRunResult(
+            succeeded=True,
+            requested_shapes=1,
+            textured_shapes=1,
+            usdz=final_usdz,
+        ),
+    )
+    result: dict[str, Any] = {
+        "status": "success",
+        "run": str(run_dir),
+        "result": "result/usdz/0002.usdz",
+    }
+
+    mini._apply_textures(result)
+
+    assert result["result"] == "result/usdz/0003.usdz"
 
 
 def test_cli_passes_reference_image_to_agent(monkeypatch, tmp_path: Path) -> None:
@@ -420,4 +465,5 @@ def test_main_args_keep_commands_and_help() -> None:
     assert mini._app_args(["generate", "articulated lamp"]) == ["generate", "articulated lamp"]
     assert mini._app_args(["replay", "run-x"]) == ["replay", "run-x"]
     assert mini._app_args(["view", "run-x"]) == ["view", "run-x"]
+    assert mini._app_args(["texture", "run-x"]) == ["texture", "run-x"]
     assert mini._app_args(["--help"]) == ["--help"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,30 @@ def test_cli_applies_textures_only_after_generation(monkeypatch) -> None:
     assert applied == [FakeAgent.result]
 
 
+def test_texture_flag_is_postprocessing_after_tui_generation(monkeypatch) -> None:
+    monkeypatch.setattr(mini, "get_settings", lambda: Settings(openai_api_key="sk-test"))
+    calls: list[tuple[str, object]] = []
+    generated = {"status": "success", "run": "/tmp/run"}
+
+    def run_generation(_settings, _prompt, _image, *, use_tui):
+        calls.append(("generate", use_tui))
+        return generated
+
+    def apply_textures(result):
+        calls.append(("textures", result))
+
+    monkeypatch.setattr(mini, "_run_generation", run_generation)
+    monkeypatch.setattr(mini, "_apply_textures", apply_textures)
+
+    result = CliRunner().invoke(
+        mini.app,
+        ["generate", "make a steel ball", "--textures", "--tui"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("generate", True), ("textures", generated)]
+
+
 def test_apply_textures_updates_the_reported_result_path(monkeypatch, tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     final_usdz = run_dir / "result" / "usdz" / "0003.usdz"
@@ -157,6 +181,15 @@ def test_apply_textures_updates_the_reported_result_path(monkeypatch, tmp_path: 
     mini._apply_textures(result)
 
     assert result["result"] == "result/usdz/0003.usdz"
+
+
+def test_apply_textures_ignores_failed_generation(monkeypatch) -> None:
+    def unexpected_texture_run(_run):
+        raise AssertionError("failed generation must not start texture postprocessing")
+
+    monkeypatch.setattr(mini, "texture_run", unexpected_texture_run)
+
+    mini._apply_textures({"status": "error", "run": "/tmp/run"})
 
 
 def test_cli_passes_reference_image_to_agent(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_texture_run.py
+++ b/tests/test_texture_run.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import mini_articraft.environments.worker as worker
+from mini_articraft.record import Record
+from mini_articraft.sdk import ArticulatedObject, BoxGeometry, Material
+from mini_articraft.sdk.export import TextureExportReport, export_object
+
+
+def _model() -> ArticulatedObject:
+    model = ArticulatedObject("plain")
+    model.part("base").add(
+        BoxGeometry([0.1, 0.1, 0.1]),
+        name="body",
+        material=Material.matte((0.5, 0.5, 0.5)),
+    )
+    return model
+
+
+def _run_dir(tmp_path):
+    run_dir = tmp_path / "run"
+    (run_dir / "workspace").mkdir(parents=True)
+    (run_dir / "workspace" / "main.py").touch()
+    return run_dir
+
+
+def test_texture_run_preserves_prior_result_when_export_fails(monkeypatch, tmp_path) -> None:
+    run_dir = _run_dir(tmp_path)
+    prior = export_object(_model(), run_dir / "result")
+    manifest_before = prior.manifest.read_bytes()
+    monkeypatch.setattr(
+        worker.runpy, "run_path", lambda *_args, **_kwargs: {"object_model": _model()}
+    )
+
+    def fail_export(*_args, **_kwargs):
+        raise RuntimeError("injected failure")
+
+    monkeypatch.setattr(worker, "export_object", fail_export)
+    outcome = worker.texture_run(run_dir)
+
+    assert not outcome.succeeded
+    assert not outcome.applied
+    assert prior.usdz.exists()
+    assert prior.manifest.read_bytes() == manifest_before
+
+
+def test_texture_run_keeps_parametric_result_when_no_textures_apply(monkeypatch, tmp_path) -> None:
+    run_dir = _run_dir(tmp_path)
+    prior = export_object(_model(), run_dir / "result")
+    manifest_before = prior.manifest.read_bytes()
+    monkeypatch.setattr(
+        worker.runpy, "run_path", lambda *_args, **_kwargs: {"object_model": _model()}
+    )
+
+    outcome = worker.texture_run(run_dir)
+
+    assert outcome.succeeded
+    assert not outcome.applied
+    assert prior.manifest.read_bytes() == manifest_before
+    assert json.loads(prior.manifest.read_text())["files"] == {"usdz": "usdz/0000.usdz"}
+    assert [path.name for path in prior.usdz.parent.glob("*.usdz")] == ["0000.usdz"]
+
+
+def test_texture_run_updates_record_to_the_final_usdz(monkeypatch, tmp_path) -> None:
+    run_dir = _run_dir(tmp_path)
+    prior = export_object(_model(), run_dir / "result")
+    Record(run_id="run", status="success", result="result/usdz/0000.usdz").save(
+        run_dir / "record.json"
+    )
+    monkeypatch.setattr(
+        worker.runpy, "run_path", lambda *_args, **_kwargs: {"object_model": _model()}
+    )
+    final_usdz = prior.usdz.parent / "0001.usdz"
+
+    def textured_export(*_args, **_kwargs):
+        final_usdz.write_bytes(b"usdz")
+        return SimpleNamespace(
+            usdz=final_usdz,
+            textures=TextureExportReport(requested_shapes=1, textured_shapes=1),
+        )
+
+    monkeypatch.setattr(worker, "export_object", textured_export)
+
+    outcome = worker.texture_run(run_dir)
+
+    assert outcome.applied
+    assert outcome.usdz == final_usdz
+    assert Record.load(run_dir / "record.json").result == "result/usdz/0001.usdz"
+    assert not prior.usdz.exists()


### PR DESCRIPTION
## Stack

Follow-up to merged #69. This PR targets `main` directly and contains only CLI and worker orchestration.

## Summary

Adds optional post-generation texture orchestration:

- `generate --textures` applies maps only after generation returns a successful result.
- `mini-articraft texture <run>` applies maps to an existing run.
- Generation, optional texture postprocessing, and result presentation are separate linear steps.
- The TUI runner receives only generation inputs; it has no texture option or texture behavior.
- Download/export failures preserve the parametric result and do not crash generation.
- Successful replacement keeps CLI output, `record.json`, and `model.json` on the same final USDZ.

## Scope

- 338 additions / 8 deletions across 4 files relative to `main`.

## Validation

- `TMPDIR=/tmp uv run pytest -q --replay` — 395 passed, 2 deselected
- Focused CLI/worker tests — 24 passed
- `uv run ruff check .`
- `uv run basedpyright`
