### PR TITLE
Return as soon as a command finishes

### DIFF
--- a/src/mini_articraft/agent/tools/_exec.py
+++ b/src/mini_articraft/agent/tools/_exec.py
@@ -145,6 +145,13 @@ class ExecSession:
             if remaining <= 0:
                 break
             self.output_event.clear()
+            # Re-check after clearing: the readers set this event when they hit
+            # EOF, and a set landing between the drain above and this clear would
+            # otherwise be discarded, leaving nothing to wake us before the
+            # deadline. The condition only ever goes from false to true, so
+            # testing it here closes that window rather than narrowing it.
+            if not self.alive and self._streams_closed:
+                break
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(self.output_event.wait(), timeout=remaining)
 
@@ -207,6 +214,11 @@ class ExecSession:
     async def _reap_descendants_after_exit(self) -> None:
         await self.proc.wait()
         _signal_process_group(self.proc, signal.SIGKILL)
+        # Wake any poll that is waiting. The stream readers signal once at EOF,
+        # and a poll that woke on that signal before this task finished would
+        # find the exit condition still false with nothing left to wake it, so
+        # it would wait out its whole deadline for a command already done.
+        self.output_event.set()
 
     async def _read_stream(self, stream: asyncio.StreamReader, buffer: OutputBuffer) -> None:
         try:

--- a/src/mini_articraft/agent/tools/_exec.py
+++ b/src/mini_articraft/agent/tools/_exec.py
@@ -145,13 +145,6 @@ class ExecSession:
             if remaining <= 0:
                 break
             self.output_event.clear()
-            # Re-check after clearing: the readers set this event when they hit
-            # EOF, and a set landing between the drain above and this clear would
-            # otherwise be discarded, leaving nothing to wake us before the
-            # deadline. The condition only ever goes from false to true, so
-            # testing it here closes that window rather than narrowing it.
-            if not self.alive and self._streams_closed:
-                break
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(self.output_event.wait(), timeout=remaining)
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -750,37 +750,3 @@ class FakeCompileEnv:
         }
         payload["compile_report"] = build_compile_report_from_payload(payload)
         return payload
-
-
-def test_a_finished_command_returns_immediately(tmp_path) -> None:
-    """A fast command must not wait out the yield deadline.
-
-    The stream readers signal once at EOF. A poll woken by that signal before the
-    process was reaped used to find the exit condition still false, with nothing
-    left to wake it, and sat until its deadline -- ten seconds by default, for
-    every shell command the agent ran.
-    """
-    ctx = context(tmp_path)
-
-    started = time.perf_counter()
-    result = run(get("exec_command").run(ctx, {"command": "echo hi"}))
-    elapsed = time.perf_counter() - started
-
-    assert result["returncode"] == 0
-    assert result["stdout"].strip() == "hi"
-    assert elapsed < 2.0, f"took {elapsed:.1f}s; the yield deadline is being waited out"
-
-
-def test_a_running_command_still_yields_at_its_deadline(tmp_path) -> None:
-    """The early return must not truncate work that is genuinely still going."""
-    ctx = context(tmp_path)
-
-    started = time.perf_counter()
-    result = run(
-        get("exec_command").run(ctx, {"command": "sleep 5; echo late", "yield_time_ms": 300})
-    )
-    elapsed = time.perf_counter() - started
-
-    assert result["running"] is True
-    assert "late" not in result["stdout"]
-    assert 0.2 < elapsed < 2.0, f"took {elapsed:.1f}s"

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -750,3 +750,37 @@ class FakeCompileEnv:
         }
         payload["compile_report"] = build_compile_report_from_payload(payload)
         return payload
+
+
+def test_a_finished_command_returns_immediately(tmp_path) -> None:
+    """A fast command must not wait out the yield deadline.
+
+    The stream readers signal once at EOF. A poll woken by that signal before the
+    process was reaped used to find the exit condition still false, with nothing
+    left to wake it, and sat until its deadline -- ten seconds by default, for
+    every shell command the agent ran.
+    """
+    ctx = context(tmp_path)
+
+    started = time.perf_counter()
+    result = run(get("exec_command").run(ctx, {"command": "echo hi"}))
+    elapsed = time.perf_counter() - started
+
+    assert result["returncode"] == 0
+    assert result["stdout"].strip() == "hi"
+    assert elapsed < 2.0, f"took {elapsed:.1f}s; the yield deadline is being waited out"
+
+
+def test_a_running_command_still_yields_at_its_deadline(tmp_path) -> None:
+    """The early return must not truncate work that is genuinely still going."""
+    ctx = context(tmp_path)
+
+    started = time.perf_counter()
+    result = run(
+        get("exec_command").run(ctx, {"command": "sleep 5; echo late", "yield_time_ms": 300})
+    )
+    elapsed = time.perf_counter() - started
+
+    assert result["running"] is True
+    assert "late" not in result["stdout"]
+    assert 0.2 < elapsed < 2.0, f"took {elapsed:.1f}s"

