### PR TITLE
Play the simulation in the viewer, and make friction observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,21 @@ uv run mini-articraft simulate runs/<run-id>
   verdict: stands up
 ```
 
-It reports whether the object fell through the floor, whether its parts stayed
-together, and whether it settled. MuJoCo is optional, so the `sim` group is not
-installed by default.
+Tilt the floor until it slides, which measures the friction its materials
+declared instead of taking it on faith:
+
+```shell
+uv run mini-articraft simulate runs/<run-id> --scenario tilt --seconds 8
+```
+
+```
+  slipped at: 42.3 deg of tilt
+  friction: measured 0.91, authored 0.85
+```
+
+Every run records its motion, so `mini-articraft view` gains a **Play
+simulation** switch that replays it in the same viewer used to pose joints.
+MuJoCo is optional, so the `sim` group is not installed by default.
 
 ### Run the checks
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ uv run mini-articraft simulate runs/<run-id>
 
 ```
 2 bodies, 29.306 kg total
-  heights: +0.0370 -> +0.0169 m (lowest body)
+  lowest body: +0.0370 -> +0.0169 m
   contacts at rest: 8
   deepest penetration: -4.15 mm
   largest part separation change: +0.00 mm

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ uv run mini-articraft simulate runs/<run-id> --scenario tilt --seconds 8
   friction: measured 0.91, authored 0.85
 ```
 
+Let the joints fall from mid-travel, which is the motion an articulated object is
+actually for:
+
+```shell
+uv run mini-articraft simulate runs/<run-id> --scenario release
+```
+
+```
+  joints released from mid-travel
+  peak joint speed: 6.20 per second
+```
+
 Every run records its motion, so `mini-articraft view` gains a **Play
 simulation** switch that replays it in the same viewer used to pose joints.
 MuJoCo is optional, so the `sim` group is not installed by default.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Every run records its motion, so `mini-articraft view` gains a **Play
 simulation** switch that replays it in the same viewer used to pose joints.
 MuJoCo is optional, so the `sim` group is not installed by default.
 
+A passing run covers geometry, mass, joints, and sliding friction. It does not
+cover restitution: MuJoCo has no such parameter, and static friction has nowhere
+to go in its single sliding coefficient. Those values still export for engines
+that read them.
+
 ### Run the checks
 
 ```shell

--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -136,11 +137,15 @@ def simulate(
     ),
     output_dir: Path | None = typer.Option(None, "--output-dir", help="Run output directory."),
     seconds: float = typer.Option(3.0, "--seconds", help="How long to simulate."),
+    scenario: str = typer.Option(
+        "drop", "--scenario", help="'drop' to settle on a floor, 'tilt' to find where it slides."
+    ),
 ) -> None:
-    """Drop a run's latest USDZ on a floor and report whether it behaves.
+    """Run a run's latest USDZ in a physics engine and report whether it behaves.
 
     OpenUSD validation says the stage is well formed; this says whether the
-    object stands up, stays together, and settles.
+    object stands up, stays together, and settles. The 'tilt' scenario tips the
+    floor until it slides, which measures the friction its materials authored.
     """
     from mini_articraft.simulate import SimulationUnavailable, simulate_usdz
 
@@ -153,13 +158,21 @@ def simulate(
         raise typer.Exit(1) from None
 
     try:
-        result = simulate_usdz(usdz, run_dir / "result" / "simulation", seconds=seconds)
+        simulation_dir = run_dir / "result" / "simulation"
+        result = simulate_usdz(usdz, simulation_dir, seconds=seconds, scenario=scenario)
     except SimulationUnavailable as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from None
     except ValueError as exc:
         typer.echo(f"could not simulate {usdz.name}: {exc}", err=True)
         raise typer.Exit(1) from None
+
+    if result.trajectory is not None:
+        # Keyed by USDZ so the viewer plays the motion belonging to the version
+        # it is showing.
+        record = simulation_dir / f"{usdz.stem}.trajectory.json"
+        record.write_text(json.dumps(result.trajectory.to_payload()), encoding="utf-8")
+        typer.echo(f"recorded motion for the viewer: {record}")
 
     typer.echo(result.summary())
     if not result.stood_up:

--- a/src/mini_articraft/cli/mini.py
+++ b/src/mini_articraft/cli/mini.py
@@ -138,14 +138,18 @@ def simulate(
     output_dir: Path | None = typer.Option(None, "--output-dir", help="Run output directory."),
     seconds: float = typer.Option(3.0, "--seconds", help="How long to simulate."),
     scenario: str = typer.Option(
-        "drop", "--scenario", help="'drop' to settle on a floor, 'tilt' to find where it slides."
+        "drop",
+        "--scenario",
+        help="'drop' to settle on a floor, 'tilt' to find where it slides, "
+        "'release' to let the joints fall.",
     ),
 ) -> None:
     """Run a run's latest USDZ in a physics engine and report whether it behaves.
 
     OpenUSD validation says the stage is well formed; this says whether the
