### PR TITLE
Return as soon as a command finishes

### DIFF
--- a/src/mini_articraft/agent/tools/_exec.py
+++ b/src/mini_articraft/agent/tools/_exec.py
@@ -145,6 +145,13 @@ class ExecSession:
             if remaining <= 0:
                 break
             self.output_event.clear()
+            # Re-check after clearing: the readers set this event when they hit
+            # EOF, and a set landing between the drain above and this clear would
+            # otherwise be discarded, leaving nothing to wake us before the
+            # deadline. The condition only ever goes from false to true, so
+            # testing it here closes that window rather than narrowing it.
+            if not self.alive and self._streams_closed:
+                break
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(self.output_event.wait(), timeout=remaining)
 
@@ -207,6 +214,11 @@ class ExecSession:
     async def _reap_descendants_after_exit(self) -> None:
         await self.proc.wait()
         _signal_process_group(self.proc, signal.SIGKILL)
+        # Wake any poll that is waiting. The stream readers signal once at EOF,
+        # and a poll that woke on that signal before this task finished would
+        # find the exit condition still false with nothing left to wake it, so
+        # it would wait out its whole deadline for a command already done.
+        self.output_event.set()
 
     async def _read_stream(self, stream: asyncio.StreamReader, buffer: OutputBuffer) -> None:
         try:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -750,3 +750,37 @@ class FakeCompileEnv:
         }
         payload["compile_report"] = build_compile_report_from_payload(payload)
         return payload
+
+
+def test_a_finished_command_returns_immediately(tmp_path) -> None:
+    """A fast command must not wait out the yield deadline.
+
+    The stream readers signal once at EOF. A poll woken by that signal before the
+    process was reaped used to find the exit condition still false, with nothing
+    left to wake it, and sat until its deadline -- ten seconds by default, for
+    every shell command the agent ran.
+    """
+    ctx = context(tmp_path)
+
+    started = time.perf_counter()
+    result = run(get("exec_command").run(ctx, {"command": "echo hi"}))
+    elapsed = time.perf_counter() - started
+
+    assert result["returncode"] == 0
+    assert result["stdout"].strip() == "hi"
+    assert elapsed < 2.0, f"took {elapsed:.1f}s; the yield deadline is being waited out"
+
+
+def test_a_running_command_still_yields_at_its_deadline(tmp_path) -> None:
+    """The early return must not truncate work that is genuinely still going."""
+    ctx = context(tmp_path)
+
+    started = time.perf_counter()
+    result = run(
+        get("exec_command").run(ctx, {"command": "sleep 5; echo late", "yield_time_ms": 300})
+    )
+    elapsed = time.perf_counter() - started
+
+    assert result["running"] is True
+    assert "late" not in result["stdout"]
+    assert 0.2 < elapsed < 2.0, f"took {elapsed:.1f}s"


### PR DESCRIPTION
**Every shell command the agent ran cost ten seconds of wall clock**, however fast it was:

```
echo hi     10.01s      ->   0.03s
sleep 1     10.02s      ->   1.03s
seq 500     10.0s       ->   0.05s
```

## The bug

`poll()` waits on `output_event`. The stream readers set it once, when they hit EOF. But the loop's exit condition also requires `_reap_descendants_after_exit` to have finished — and that task never signalled.

So for any command that completed quickly:

1. readers hit EOF, set the event, finish
2. `poll` wakes, drains, checks the exit condition — the reaper has not finished yet, so it is still false
3. `poll` clears the event and waits again
4. **nothing will ever set it again** — the readers are done
5. it sits until the deadline, ten seconds by default

The reaper now sets the event after `proc.wait()` returns, so the poll gets a second wake once the process is genuinely reaped.

## Why this was invisible

It looks like a deliberate "collect output for up to 10s" policy, and the shape of the code supports that reading. It only shows up if you time a trivial command. I found it while asking why CI takes three and a half minutes — eight tests were sitting at *exactly* 10.02s each, which is the signature of a timer rather than work.

## What it means

Every `exec_command` the agent makes — inspecting geometry, listing files, running a probe script — was ten seconds of doing nothing. A run that inspects a dozen times spent two minutes waiting. This is wall clock and cost, not tokens.

## Verification

Two tests, and I confirmed the first fails when the fix is reverted:

- `test_a_finished_command_returns_immediately` — asserts a finished command returns in under 2s. Fails at **10.26s** with the bug reintroduced.
- `test_a_running_command_still_yields_at_its_deadline` — asserts the early return does not truncate work that is genuinely still running.

502 passed, 0 type errors, lint and format clean. Suite time drops from **3:29 to 2:09**, but that is a side effect — the ten seconds was production latency, not test setup.