--- a/tests/test_exec_unit.py
+++ b/tests/test_exec_unit.py
@@ -79,9 +79,26 @@ class _FakeProc:
     """A stand-in for a finished subprocess (returncode set, so not alive)."""
 
     def __init__(self) -> None:
-        self.returncode = 0
+        self.returncode: int | None = 0
         self.pid = None
         self.stdin = _FakeStdin()
+
+
+class _ControlledProc(_FakeProc):
+    """A subprocess whose exit order the test controls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.returncode = None
+        self._exit = asyncio.Event()
+
+    async def wait(self) -> int:
+        await self._exit.wait()
+        self.returncode = 0
+        return 0
+
+    def finish(self) -> None:
+        self._exit.set()
 
 
 async def _dead_session() -> tuple[ExecSession, _FakeProc]:
@@ -131,3 +148,41 @@ def test_exec_session_aclose_is_idempotent() -> None:
 
     assert session._closed is True
     assert proc.stdin.close_calls == 1
+
+
+def test_reaper_completion_wakes_poll_after_streams_close() -> None:
+    async def exercise() -> dict[str, object]:
+        proc = _ControlledProc()
+        session = ExecSession(
+            session_id=1,
+            proc=cast(asyncio.subprocess.Process, proc),
+            stdout=OutputBuffer(),
+            stderr=OutputBuffer(),
+            output_event=asyncio.Event(),
+        )
+
+        async def close_stream() -> None:
+            session.output_event.set()
+
+        stream_tasks = [
+            asyncio.create_task(close_stream()),
+            asyncio.create_task(close_stream()),
+        ]
+        reaper_task = asyncio.create_task(session._reap_descendants_after_exit())
+        session._readers = [*stream_tasks, reaper_task]
+        await asyncio.gather(*stream_tasks)
+
+        poll_task = asyncio.create_task(
+            session.poll(yield_time=10.0, timeout=None, max_output_chars=100)
+        )
+        await asyncio.sleep(0)
+        assert not poll_task.done()
+        assert not session.output_event.is_set()
+
+        proc.finish()
+        return await asyncio.wait_for(poll_task, timeout=0.5)
+
+    result = run(exercise())
+
+    assert result["returncode"] == 0
+    assert result["running"] is False


### PR DESCRIPTION
Re-lands #85, which was merged into `jchiu/compiler-internals` **46 seconds after** that branch had already been squash-merged to main as #84, so the fix never reached `main`. The first commit is the same change, cherry-picked onto current main.

**Fast shell commands could wait for the full ten-second yield deadline** when task scheduling exposed the missed wakeup. On the machine where this was found:

```
echo hi     10.01s   ->   0.03s
sleep 1     10.02s   ->   1.03s
seq 500     10.0s    ->   0.05s
```

## The bug

`poll()` waits on `output_event`. The stream readers set it at EOF. The loop's exit condition also requires `_reap_descendants_after_exit` to have finished, but that task did not signal.

When the readers finished before the reaper:

1. the readers hit EOF, set the event, and finished
2. `poll` woke and checked the exit condition while the reaper was still running
3. `poll` cleared the event and waited again
4. the reaper finished without setting the event
5. `poll` waited until the deadline, which is ten seconds by default

The reaper now sets the event when it finishes, so `poll` gets the final wakeup it needs.

## Why it stayed hidden

The failure depends on task ordering. It happened consistently on the machine where this was found, where eight tests sat at exactly 10.02 seconds. On another machine, the reaper often finished before `poll` checked and the same unpatched commands returned immediately.

The production cost appeared whenever the bad ordering occurred. Short geometry inspections, file listings, and probe scripts then waited for the full yield deadline after the command had finished.

## Verification

- A deterministic unit test closes the streams, waits until `poll` is blocked, and then releases the reaper.
- The test fails in 0.59 seconds when the reaper signal is removed and passes in 0.01 seconds when it is restored.
- The existing session test covers a command that is still running at its yield deadline and then completes it through `write_stdin`.
- `pytest -q --replay`: 488 passed, 2 skipped, 2 deselected in 1:36.
- `basedpyright`: 0 errors and 2 existing optional Mujoco warnings. Lint and format checks are clean.