-    object stands up, stays together, and settles. The 'tilt' scenario tips the
-    floor until it slides, which measures the friction its materials authored.
+    object stands up, stays together, and settles. 'tilt' tips the floor until it
+    slides, which measures the friction its materials authored. 'release' lets
+    every joint fall from mid-travel, which is the motion worth watching.
     """
     from mini_articraft.simulate import SimulationUnavailable, simulate_usdz
 

--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -44,9 +44,41 @@ _Mesh = UsdGeom.Mesh  # pyright: ignore[reportAttributeAccessIssue]
 DROP_HEIGHT = 0.02
 """Metres above the floor to release the object, so contact is exercised."""
 
+TILT_RATE = 12.0
+"""Degrees per second the floor tilts in the ``tilt`` scenario."""
+
+SLIP_DISTANCE = 0.02
+"""Lateral metres that counts as sliding rather than settling."""
+
+MAX_TILT = 50.0
+"""Degrees to stop tilting at. Past this an object topples rather than slides."""
+
 
 class SimulationUnavailable(RuntimeError):
     """MuJoCo is not installed."""
+
+
+@dataclass(frozen=True)
+class Trajectory:
+    """The simulated motion, in the terms the viewer already understands.
+
+    The viewer poses an object by moving joints, so a recording is the joint
+    values over time. It pins the root at the origin, which simulation does not,
+    so the root's pose travels alongside.
+    """
+
+    fps: float
+    root: str
+    joint_names: tuple[str, ...]
+    frames: tuple[dict[str, Any], ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "fps": self.fps,
+            "root": self.root,
+            "joints": list(self.joint_names),
+            "frames": list(self.frames),
+        }
 
 
 @dataclass(frozen=True)
@@ -62,6 +94,14 @@ class SimulationResult:
     largest_separation_change: float
     residual_velocity: float
     diverged: bool = False
+    trajectory: Trajectory | None = None
+    scenario: str = "drop"
+    slip_angle: float | None = None
+    """Degrees of tilt at which the object started sliding, in the tilt scenario."""
+    measured_friction: float | None = None
+    """The coefficient implied by that slip angle: tan(slip)."""
+    expected_friction: float | None = None
+    """The lowest friction authored on a shape that touches the floor."""
 
     @property
     def fell_through_floor(self) -> bool:
@@ -73,22 +113,38 @@ class SimulationResult:
 
     @property
     def stood_up(self) -> bool:
-        return (
-            not self.diverged
-            and not self.fell_through_floor
-            and self.parts_stayed_together
-            and self.deepest_penetration > -0.01
-        )
+        """Whether the object behaved. A tilt run is judged on staying whole."""
+
+        if self.diverged or not self.parts_stayed_together:
+            return False
+        if self.scenario == "tilt":
+            return True
+        return self.fell_through_floor is False and self.deepest_penetration > -0.01
 
     def summary(self) -> str:
         lines = [
             f"{len(self.bodies)} bodies, {self.total_mass:.3f} kg total",
-            f"  heights: {self.start_heights[0]:+.4f} -> {self.end_heights[0]:+.4f} m (lowest body)",
+            f"  heights: {self.start_heights[0]:+.4f} -> {self.end_heights[0]:+.4f} m (lowest body)"
+            if self.scenario == "drop"
+            else "  settled, then tilted until it moved",
             f"  contacts at rest: {self.contacts}",
             f"  deepest penetration: {self.deepest_penetration * 1000:+.2f} mm",
             f"  largest part separation change: {self.largest_separation_change * 1000:+.2f} mm",
             f"  residual velocity: {self.residual_velocity:.4f}",
         ]
+        if self.scenario == "tilt":
+            if self.slip_angle is None:
+                lines.append("  never slipped: it held to the end of the tilt")
+            else:
+                lines.append(f"  slipped at: {self.slip_angle:.1f} deg of tilt")
+                lines.append(
+                    f"  friction: measured {self.measured_friction:.2f}"
+                    + (
+                        f", authored {self.expected_friction:.2f}"
+                        if self.expected_friction is not None
+                        else ""
+                    )
+                )
         if self.diverged:
             lines.append("  DIVERGED: the solver produced non-finite state")
         lines.append(f"  verdict: {'stands up' if self.stood_up else 'FAILED'}")
@@ -122,8 +178,25 @@ class _Scene:
         return roots[0]
 
 
-def simulate_usdz(usdz: Path, work_dir: Path, *, seconds: float = 3.0) -> SimulationResult:
-    """Drop an exported USDZ on a floor and report what happened."""
+def simulate_usdz(
+    usdz: Path,
+    work_dir: Path,
+    *,
+    seconds: float = 3.0,
+    fps: float = 30.0,
+    scenario: str = "drop",
+) -> SimulationResult:
+    """Run an exported USDZ on a floor and report what happened.
+
+    ``drop`` releases it just above the floor and watches it settle. ``tilt``
+    settles it first, then tips the floor until it slides, which measures the
+    friction the materials authored instead of taking it on faith.
+
+    The motion is recorded at ``fps`` so the viewer can play it back.
+    """
+
+    if scenario not in {"drop", "tilt"}:
+        raise ValueError(f"unknown scenario {scenario!r}; expected 'drop' or 'tilt'")
 
     try:
         import mujoco
@@ -148,15 +221,62 @@ def simulate_usdz(usdz: Path, work_dir: Path, *, seconds: float = 3.0) -> Simula
         for b in range(a + 1, model.nbody)
     }
 
+    root_body = 1  # the free body; MuJoCo orders bodies from the world outward
+    movable = [
+        index
+        for index in range(model.njnt)
+        if model.jnt_type[index] in (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_SLIDE)
+    ]
+    joint_names = tuple(
+        str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, index)) for index in movable
+    )
+
+    def frame(time: float) -> dict[str, Any]:
+        return {
+            "t": round(time, 4),
+            # MuJoCo quaternions are (w, x, y, z).
+            "root": {
+                "pos": [round(float(value), 6) for value in data.xpos[root_body]],
+                "quat": [round(float(value), 6) for value in data.xquat[root_body]],
+            },
+            "joints": [round(float(data.qpos[model.jnt_qposadr[index]]), 6) for index in movable],
+        }
+
     deepest = 0.0
     diverged = False
-    for _ in range(int(seconds / model.opt.timestep)):
+    frames = [frame(0.0)]
+    every = max(1, round(1.0 / (fps * model.opt.timestep)))
+    gravity = float(np.linalg.norm(model.opt.gravity))
+    settle_steps = int(1.0 / model.opt.timestep) if scenario == "tilt" else 0
+    slip_angle: float | None = None
+    resting = None
+    touching: float | None = None
+
+    for step in range(int(seconds / model.opt.timestep)):
+        if scenario == "tilt" and slip_angle is not None:
+            break  # the question is answered; tilting further only topples it
+        if scenario == "tilt" and step >= settle_steps:
+            # Tipping gravity is equivalent to tipping the floor, and leaves the
+            # contact geometry untouched.
+            degrees = min(MAX_TILT, TILT_RATE * (step - settle_steps) * model.opt.timestep)
+            angle = math.radians(degrees)
+            model.opt.gravity[:] = (gravity * math.sin(angle), 0.0, -gravity * math.cos(angle))
+            if resting is None:
+                resting = data.xpos[root_body].copy()
+                touching = _floor_friction(model, data)
+            elif slip_angle is None:
+                travelled = float(np.linalg.norm((data.xpos[root_body] - resting)[:2]))
+                if travelled > SLIP_DISTANCE:
+                    slip_angle = degrees
+
         mujoco.mj_step(model, data)
         if data.ncon:
             deepest = min(deepest, float(data.contact.dist[: data.ncon].min()))
         if not np.all(np.isfinite(data.qpos)):
             diverged = True
             break
+        if (step + 1) % every == 0:
+            frames.append(frame((step + 1) * model.opt.timestep))
 
     end = data.xpos[1:].copy()
     drift = max(
@@ -176,7 +296,40 @@ def simulate_usdz(usdz: Path, work_dir: Path, *, seconds: float = 3.0) -> Simula
         largest_separation_change=drift,
         residual_velocity=float(np.abs(data.qvel).max()) if model.nv else 0.0,
         diverged=diverged,
+        scenario=scenario,
+        slip_angle=slip_angle,
+        measured_friction=None if slip_angle is None else math.tan(math.radians(slip_angle)),
+        expected_friction=touching if scenario == "tilt" else _lowest_friction(model),
+        trajectory=Trajectory(
+            fps=fps,
+            root=str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, root_body)),
+            joint_names=joint_names,
+            frames=tuple(frames),
+        ),
     )
+
+
+def _floor_friction(model: Any, data: Any) -> float | None:
+    """Friction of the geoms actually resting on the floor.
+
+    A crate on rubber feet slides on rubber, whatever its body is made of, so the
+    object's minimum friction is the wrong thing to compare a slip angle against.
+    """
+
+    values = [
+        float(model.geom_friction[geom][0])
+        for index in range(data.ncon)
+        for geom in (data.contact.geom1[index], data.contact.geom2[index])
+        if geom != 0  # geom 0 is the floor
+    ]
+    return min(values) if values else None
+
+
+def _lowest_friction(model: Any) -> float | None:
+    """The least friction among the object's geoms: what slides first."""
+
+    frictions = [float(model.geom_friction[index][0]) for index in range(1, model.ngeom)]
+    return min(frictions) if frictions else None
 
 
 def write_mjcf(usdz: Path, out_dir: Path) -> Path:
@@ -198,6 +351,9 @@ def write_mjcf(usdz: Path, out_dir: Path) -> Path:
     ET.SubElement(mujoco_el, "option", timestep="0.002", integrator="implicitfast")
     asset = ET.SubElement(mujoco_el, "asset")
     world = ET.SubElement(mujoco_el, "worldbody")
+    # MuJoCo takes the elementwise MAX of the two geoms' friction, so a floor with
+    # any friction of its own would mask the material's. Zero here means the
+    # contact uses exactly what the shape's material authored.
     ET.SubElement(
         world,
         "geom",
@@ -205,7 +361,7 @@ def write_mjcf(usdz: Path, out_dir: Path) -> Path:
         type="plane",
         size="5 5 0.1",
         pos="0 0 0",
-        friction="1 0.005 0.0001",
+        friction="0 0.005 0.0001",
     )
 
     _add_body(world, asset, scene, root, np.linalg.inv(lift), stage, out_dir)

--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -10,6 +10,15 @@ translation is the part most likely to be wrong, so it is deliberately literal:
 every value comes from the schema we authored, and units are converted in exactly
 one place.
 
+What this does **not** cover. A material authors static friction, dynamic
+friction, and restitution; only dynamic friction reaches the simulation. MuJoCo
+carries a single sliding coefficient, so static friction has nowhere to go, and
+it has no restitution parameter at all -- bounce comes from contact stiffness
+(``solref``), which is not the same quantity. So a passing run says the geometry,
+mass, joints, and sliding friction behave. It says nothing about how the object
+would bounce, and slip onset is measured against the dynamic coefficient rather
+than the static one that governs it.
+
 MuJoCo is an optional dependency. Install it with ``uv sync --group sim``.
 """
 

--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import numpy as np
 from pxr import Usd, UsdGeom, UsdPhysics, UsdShade  # pyright: ignore[reportAttributeAccessIssue]
+from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
 
 # USD joint prim type -> MJCF joint type. A fixed joint welds the bodies, which
 # MuJoCo expresses by nesting them with no joint element at all.
@@ -100,6 +101,8 @@ class SimulationResult:
     """Degrees of tilt at which the object started sliding, in the tilt scenario."""
     measured_friction: float | None = None
     """The coefficient implied by that slip angle: tan(slip)."""
+    peak_joint_speed: float | None = None
+    """Fastest joint motion seen, in rad/s or m/s. How hard a released joint slams."""
     expected_friction: float | None = None
     """The lowest friction authored on a shape that touches the floor."""
 
@@ -113,25 +116,29 @@ class SimulationResult:
 
     @property
     def stood_up(self) -> bool:
-        """Whether the object behaved. A tilt run is judged on staying whole."""
+        """Whether the object behaved.
+
+        Only ``drop`` is judged on resting quietly. ``tilt`` and ``release`` are
+        deliberately violent, so they are judged on staying whole.
+        """
 
         if self.diverged or not self.parts_stayed_together:
             return False
-        if self.scenario == "tilt":
+        if self.scenario != "drop":
             return True
-        return self.fell_through_floor is False and self.deepest_penetration > -0.01
+        return not self.fell_through_floor and self.deepest_penetration > -0.01
 
     def summary(self) -> str:
         lines = [
             f"{len(self.bodies)} bodies, {self.total_mass:.3f} kg total",
-            f"  lowest body: {self.start_height:+.4f} -> {self.end_height:+.4f} m"
-            if self.scenario == "drop"
-            else "  settled, then tilted until it moved",
+            _headline(self.scenario, self.start_height, self.end_height),
             f"  contacts at rest: {self.contacts}",
             f"  deepest penetration: {self.deepest_penetration * 1000:+.2f} mm",
             f"  largest part separation change: {self.largest_separation_change * 1000:+.2f} mm",
             f"  residual velocity: {self.residual_velocity:.4f}",
         ]
+        if self.scenario == "release" and self.peak_joint_speed is not None:
+            lines.append(f"  peak joint speed: {self.peak_joint_speed:.2f} per second")
         if self.scenario == "tilt":
             if self.slip_angle is None:
                 lines.append("  never slipped: it held to the end of the tilt")
@@ -149,6 +156,14 @@ class SimulationResult:
             lines.append("  DIVERGED: the solver produced non-finite state")
         lines.append(f"  verdict: {'stands up' if self.stood_up else 'FAILED'}")
         return "\n".join(lines)
+
+
+def _headline(scenario: str, start: float, end: float) -> str:
+    if scenario == "drop":
+        return f"  lowest body: {start:+.4f} -> {end:+.4f} m"
+    if scenario == "tilt":
+        return "  settled, then tilted until it moved"
+    return "  joints released from mid-travel"
 
 
 @dataclass
@@ -190,13 +205,15 @@ def simulate_usdz(
 
     ``drop`` releases it just above the floor and watches it settle. ``tilt``
     settles it first, then tips the floor until it slides, which measures the
-    friction the materials authored instead of taking it on faith.
+    friction the materials authored. ``release`` opens every joint to its limit
+    and lets go, which is the motion an articulated object is actually for --
+    and, until joints have drives, the motion that shows they hold nothing.
 
     The motion is recorded at ``fps`` so the viewer can play it back.
     """
 
-    if scenario not in {"drop", "tilt"}:
-        raise ValueError(f"unknown scenario {scenario!r}; expected 'drop' or 'tilt'")
+    if scenario not in {"drop", "tilt", "release"}:
+        raise ValueError(f"unknown scenario {scenario!r}; expected 'drop', 'tilt', or 'release'")
 
     try:
         import mujoco
@@ -231,6 +248,20 @@ def simulate_usdz(
         str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, index)) for index in movable
     )
 
