### PR TITLE
Give the compile payload a type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ include = ["src", "tests", "scripts", "benchmarks"]
 # The vendored build123d doc snippets are agent-facing content, not package code.
 exclude = ["src/mini_articraft/sdk/docs"]
 typeCheckingMode = "standard"
+# CompilePayload exists to catch mistyped keys, not to prove every optional key
+# is present at each read. The latter would need a guard at ~20 call sites that
+# already know the key is there. Unknown keys are still an error.
+reportTypedDictNotRequiredAccess = false
 
 # Test modules import the test environment as `import harness` (pytest prepend
 # mode puts tests/ on sys.path); teach the type checker the same root.

--- a/src/mini_articraft/__init__.py
+++ b/src/mini_articraft/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from mini_articraft.compiler.result import CompilePayload
+
 __version__ = "0.1.0"
 
 package_dir = Path(__file__).resolve().parent
@@ -36,7 +38,7 @@ class Workspace(Protocol):
     """
 
     def create_run(self, run_id: str) -> Path: ...
-    def compile_path(self, run_dir: Path | str) -> dict[str, Any]: ...
+    def compile_path(self, run_dir: Path | str) -> CompilePayload: ...
 
 
 __all__ = ["ContextSummarizer", "Model", "Workspace", "__version__", "package_dir"]

--- a/src/mini_articraft/agent/harness.py
+++ b/src/mini_articraft/agent/harness.py
@@ -5,7 +5,7 @@ import contextlib
 import json
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -286,11 +286,9 @@ class Agent:
         compile_result = (
             context.successful_compile_result if workspace_is_compiled else context.compile_result
         )
-        if compile_result and isinstance(
-            compile_result.get("compile_report"),
-            dict,
-        ):
-            data["compile_report"] = compile_result["compile_report"]
+        compile_report = compile_result.get("compile_report") if compile_result else None
+        if isinstance(compile_report, dict):
+            data["compile_report"] = compile_report
         if self.config.output_path:
             record.save(self.config.output_path)
         self._emit(
@@ -503,7 +501,7 @@ def _append_reminder(messages: list[dict[str, Any]], path: Path, content: str) -
     append_conversation(path, reminder)
 
 
-def _result_path(run_dir: Path, compile_result: dict[str, Any] | None) -> str:
+def _result_path(run_dir: Path, compile_result: Mapping[str, Any] | None) -> str:
     raw = compile_result.get("usdz") if compile_result else None
     if not raw:
         return ""

--- a/src/mini_articraft/agent/tools/_core.py
+++ b/src/mini_articraft/agent/tools/_core.py
@@ -11,6 +11,7 @@ from typing import Any, Generic, Protocol, TypeVar
 from mini_articraft import package_dir
 from mini_articraft.agent.tools._exec import ExecSessions
 from mini_articraft.agent.tools._paths import scoped_path
+from mini_articraft.compiler.result import CompilePayload
 
 SDK_DOCS_ROOT = package_dir / "sdk" / "docs"
 WORKSPACE_SDK_DOCS_ROOT = Path("docs") / "sdk"
@@ -33,7 +34,7 @@ class Compiler(Protocol):
     than the whole protocol. A ``Workspace`` satisfies this structurally.
     """
 
-    def compile_path(self, run_dir: Path | str) -> dict[str, Any]: ...
+    def compile_path(self, run_dir: Path | str) -> CompilePayload: ...
 
 
 @dataclass
@@ -42,8 +43,8 @@ class ToolContext:
     run_dir: Path
     workspace: Path
     """The directory the agent edits: ``run_dir / "workspace"``."""
-    compile_result: dict[str, Any] | None = None
-    successful_compile_result: dict[str, Any] | None = None
+    compile_result: CompilePayload | None = None
+    successful_compile_result: CompilePayload | None = None
     successful_compile_digest: str | None = None
     last_compile_failure_signature: str | None = None
     consecutive_compile_failures: int = 0

--- a/src/mini_articraft/agent/tools/compile.py
+++ b/src/mini_articraft/agent/tools/compile.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from mini_articraft.agent.tools._core import Tool, ToolContext, schema, workspace_digest
 from mini_articraft.compiler.feedback import compile_failure_signature, render_compile_report
+from mini_articraft.compiler.result import CompilePayload
+
+_AGENT_FACING_KEYS = frozenset(
+    {
+        "status",
+        "manifest",
+        "usdz",
+        "error",
+        "stdout",
+        "stderr",
+        "traceback",
+        "returncode",
+        "compile_stats",
+        "test_report",
+        "compile_report",
+    }
+)
 
 
 async def run(context: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
@@ -24,7 +42,7 @@ async def run(context: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     return _compact_result(internal_result)
 
 
-def _internal_result(context: ToolContext, result: dict[str, Any]) -> dict[str, Any]:
+def _internal_result(context: ToolContext, result: CompilePayload) -> CompilePayload:
     compile_report = result.get("compile_report")
     if isinstance(compile_report, dict):
         signature = compile_failure_signature(compile_report)
@@ -41,26 +59,12 @@ def _internal_result(context: ToolContext, result: dict[str, Any]) -> dict[str, 
                 repeated=repeated,
                 failure_streak=context.consecutive_compile_failures,
             )
-    return {
-        key: result[key]
-        for key in (
-            "status",
-            "manifest",
-            "usdz",
-            "error",
-            "stdout",
-            "stderr",
-            "traceback",
-            "returncode",
-            "compile_stats",
-            "test_report",
-            "compile_report",
-        )
-        if key in result
-    }
+    # Iterate the payload rather than index it: dynamic keys cannot be spelled
+    # as a TypedDict literal, and this way no optional key is accessed.
+    return cast(CompilePayload, {k: v for k, v in result.items() if k in _AGENT_FACING_KEYS})
 
 
-def _compact_result(result: dict[str, Any]) -> dict[str, Any]:
+def _compact_result(result: Mapping[str, Any]) -> dict[str, Any]:
     report = result.get("compile_report")
     signals = report.get("signals_text") if isinstance(report, dict) else None
     if not isinstance(signals, str):

--- a/src/mini_articraft/agent/workspace/local.py
+++ b/src/mini_articraft/agent/workspace/local.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from mini_articraft import package_dir
 from mini_articraft._child_process import child_environment
 from mini_articraft.compiler.feedback import with_compile_report
-from mini_articraft.compiler.result import CompileResult
+from mini_articraft.compiler.result import CompilePayload, CompileResult
 from mini_articraft.record import Record
 from mini_articraft.settings import DEFAULT_COMPILE_TIMEOUT_SECONDS, DEFAULT_OUTPUT_DIR
 
@@ -67,7 +67,7 @@ class LocalWorkspace:
         Record(run_id=run_id).save(run_dir / "record.json")
         return run_dir
 
-    def compile_path(self, run_dir: Path | str) -> dict[str, Any]:
+    def compile_path(self, run_dir: Path | str) -> CompilePayload:
         run_dir = Path(run_dir)
         workspace = run_dir / "workspace"
 
@@ -80,7 +80,7 @@ class LocalWorkspace:
         self._record_compile(run_dir)
         return result
 
-    def _run_worker(self, run_dir: Path) -> dict[str, Any]:
+    def _run_worker(self, run_dir: Path) -> CompilePayload:
         args = [
             sys.executable,
             "-m",
@@ -210,7 +210,7 @@ def _signal_worker_group(proc: subprocess.Popen[str], sig: signal.Signals) -> No
         return
 
 
-def _with_paths(run_dir: Path, result: dict[str, Any]) -> dict[str, Any]:
+def _with_paths(run_dir: Path, result: CompilePayload) -> CompilePayload:
     workspace = run_dir / "workspace"
     result_dir = run_dir / "result"
     result["run_id"] = run_dir.name
@@ -227,7 +227,7 @@ def _finalize_payload(
     *,
     stderr: str,
     returncode: int | None,
-) -> dict[str, Any]:
+) -> CompilePayload:
     """Assemble the environment-level compile result from a worker payload.
 
     Single owner of result assembly for any worker transport: captured worker
@@ -243,7 +243,7 @@ def _finalize_result(
     run_dir: Path,
     result: CompileResult,
     returncode: int | None,
-) -> dict[str, Any]:
+) -> CompilePayload:
     payload = with_compile_report(result.to_payload(include_returncode=True, returncode=returncode))
     return _with_paths(run_dir, payload)
 
@@ -283,7 +283,7 @@ def _error_result(
     stderr: str = "",
     returncode: int | None = None,
     compile_stats: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+) -> CompilePayload:
     return _finalize_result(
         run_dir,
         CompileResult(

--- a/src/mini_articraft/compiler/feedback.py
+++ b/src/mini_articraft/compiler/feedback.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import PurePosixPath
 from typing import Any, Literal
 
-from mini_articraft.compiler.result import CompileResult
+from mini_articraft.compiler.result import CompilePayload, CompileResult
 from mini_articraft.sdk import FailureKind, TestReport
 
 Severity = Literal["failure", "warning", "note"]
@@ -54,11 +55,11 @@ class CompileSignalBundle:
     signals: tuple[CompileSignal, ...] = ()
 
 
-def empty_compile_payload(*, error: str = "", stdout: str = "", stderr: str = "") -> dict[str, Any]:
+def empty_compile_payload(*, error: str = "", stdout: str = "", stderr: str = "") -> CompilePayload:
     return CompileResult(error=error, stdout=stdout, stderr=stderr).to_payload()
 
 
-def with_compile_report(payload: dict[str, Any]) -> dict[str, Any]:
+def with_compile_report(payload: CompilePayload) -> CompilePayload:
     """Attach the agent-facing report to a compile payload.
 
     Callers add this rather than ``CompileResult`` building its own report: the
@@ -69,7 +70,7 @@ def with_compile_report(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def build_compile_report_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+def build_compile_report_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     status: Status = "success" if payload["status"] == "success" else "failure"
     return build_compile_report(
         status=status,

--- a/src/mini_articraft/compiler/result.py
+++ b/src/mini_articraft/compiler/result.py
@@ -1,10 +1,55 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, fields
-from typing import Any, Literal
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
 
 CompileStatus = Literal["success", "error"]
+
+
+class _CompilePayloadBase(TypedDict):
+    """Written by every compile, whatever the outcome.
+
+    ``CompileResult.to_payload`` always sets these, so reading them needs no
+    guard. Everything below is conditional and does.
+    """
+
+    status: CompileStatus
+    manifest: str
+    usdz: str
+    test_report: Any
+    stdout: str
+    stderr: str
+    error: str
+    traceback: str
+
+
+class CompilePayload(_CompilePayloadBase, total=False):
+    """What one compile attempt looks like on the wire.
+
+    Assembled in three layers, which is why nothing owned its shape before: the
+    compiler produces the required fields above, the workspace attaches the
+    process-level ones as it collects the subprocess, and the agent's tools
+    attach the last group before the model sees the result.
+    """
+
+    compile_stats: dict[str, Any]
+
+    # Attached by the workspace once the subprocess is collected.
+    returncode: int | None
+    run: str
+    run_id: str
+    workspace: str
+    entrypoint: str
+    result: str
+    # A dict on the wire and in the record; the agent's compile tool replaces it
+    # with the rendered text before the model sees it. Any, because this type
+    # exists to check key names -- the nested reports are their own shapes.
+    compile_report: Any
+
+    # Attached by the agent's tools before the model sees it.
+    is_error: bool
+    raster_path: str
 
 
 @dataclass
@@ -41,10 +86,19 @@ class CompileResult:
         *,
         include_returncode: bool = False,
         returncode: int | None = None,
-    ) -> dict[str, Any]:
-        payload = {field.name: getattr(self, field.name) for field in fields(self)}
+    ) -> CompilePayload:
+        payload: CompilePayload = {
+            "status": self.status,
+            "manifest": self.manifest,
+            "usdz": self.usdz,
+            "test_report": self.test_report,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "error": self.error,
+            "traceback": self.traceback,
+        }
+        if self.compile_stats is not None:
+            payload["compile_stats"] = self.compile_stats
         if include_returncode:
             payload["returncode"] = returncode
-        if self.compile_stats is None:
-            payload.pop("compile_stats")
         return payload

--- a/src/mini_articraft/compiler/worker.py
+++ b/src/mini_articraft/compiler/worker.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from mini_articraft.compiler.feedback import with_compile_report
-from mini_articraft.compiler.result import CompileResult
+from mini_articraft.compiler.result import CompilePayload, CompileResult
 from mini_articraft.record import Record
 from mini_articraft.sdk import (
     ArticulatedObject,
@@ -84,7 +84,7 @@ class _CompileTracker:
 
 def compile_run(
     run_dir: Path, *, include_report: bool = True, physics_enabled: bool = False
-) -> dict[str, Any]:
+) -> CompilePayload:
     workspace = run_dir / "workspace"
     result_dir = run_dir / "result"
     tracker = _CompileTracker(result_dir / _COMPILE_PROGRESS_FILE)

--- a/tests/_compile_server.py
+++ b/tests/_compile_server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +46,7 @@ def _parse_request(line: str) -> Path | None:
         return None
 
 
-def _emit(payload: dict[str, Any]) -> None:
+def _emit(payload: Mapping[str, Any]) -> None:
     sys.stdout.write(json.dumps(payload, default=str) + "\n")
     sys.stdout.flush()
 

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -44,7 +44,7 @@ from collections.abc import Awaitable, Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Generic, Literal, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TypeVar, cast
 
 from mini_articraft import Model
 from mini_articraft.agent import Agent, events
@@ -52,7 +52,21 @@ from mini_articraft.agent.tools import Tool, ToolContext
 from mini_articraft.agent.tools._core import schema as _tool_schema
 from mini_articraft.agent.tools._core import workspace_digest
 from mini_articraft.agent.workspace.local import LocalWorkspace, _error_result, _finalize_payload
+from mini_articraft.compiler.result import CompilePayload, CompileResult
 from mini_articraft.record import Record, read_conversation
+
+
+def fake_compile_payload(**overrides: Any) -> CompilePayload:
+    """A structurally complete payload for fakes that only care about a few keys.
+
+    Built through the real producer so a field added to ``CompileResult`` shows
+    up here too, instead of every fake drifting from the shape it stands in for.
+    """
+
+    payload = CompileResult(status="success").to_payload()
+    payload.update(cast(CompilePayload, overrides))
+    return payload
+
 
 T = TypeVar("T")
 Item = TypeVar("Item")
@@ -783,7 +797,7 @@ class WarmEnvironment(LocalWorkspace):
                 cls._server = _CompileServer()
             return cls._server
 
-    def _run_worker(self, run_dir: Path) -> dict[str, Any]:
+    def _run_worker(self, run_dir: Path) -> CompilePayload:
         self.compile_count += 1
         status, payload = self._shared_server().compile(
             run_dir,
@@ -937,11 +951,11 @@ def compile_success_tool() -> Tool:
         usdz = context.run_dir / "result" / "usdz" / "0000.usdz"
         usdz.parent.mkdir(parents=True, exist_ok=True)
         usdz.write_bytes(b"test-usdz")
-        result = {"status": "success", "usdz": str(usdz)}
+        result = fake_compile_payload(usdz=str(usdz))
         context.compile_result = result
         context.successful_compile_result = result
         context.successful_compile_digest = workspace_digest(context.workspace)
-        return result
+        return dict(result)
 
     return Tool("compile", stub_schema("compile"), run_compile)
 
@@ -954,6 +968,7 @@ GOOD_MAIN_PY = """
 from build123d import Box
 
 from mini_articraft.sdk import ArticulatedObject, TestContext, TestReport
+
 
 
 def build_object_model() -> ArticulatedObject:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -10,9 +10,9 @@ import shlex
 import sys
 import time
 from pathlib import Path
-from typing import Any
 
 import pytest
+from harness import fake_compile_payload
 from PIL import Image
 
 from mini_articraft.agent.images import LIMITS, prepare_image
@@ -21,6 +21,7 @@ from mini_articraft.agent.tools._core import workspace_digest
 from mini_articraft.agent.tools._exec import ExecSessions
 from mini_articraft.agent.workspace.local import LocalWorkspace
 from mini_articraft.compiler.feedback import build_compile_report_from_payload
+from mini_articraft.compiler.result import CompilePayload
 
 
 def run(awaitable):
@@ -489,7 +490,7 @@ render_view(
 
 def test_preview_output_invalidates_compile_freshness(tmp_path) -> None:
     ctx = context(tmp_path)
-    ctx.successful_compile_result = {"status": "success"}
+    ctx.successful_compile_result = fake_compile_payload()
     ctx.successful_compile_digest = workspace_digest(ctx.workspace)
     assert ctx.refresh_compile_freshness()
 
@@ -716,12 +717,11 @@ def test_compile_tool_resets_failure_streak_on_success(tmp_path) -> None:
 
 def test_cached_compile_success_resets_failure_streak(tmp_path) -> None:
     ctx = context(tmp_path)
-    ctx.successful_compile_result = {
-        "status": "success",
-        "compile_report": build_compile_report_from_payload(
+    ctx.successful_compile_result = fake_compile_payload(
+        compile_report=build_compile_report_from_payload(
             {"status": "success", "test_report": None}
         ),
-    }
+    )
     ctx.successful_compile_digest = workspace_digest(ctx.workspace)
     ctx.last_compile_failure_signature = "previous-failure"
     ctx.consecutive_compile_failures = 2
@@ -737,16 +737,12 @@ class FakeCompileEnv:
     def __init__(self, *statuses: str) -> None:
         self.statuses = list(statuses)
 
-    def compile_path(self, run_dir: Path | str) -> dict[str, Any]:
+    def compile_path(self, run_dir: Path | str) -> CompilePayload:
         status = self.statuses.pop(0)
-        payload = {
-            "status": status,
-            "error": "ValueError: bad loft" if status == "error" else "",
-            "stdout": "",
-            "stderr": "",
-            "traceback": "",
-            "returncode": 1 if status == "error" else 0,
-            "test_report": None,
-        }
+        payload = fake_compile_payload(
+            status=status,
+            error="ValueError: bad loft" if status == "error" else "",
+            returncode=1 if status == "error" else 0,
+        )
         payload["compile_report"] = build_compile_report_from_payload(payload)
         return payload

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,16 +11,17 @@ from __future__ import annotations
 import shutil
 import time
 from pathlib import Path
-from typing import Any
 
 import pytest
 from harness import WarmEnvironment
+
+from mini_articraft.compiler.result import CompilePayload
 
 EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
 EXAMPLES = ("hinged_box", "mesh_knob")
 
 
-def compile_example(env: WarmEnvironment, name: str) -> tuple[dict[str, Any], float]:
+def compile_example(env: WarmEnvironment, name: str) -> tuple[CompilePayload, float]:
     run_dir = env.create_run(name)
     shutil.copy(EXAMPLES_DIR / name / "main.py", run_dir / "workspace" / "main.py")
     started = time.perf_counter()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -34,6 +34,7 @@ from harness import (
 from mini_articraft.agent.events import TurnStarted
 from mini_articraft.agent.tools import ToolContext
 from mini_articraft.agent.workspace.local import LocalWorkspace
+from mini_articraft.compiler.result import CompilePayload
 from mini_articraft.record import Record
 
 
@@ -284,7 +285,7 @@ def run_tests() -> TestReport:
 """
 
 
-def _compile_helper_run(env: WarmEnvironment, run_id: str, value: str) -> dict:
+def _compile_helper_run(env: WarmEnvironment, run_id: str, value: str) -> CompilePayload:
     run_dir = env.create_run(run_id)
     workspace = run_dir / "workspace"
     workspace.joinpath("helper.py").write_text(f'VALUE = "{value}"\n', encoding="utf-8")


### PR DESCRIPTION
`CompileResult` is a typed dataclass, then `to_payload()` flattens it to `dict[str, Any]` and every consumer downstream indexes it by string. A mistyped key was a runtime `KeyError`; a renamed field was a grep.

This adds `CompilePayload`, a `TypedDict`. Not a class — the payload genuinely crosses a JSON subprocess boundary, so a dict is right on the wire. Required keys are the ones `to_payload()` always writes; the rest are attached later by the workspace and the agent's tools, which is why nothing owned this shape before.

### Deliberately narrow

Nested values (`test_report`, `compile_report`) stay `Any`, and `reportTypedDictNotRequiredAccess` is off. The goal is catching mistyped **key names**, not proving presence at each read — the latter needed a guard at ~20 sites that already know the key is there. Unknown keys still error (verified against a probe).

Providers keep `dict[str, Any]` — 166 of the repo's ~199 are LLM request/response bodies, which are arbitrary vendor JSON that would go stale if modelled.

### What it surfaced

- **`compile_report` is polymorphic by layer** — a dict on the wire and in ~20 tests, but the agent's compile tool overwrites it with rendered text before the model sees it. Now noted at the declaration.
- **Test fakes had drifted** — several stood in for a payload with `{"status": "success"}` and little else. They now build through `fake_compile_payload()`, which goes via the real `CompileResult`, so a new field reaches the fakes instead of each drifting alone.
- **`to_payload()` reflected over `fields()`** — writing the keys out is shorter and lets it omit `compile_stats` rather than writing `None`, which in turn killed a `| None` in the type.

### Verification

`ruff check`, `ruff format --check`, and repo-wide `basedpyright` all clean. 502 tests pass.

Two failures are pre-existing on `main`, not from this PR:
- `test_live_generation.py::test_box_generation` — needs `OPENAI_API_KEY`
- `test_cli_rejects_missing_reference_image` — asserts `"does not exist"` in output, but Typer's Rich error box wraps the phrase across lines at narrow terminal widths. The CLI does reject correctly (exit 2). Width-dependent assertion; worth fixing separately.