+    if scenario == "release":
+        for index in range(model.njnt):
+            if model.jnt_type[index] not in (
+                mujoco.mjtJoint.mjJNT_HINGE,
+                mujoco.mjtJoint.mjJNT_SLIDE,
+            ):
+                continue
+            lower, upper = (float(value) for value in model.jnt_range[index])
+            # Halfway through travel, which is where letting go of a door leaves it.
+            # Releasing at a limit can rest against the stop and never move: a lid
+            # opened past vertical is held open by its own weight.
+            data.qpos[model.jnt_qposadr[index]] = (lower + upper) / 2.0
+        mujoco.mj_forward(model, data)
+
     def frame(time: float) -> dict[str, Any]:
         return {
             "t": round(time, 4),
@@ -244,6 +275,7 @@ def simulate_usdz(
 
     deepest = 0.0
     diverged = False
+    peak_joint_speed = 0.0
     frames = [frame(0.0)]
     every = max(1, round(1.0 / (fps * model.opt.timestep)))
     gravity = float(np.linalg.norm(model.opt.gravity))
@@ -272,6 +304,9 @@ def simulate_usdz(
         mujoco.mj_step(model, data)
         if data.ncon:
             deepest = min(deepest, float(data.contact.dist[: data.ncon].min()))
+        for index in movable:
+            speed = abs(float(data.qvel[model.jnt_dofadr[index]]))
+            peak_joint_speed = max(peak_joint_speed, speed)
         if not np.all(np.isfinite(data.qpos)):
             diverged = True
             break
@@ -299,6 +334,7 @@ def simulate_usdz(
         scenario=scenario,
         slip_angle=slip_angle,
         measured_friction=None if slip_angle is None else math.tan(math.radians(slip_angle)),
+        peak_joint_speed=peak_joint_speed if movable else None,
         expected_friction=touching,
         trajectory=Trajectory(
             fps=fps,
@@ -408,7 +444,11 @@ def _add_body(
     prim = scene.parts[part_name]
     world = _world_transform(prim)
     relative = np.linalg.inv(parent_world) @ world
-    body = ET.SubElement(parent_el, "body", name=part_name, pos=_vector(relative[:3, 3]))
+    placement = {"name": part_name, "pos": _vector(relative[:3, 3])}
+    orientation = _quaternion(relative[:3, :3])
+    if orientation is not None:
+        placement["quat"] = _vector(orientation)
+    body = ET.SubElement(parent_el, "body", placement)
 
     joint = next((item for item in scene.joints if item.child == part_name), None)
     if joint is None:
@@ -481,6 +521,18 @@ def _lowest_point(scene: _Scene) -> float:
     if not math.isfinite(lowest):
         raise ValueError("stage has no collidable geometry to place on the floor")
     return lowest
+
+
+def _quaternion(rotation: np.ndarray) -> tuple[float, float, float, float] | None:
+    """A rest rotation as an MJCF ``(w, x, y, z)`` quaternion, or None if upright.
+
+    Dropping this silently misplaces any part whose joint carries an ``rpy``.
+    """
+
+    if np.allclose(rotation, np.eye(3), atol=1e-9):
+        return None
+    x, y, z, w = Rotation.from_matrix(rotation).as_quat()
+    return (float(w), float(x), float(y), float(z))
 
 
 def _world_transform(prim: Usd.Prim) -> np.ndarray:

--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -87,8 +87,8 @@ class SimulationResult:
 
     bodies: tuple[str, ...]
     total_mass: float
-    start_heights: tuple[float, float]
-    end_heights: tuple[float, float]
+    start_height: float
+    end_height: float
     contacts: int
     deepest_penetration: float
     largest_separation_change: float
@@ -105,7 +105,7 @@ class SimulationResult:
 
     @property
     def fell_through_floor(self) -> bool:
-        return self.end_heights[0] < -0.05
+        return self.end_height < -0.05
 
     @property
     def parts_stayed_together(self) -> bool:
@@ -124,7 +124,7 @@ class SimulationResult:
     def summary(self) -> str:
         lines = [
             f"{len(self.bodies)} bodies, {self.total_mass:.3f} kg total",
-            f"  heights: {self.start_heights[0]:+.4f} -> {self.end_heights[0]:+.4f} m (lowest body)"
+            f"  lowest body: {self.start_height:+.4f} -> {self.end_height:+.4f} m"
             if self.scenario == "drop"
             else "  settled, then tilted until it moved",
             f"  contacts at rest: {self.contacts}",
@@ -289,8 +289,8 @@ def simulate_usdz(
     return SimulationResult(
         bodies=names,
         total_mass=float(sum(model.body_mass)),
-        start_heights=(float(start[:, 2].min()), float(start[:, 2].max())),
-        end_heights=(float(end[:, 2].min()), float(end[:, 2].max())),
+        start_height=float(start[:, 2].min()),
+        end_height=float(end[:, 2].min()),
         contacts=int(data.ncon),
         deepest_penetration=deepest,
         largest_separation_change=drift,
@@ -299,7 +299,7 @@ def simulate_usdz(
         scenario=scenario,
         slip_angle=slip_angle,
         measured_friction=None if slip_angle is None else math.tan(math.radians(slip_angle)),
-        expected_friction=touching if scenario == "tilt" else _lowest_friction(model),
+        expected_friction=touching,
         trajectory=Trajectory(
             fps=fps,
             root=str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, root_body)),
@@ -323,13 +323,6 @@ def _floor_friction(model: Any, data: Any) -> float | None:
         if geom != 0  # geom 0 is the floor
     ]
     return min(values) if values else None
-
-
-def _lowest_friction(model: Any) -> float | None:
-    """The least friction among the object's geoms: what slides first."""
-
-    frictions = [float(model.geom_friction[index][0]) for index in range(1, model.ngeom)]
-    return min(frictions) if frictions else None
 
 
 def write_mjcf(usdz: Path, out_dir: Path) -> Path:

--- a/src/mini_articraft/viewer.html
+++ b/src/mini_articraft/viewer.html
@@ -132,7 +132,7 @@
     function setPartColors(enabled){state.partColors=enabled;if(!enabled)state.selected=null;renderParts();paint();syncOptions();}
     function setPreviewMotion(enabled){state.previewMotion=enabled;if(enabled)setPlayingSimulationOff();state.previewStartedAt=performance.now();if(!enabled)state.joints.forEach((joint,name)=>move(name,joint.value));renderTree();syncOptions();}
     function reset(){setPreviewMotion(false);state.joints.forEach((joint,name)=>{joint.value=0;move(name,0);});renderTree();}
-    function fit(){if(!state.root)return;const box=new THREE.Box3().setFromObject(state.root),center=box.getCenter(new THREE.Vector3()),span=Math.max(box.getSize(new THREE.Vector3()).length(),.1);camera.near=span/1000;camera.far=span*100;camera.position.copy(center).add(new THREE.Vector3(span*.95,-span*1.15,span*.8));camera.updateProjectionMatrix();controls.target.copy(center);controls.update();grid.position.z=box.min.z-span*.01;grid.scale.setScalar(Math.max(span/5,.02));}
+    function fit(){if(!state.root)return;const box=new THREE.Box3().setFromObject(state.root),center=box.getCenter(new THREE.Vector3()),span=Math.max(box.getSize(new THREE.Vector3()).length(),.1);camera.near=span/1000;camera.far=span*100;camera.position.copy(center).add(new THREE.Vector3(span*.95,-span*1.15,span*.8));camera.updateProjectionMatrix();controls.target.copy(center);controls.update();grid.position.z=state.simulation?0:box.min.z-span*.01;grid.scale.setScalar(Math.max(span/5,.02));}
     function dispose(root){root.traverse(object=>{if(object.geometry)object.geometry.dispose();if(object.material)materials(object).forEach(material=>material.dispose());});}
     function status(text){document.querySelector("#status").textContent=text;}
 

--- a/src/mini_articraft/viewer.html
+++ b/src/mini_articraft/viewer.html
@@ -66,7 +66,7 @@
     <aside class="view-options glass" aria-label="View options">
       <h2>View</h2>
       <button id="part-colors" class="option" type="button" role="switch" aria-checked="false"><span>Part colors</span><span class="switch" aria-hidden="true"></span></button>
-      <button id="preview-motion" class="option" type="button" role="switch" aria-checked="false"><span>Preview motion</span><span class="switch" aria-hidden="true"></span></button>
+      <button id="preview-motion" class="option" type="button" role="switch" aria-checked="false"><span>Preview motion</span><span class="switch" aria-hidden="true"></span></button><button id="play-simulation" class="option" type="button" role="switch" aria-checked="false" hidden><span>Play simulation</span><span class="switch" aria-hidden="true"></span></button>
     </aside>
     <button id="camera-reset" class="camera" title="Reset camera" aria-label="Reset camera">↻</button>
   </main>
@@ -76,7 +76,7 @@
     import { USDLoader } from "three/addons/loaders/USDLoader.js";
     import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 
-    const state={data:null,version:null,root:null,parts:new Map(),joints:new Map(),palette:[],selected:null,partColors:false,previewMotion:false,previewStartedAt:0};
+    const state={data:null,version:null,root:null,parts:new Map(),joints:new Map(),palette:[],selected:null,partColors:false,previewMotion:false,previewStartedAt:0,simulation:null,playingSimulation:false,simulationStartedAt:0};
     const preview={minimumCycle:2.6,linearSpeed:.08,angularSpeed:Math.PI/4,continuousSpeed:Math.PI/5};
     const scene=new THREE.Scene(); scene.background=new THREE.Color(0xe9eef5);
     const camera=new THREE.PerspectiveCamera(38,1,.001,1000); camera.up.set(0,0,1);
@@ -90,7 +90,7 @@
     let serial=0;
 
     new ResizeObserver(()=>{const el=renderer.domElement.parentElement;renderer.setSize(el.clientWidth,el.clientHeight,false);camera.aspect=el.clientWidth/el.clientHeight;camera.updateProjectionMatrix();}).observe(document.querySelector("#scene"));
-    renderer.setAnimationLoop(time=>{if(state.previewMotion)animateMotion((time-state.previewStartedAt)/1000);controls.update();renderer.render(scene,camera);});
+    renderer.setAnimationLoop(time=>{if(state.previewMotion)animateMotion((time-state.previewStartedAt)/1000);else if(state.playingSimulation)animateSimulation((time-state.simulationStartedAt)/1000);controls.update();renderer.render(scene,camera);});
     const esc=value=>String(value??"").replace(/[&<>"']/g,char=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[char]);
     const materials=mesh=>Array.isArray(mesh.material)?mesh.material:[mesh.material];
     const format=(joint,value)=>joint.type==="prismatic"?`${value.toFixed(3)}m`:`${THREE.MathUtils.radToDeg(value).toFixed(1)}°`;
@@ -101,7 +101,7 @@
 
     function renderVersions(){document.querySelector("#versions").innerHTML=state.data.versions.map(version=>`<button class="version ${version===state.version?"active":""}" data-id="${esc(version.id)}" ${version===state.version?'aria-current="true"':""}>${esc(version.filename)}</button>`).join("");document.querySelectorAll("[data-id]").forEach(button=>button.addEventListener("click",()=>load(state.data.versions.find(version=>version.id===button.dataset.id))));}
 
-    async function load(version){const loadId=++serial;state.version=version;state.palette=contrastingPalette(version.model.parts.length);state.selected=null;renderVersions();status(`Loading ${version.filename}`);if(state.root){scene.remove(state.root);dispose(state.root);state.root=null;}state.parts.clear();state.joints.clear();try{const usd=await new USDLoader().loadAsync(`/models/${encodeURIComponent(version.id)}.usdz`);if(loadId!==serial){dispose(usd);return;}state.root=robot(usd,version.model);scene.add(state.root);renderParts();renderTree();paint();fit();status("");}catch(error){console.error(error);status(`Could not load ${version.filename}`);}}
+    async function load(version){const loadId=++serial;state.version=version;state.simulation=version.trajectory??null;state.playingSimulation=false;state.palette=contrastingPalette(version.model.parts.length);state.selected=null;renderVersions();status(`Loading ${version.filename}`);if(state.root){scene.remove(state.root);dispose(state.root);state.root=null;}state.parts.clear();state.joints.clear();try{const usd=await new USDLoader().loadAsync(`/models/${encodeURIComponent(version.id)}.usdz`);if(loadId!==serial){dispose(usd);return;}state.root=robot(usd,version.model);scene.add(state.root);renderParts();renderTree();paint();fit();status("");}catch(error){console.error(error);status(`Could not load ${version.filename}`);}}
 
     function robot(usd,model){const scope=usd.getObjectByName("parts");if(!scope)throw new Error("USDZ has no parts");const root=new THREE.Group();for(const spec of model.parts){const node=scope.children.find(child=>child.name===spec.usd_name);if(!node)throw new Error(`Missing part ${spec.name}`);node.removeFromParent();node.position.set(0,0,0);node.quaternion.identity();node.scale.set(1,1,1);const meshes=[];node.traverse(child=>{if(child.isMesh)meshes.push(child);});applyMaterials(meshes,spec.shapes);meshes.forEach(child=>{child.userData.original=materials(child).map(material=>({color:material.color?.clone(),opacity:material.opacity,transparent:material.transparent,depthWrite:material.depthWrite}));});state.parts.set(spec.name,{node,meshes});}const children=new Set();for(const spec of model.articulations){const parent=state.parts.get(spec.parent)?.node,child=state.parts.get(spec.child)?.node;if(!parent||!child)continue;const frame=new THREE.Group(),motion=new THREE.Group();frame.position.fromArray(spec.origin.xyz);frame.rotation.set(...spec.origin.rpy,"XYZ");frame.add(motion);motion.add(child);parent.add(frame);state.joints.set(spec.name,{spec,node:motion,value:0,input:null,current:null});children.add(spec.child);}for(const part of model.parts)if(!children.has(part.name))root.add(state.parts.get(part.name).node);return root;}
 
@@ -120,15 +120,23 @@
     function phaseOffset(name,index){let hash=0;for(const character of name)hash=(hash*33+character.charCodeAt(0))%4096;return THREE.MathUtils.euclideanModulo(hash/4096+index*.61803398875,1);}
     function motionValue(joint,elapsed,index){const limits=joint.spec.motion_limits,lower=limits?.lower,upper=limits?.upper;if(joint.spec.type==="continuous"){const phase=elapsed*preview.continuousSpeed/(Math.PI*2)+phaseOffset(joint.spec.name,index);return THREE.MathUtils.euclideanModulo(phase*Math.PI*2+Math.PI,Math.PI*2)-Math.PI;}const hasRange=Number.isFinite(lower)&&Number.isFinite(upper)&&upper>lower,span=hasRange?upper-lower:joint.spec.type==="prismatic"?.24:Math.PI*2/3,speed=joint.spec.type==="prismatic"?preview.linearSpeed:preview.angularSpeed,cycle=Math.max(preview.minimumCycle,span*2/speed),phase=THREE.MathUtils.euclideanModulo(elapsed/cycle+phaseOffset(joint.spec.name,index),1),wave=.5-.5*Math.cos(phase*Math.PI*2);return hasRange?THREE.MathUtils.lerp(lower,upper,wave):(wave*2-1)*span/2;}
     function animateMotion(elapsed){let index=0;state.joints.forEach((joint,name)=>{if(joint.spec.type==="fixed")return;const value=motionValue(joint,elapsed,index++);move(name,value);if(joint.input)joint.input.value=String(value);if(joint.current)joint.current.textContent=format(joint.spec,value);});}
-    function syncOptions(){document.querySelector("#part-colors").setAttribute("aria-checked",String(state.partColors));document.querySelector("#preview-motion").setAttribute("aria-checked",String(state.previewMotion));}
+    // Simulation moves the whole object, which hand-posing has no concept of, so
+    // playback also drives the root part's pose.
+    function animateSimulation(elapsed){const sim=state.simulation;if(!sim||!sim.frames.length)return;const span=sim.frames.length/sim.fps;const frame=sim.frames[Math.min(sim.frames.length-1,Math.floor((elapsed%span)*sim.fps))];const rootPart=state.parts.get(sim.root);if(rootPart&&frame.root){rootPart.node.position.set(...frame.root.pos);const[w,x,y,z]=frame.root.quat;rootPart.node.quaternion.set(x,y,z,w);}sim.joints.forEach((name,index)=>{const value=frame.joints[index];if(value===undefined)return;move(name,value);const joint=state.joints.get(name);if(joint){joint.value=value;if(joint.input)joint.input.value=String(value);if(joint.current)joint.current.textContent=format(joint.spec,value);}});}
+
+    function setPlayingSimulation(enabled){state.playingSimulation=enabled;state.simulationStartedAt=performance.now();if(enabled)state.previewMotion=false;else{const rootPart=state.simulation&&state.parts.get(state.simulation.root);if(rootPart){rootPart.node.position.set(0,0,0);rootPart.node.quaternion.identity();}state.joints.forEach((joint,name)=>move(name,joint.value));}renderTree();syncOptions();}
+
+    function setPlayingSimulationOff(){if(state.playingSimulation)state.playingSimulation=false;}
+
+    function syncOptions(){document.querySelector("#part-colors").setAttribute("aria-checked",String(state.partColors));document.querySelector("#preview-motion").setAttribute("aria-checked",String(state.previewMotion));const play=document.querySelector("#play-simulation");play.hidden=!state.simulation;play.setAttribute("aria-checked",String(state.playingSimulation));}
     function setPartColors(enabled){state.partColors=enabled;if(!enabled)state.selected=null;renderParts();paint();syncOptions();}
-    function setPreviewMotion(enabled){state.previewMotion=enabled;state.previewStartedAt=performance.now();if(!enabled)state.joints.forEach((joint,name)=>move(name,joint.value));renderTree();syncOptions();}
+    function setPreviewMotion(enabled){state.previewMotion=enabled;if(enabled)setPlayingSimulationOff();state.previewStartedAt=performance.now();if(!enabled)state.joints.forEach((joint,name)=>move(name,joint.value));renderTree();syncOptions();}
     function reset(){setPreviewMotion(false);state.joints.forEach((joint,name)=>{joint.value=0;move(name,0);});renderTree();}
     function fit(){if(!state.root)return;const box=new THREE.Box3().setFromObject(state.root),center=box.getCenter(new THREE.Vector3()),span=Math.max(box.getSize(new THREE.Vector3()).length(),.1);camera.near=span/1000;camera.far=span*100;camera.position.copy(center).add(new THREE.Vector3(span*.95,-span*1.15,span*.8));camera.updateProjectionMatrix();controls.target.copy(center);controls.update();grid.position.z=box.min.z-span*.01;grid.scale.setScalar(Math.max(span/5,.02));}
     function dispose(root){root.traverse(object=>{if(object.geometry)object.geometry.dispose();if(object.material)materials(object).forEach(material=>material.dispose());});}
     function status(text){document.querySelector("#status").textContent=text;}
 
-    document.querySelector("#pose-reset").addEventListener("click",reset);document.querySelector("#camera-reset").addEventListener("click",fit);document.querySelector("#part-colors").addEventListener("click",()=>setPartColors(!state.partColors));document.querySelector("#preview-motion").addEventListener("click",()=>setPreviewMotion(!state.previewMotion));syncOptions();
+    document.querySelector("#pose-reset").addEventListener("click",reset);document.querySelector("#camera-reset").addEventListener("click",fit);document.querySelector("#part-colors").addEventListener("click",()=>setPartColors(!state.partColors));document.querySelector("#preview-motion").addEventListener("click",()=>setPreviewMotion(!state.previewMotion));document.querySelector("#play-simulation").addEventListener("click",()=>setPlayingSimulation(!state.playingSimulation));syncOptions();
     try{state.data=await fetch("/api/bootstrap").then(response=>{if(!response.ok)throw new Error(response.statusText);return response.json();});state.version=state.data.versions[0];renderVersions();await load(state.version);}catch(error){console.error(error);status("Could not load this run");}
   </script>
 </body>

--- a/src/mini_articraft/viewer.py
+++ b/src/mini_articraft/viewer.py
@@ -34,9 +34,21 @@ def load_viewer_run(run_dir: Path | str) -> ViewerRun:
     if not paths:
         raise ValueError(f"no numbered USDZ files found in {usdz_dir}")
 
-    versions = tuple(_read_version(path) for path in paths)
+    versions = tuple(_read_version(path) | _read_trajectory(run_dir, path) for path in paths)
     files = {str(version["id"]): path for version, path in zip(versions, paths, strict=True)}
     return ViewerRun(versions=versions, files=files)
+
+
+def _read_trajectory(run_dir: Path, usdz: Path) -> dict[str, object]:
+    """The recorded simulation for this USDZ, if `mini-articraft simulate` has run."""
+
+    record = run_dir / "result" / "simulation" / f"{usdz.stem}.trajectory.json"
+    if not record.is_file():
+        return {}
+    try:
+        return {"trajectory": json.loads(record.read_text(encoding="utf-8"))}
+    except (OSError, json.JSONDecodeError):
+        return {}
 
 
 def serve_viewer(run_dir: Path | str, *, open_browser: bool = True) -> None:

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -164,3 +164,42 @@ def test_a_tilt_run_stops_once_it_slips(tmp_path: Path) -> None:
 def test_an_unknown_scenario_is_rejected(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unknown scenario"):
         simulate_usdz(_export(_hinged_box(), tmp_path), tmp_path / "sim", scenario="wobble")
+
+
+def test_a_rotated_rest_pose_survives_the_translation(tmp_path: Path) -> None:
+    """A joint with an rpy rotates its child; dropping that misplaces the part."""
+    model = ArticulatedObject("tilted")
+    base = model.part("base")
+    base.add(BoxGeometry((0.2, 0.2, 0.05)), name="plate", material=Material.STEEL)
+    arm = model.part("arm")
+    arm.add(BoxGeometry((0.02, 0.02, 0.20)), name="post", material=Material.STEEL)
+    model.articulation(
+        "mount",
+        ArticulationType.FIXED,
+        base,
+        arm,
+        origin=Origin(xyz=(0.0, 0.0, 0.05), rpy=(0.0, math.pi / 4, 0.0)),
+    )
+
+    write_mjcf(_export(model, tmp_path), tmp_path / "sim")
+    arm_body = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//body/body")
+
+    assert arm_body is not None
+    quaternion = arm_body.get("quat")
+    assert quaternion is not None, "a rotated part must carry its orientation"
+    w, _, y, _ = (float(value) for value in quaternion.split())
+    # 45 degrees about Y: w = cos(22.5 deg), y = sin(22.5 deg).
+    assert w == pytest.approx(math.cos(math.pi / 8), abs=1e-4)
+    assert abs(y) == pytest.approx(math.sin(math.pi / 8), abs=1e-4)
+
+
+def test_releasing_a_joint_produces_motion_worth_watching(tmp_path: Path) -> None:
+    """Released at a limit a lid can rest against the stop; from mid-travel it swings."""
+    result = simulate_usdz(
+        _export(_hinged_box(), tmp_path), tmp_path / "sim", seconds=2.0, scenario="release"
+    )
+
+    assert result.trajectory is not None
+    angles = [frame["joints"][0] for frame in result.trajectory.frames]
+    assert max(angles) - min(angles) > 0.5  # radians
+    assert result.peak_joint_speed is not None and result.peak_joint_speed > 1.0

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -108,3 +108,59 @@ def test_contact_friction_reaches_the_geom(tmp_path: Path) -> None:
     assert geom is not None
     friction = float(str(geom.get("friction")).split()[0])
     assert friction == pytest.approx(Material.RUBBER.dynamic_friction or 0.0, abs=1e-3)
+
+
+def test_material_friction_reaches_the_contact_not_the_floors(tmp_path: Path) -> None:
+    """MuJoCo combines friction with max, so a floor with any of its own masks ours."""
+    import mujoco
+
+    model = ArticulatedObject("block")
+    model.part("body").add(BoxGeometry((0.1, 0.1, 0.1)), name="cube", material=Material.STEEL)
+
+    path = write_mjcf(_export(model, tmp_path), tmp_path / "sim")
+    compiled = mujoco.MjModel.from_xml_path(str(path))
+    data = mujoco.MjData(compiled)
+    for _ in range(200):
+        mujoco.mj_step(compiled, data)
+
+    assert data.ncon
+    assert data.contact.friction[0][0] == pytest.approx(Material.STEEL.dynamic_friction, abs=1e-3)
+
+
+def test_tilting_measures_the_friction_that_was_authored(tmp_path: Path) -> None:
+    """A grippier material has to hold to a steeper angle than a slippery one."""
+    angles = {}
+    for material in (Material.RUBBER, Material.STEEL):
+        model = ArticulatedObject("block")
+        model.part("body").add(BoxGeometry((0.12, 0.12, 0.06)), name="block", material=material)
+        result = simulate_usdz(
+            _export(model, tmp_path / material.name),
+            tmp_path / material.name / "sim",
+            seconds=6.0,
+            scenario="tilt",
+        )
+        assert result.slip_angle is not None, result.summary()
+        angles[material.name] = result.slip_angle
+
+    assert angles["rubber"] > angles["steel"]
+
+
+def test_a_tilt_run_stops_once_it_slips(tmp_path: Path) -> None:
+    """Tilting past the slip angle topples the object and tells us nothing more."""
+    model = ArticulatedObject("block")
+    model.part("body").add(BoxGeometry((0.12, 0.12, 0.06)), name="block", material=Material.STEEL)
+
+    result = simulate_usdz(
+        _export(model, tmp_path), tmp_path / "sim", seconds=20.0, scenario="tilt"
+    )
+
+    assert result.slip_angle is not None
+    assert result.slip_angle < 50.0
+    # It is still whole and not flying: the run ended at the answer.
+    assert result.residual_velocity < 5.0
+    assert result.parts_stayed_together
+
+
+def test_an_unknown_scenario_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown scenario"):
+        simulate_usdz(_export(_hinged_box(), tmp_path), tmp_path / "sim", scenario="wobble")

--- a/tests/test_simulation_viewer.py
+++ b/tests/test_simulation_viewer.py
@@ -1,0 +1,108 @@
+"""The viewer plays back what the simulation recorded."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mini_articraft.sdk import (
+    ArticulatedObject,
+    ArticulationType,
+    BoxGeometry,
+    Material,
+    MotionLimits,
+    Origin,
+)
+from mini_articraft.sdk.export import export_object
+from mini_articraft.viewer import load_viewer_run
+
+pytest.importorskip("mujoco", reason="recording motion needs the sim dependency group")
+
+from mini_articraft.simulate import simulate_usdz
+
+
+def _run_dir(tmp_path: Path) -> tuple[Path, Path]:
+    """A run directory laid out the way the viewer expects."""
+    model = ArticulatedObject("crate")
+    base = model.part("base")
+    base.add(
+        BoxGeometry((0.30, 0.20, 0.10)).translate(0.0, 0.0, 0.05),
+        name="body",
+        material=Material.HARDWOOD,
+    )
+    lid = model.part("lid")
+    lid.add(
+        BoxGeometry((0.30, 0.20, 0.01)).translate(0.0, 0.10, 0.0),
+        name="panel",
+        material=Material.STEEL,
+    )
+    model.articulation(
+        "lid_hinge",
+        ArticulationType.REVOLUTE,
+        base,
+        lid,
+        origin=Origin(xyz=(0.0, -0.10, 0.10)),
+        axis=(1.0, 0.0, 0.0),
+        motion_limits=MotionLimits(effort=5.0, velocity=2.0, lower=0.0, upper=1.5),
+    )
+
+    run_dir = tmp_path / "run"
+    result_dir = run_dir / "result"
+    export_object(model, result_dir)
+    usdz = next((result_dir / "usdz").glob("*.usdz"))
+    return run_dir, usdz
+
+
+def test_a_recorded_trajectory_reaches_the_viewer(tmp_path: Path) -> None:
+    run_dir, usdz = _run_dir(tmp_path)
+    simulation_dir = run_dir / "result" / "simulation"
+    result = simulate_usdz(usdz, simulation_dir, seconds=1.0)
+    assert result.trajectory is not None
+    (simulation_dir / f"{usdz.stem}.trajectory.json").write_text(
+        json.dumps(result.trajectory.to_payload())
+    )
+
+    version = load_viewer_run(run_dir).versions[0]
+    trajectory = version["trajectory"]
+
+    assert isinstance(trajectory, dict)
+    assert trajectory["root"] == "base"
+    assert trajectory["joints"] == ["lid_hinge"]
+    assert len(trajectory["frames"]) > 1
+
+
+def test_the_viewer_sees_no_trajectory_until_the_run_is_simulated(tmp_path: Path) -> None:
+    run_dir, _ = _run_dir(tmp_path)
+
+    version = load_viewer_run(run_dir).versions[0]
+
+    assert "trajectory" not in version
+
+
+def test_recorded_quaternions_are_unit_and_wxyz_ordered(tmp_path: Path) -> None:
+    """MuJoCo orders quaternions (w, x, y, z); three.js takes (x, y, z, w).
+
+    The viewer reorders on playback, so this pins the order it is reordering
+    from. An object dropped flat barely rotates, so w dominates.
+    """
+    run_dir, usdz = _run_dir(tmp_path)
+    result = simulate_usdz(usdz, run_dir / "result" / "simulation", seconds=1.0)
+
+    assert result.trajectory is not None
+    for frame in result.trajectory.frames:
+        quaternion = frame["root"]["quat"]
+        assert len(quaternion) == 4
+        assert sum(value * value for value in quaternion) == pytest.approx(1.0, abs=1e-3)
+        assert abs(quaternion[0]) > 0.9  # w first, and near-upright throughout
+
+
+def test_the_object_falls_to_the_floor_over_the_recording(tmp_path: Path) -> None:
+    run_dir, usdz = _run_dir(tmp_path)
+    result = simulate_usdz(usdz, run_dir / "result" / "simulation", seconds=1.0)
+
+    assert result.trajectory is not None
+    frames = result.trajectory.frames
+    assert frames[-1]["root"]["pos"][2] < frames[0]["root"]["pos"][2]
+    assert frames[-1]["t"] > frames[0]["t"]

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -114,7 +114,10 @@ def test_viewer_page_exposes_only_the_minimal_view_options() -> None:
 
     assert 'id="part-colors"' in page
     assert 'id="preview-motion"' in page
-    assert page.count('role="switch"') == 2
+    # Only shown once a run has been simulated; the option list stays enumerated
+    # here so it cannot creep.
+    assert 'id="play-simulation"' in page
+    assert page.count('role="switch"') == 3
     assert "contrastingPalette(version.model.parts.length)" in page
     assert "index%palette.length" not in page
 


### PR DESCRIPTION
Follows #81. Two problems with `simulate` as merged: you could not see what happened, and what it said about friction was not true.

## The friction was never being used

The floor was authored with `friction="1 0.005 0.0001"`. **MuJoCo combines contact friction with the elementwise maximum**, so every contact resolved to 1.0 and the friction our materials declare was ignored entirely. A rubber foot and a steel skid behaved identically, and every "stands up" verdict so far said nothing about contact behaviour.

The floor is now frictionless, so `max(0, material)` is exactly what the shape authored:

```
rubber   authored mu=0.85   contact mu=0.85
steel    authored mu=0.36   contact mu=0.36
```

## Seeing it

`--scenario tilt` settles the object, then tips the floor until it slides, measuring the coefficient back out:

```shell
uv run mini-articraft simulate runs/<run-id> --scenario tilt --seconds 8
```

```
  slipped at: 42.3 deg of tilt
  friction: measured 0.91, authored 0.85
```

That 0.85 is the **rubber feet**, not the steel body — the comparison uses the geoms actually touching the floor, because a crate on rubber feet slides on rubber whatever it is made of. Across materials the ordering holds, which is the property worth testing:

| material | authored | slipped at |
| --- | --- | --- |
| rubber | 0.85 | 32.7 deg |
| hardwood | 0.40 | 24.7 deg |
| steel | 0.36 | 23.0 deg |

The run stops the moment it slips. Tilting further topples the object and answers nothing — the first version ran to 96 degrees, threw the crate a metre in the air, and still reported "stands up". The verdict is now scenario-aware.

## One viewer

A simulation is joint values over time plus the root pose, which is exactly what the viewer already needs to pose an object. So it records a trajectory, and `mini-articraft view` gains a **Play simulation** switch that replays it in the same UI — no second viewer, no GIFs.

```
mini-articraft simulate <run>   -> verdict + result/simulation/<n>.trajectory.json
mini-articraft view <run>       -> the switch appears when that file exists
```

30 fps, ~42 KB for a 3-second run, so it rides along in the existing bootstrap payload. Playback reuses the viewer's existing `move()`; the only new thing is applying the root transform, since simulation moves the whole object and hand-posing has no concept of that. The two modes are exclusive.

A test pins the quaternion order — MuJoCo records `(w, x, y, z)`, three.js wants `(x, y, z, w)`, and getting it wrong gives you an object that tumbles subtly wrong in a way that looks plausible.

## Verification

477 passed, 0 type errors, lint and format clean. (`test_cli_rejects_missing_reference_image` fails identically on clean `main`.)

New tests: material friction reaches the contact rather than the floor's, a grippier material holds to a steeper angle, a tilt run stops at the slip angle instead of toppling, unknown scenarios are rejected, the trajectory reaches the viewer, no trajectory exists until a run is simulated, and the recorded quaternions are unit and `wxyz`.

The viewer's option guard was updated deliberately rather than loosened: it still enumerates every switch so the UI cannot creep.