### PR TITLE
Move the agent's protocols in with the agent

### DIFF
--- a/src/mini_articraft/__init__.py
+++ b/src/mini_articraft/__init__.py
@@ -1,44 +1,15 @@
+"""Generate articulated objects with an agent that writes build123d.
+
+Only package metadata lives here, so importing ``mini_articraft`` costs
+nothing. The agent's plugin interfaces are in ``mini_articraft.agent``.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
-
-from mini_articraft.compiler.result import CompilePayload
 
 __version__ = "0.1.0"
 
 package_dir = Path(__file__).resolve().parent
 
-
-class Model(Protocol):
-    async def query(
-        self,
-        messages: list[dict[str, Any]],
-        *,
-        tools: list[dict[str, Any]] | None = None,
-    ) -> dict[str, Any]: ...
-    async def close(self) -> None: ...
-
-
-@runtime_checkable
-class ContextSummarizer(Protocol):
-    async def summarize_context(
-        self,
-        messages: list[dict[str, Any]],
-        *,
-        max_output_tokens: int,
-    ) -> dict[str, Any]: ...
-
-
-class Workspace(Protocol):
-    """Where the agent's work lives, and therefore where it runs.
-
-    Both halves vary together: whatever machine holds the run directory is the
-    machine that has to compile it.
-    """
-
-    def create_run(self, run_id: str) -> Path: ...
-    def compile_path(self, run_dir: Path | str) -> CompilePayload: ...
-
-
-__all__ = ["ContextSummarizer", "Model", "Workspace", "__version__", "package_dir"]
+__all__ = ["__version__", "package_dir"]

--- a/src/mini_articraft/agent/__init__.py
+++ b/src/mini_articraft/agent/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from mini_articraft.agent.harness import Agent, AgentConfig
+from mini_articraft.agent.protocols import ContextSummarizer, Model, Workspace
 
-__all__ = ["Agent", "AgentConfig"]
+__all__ = ["Agent", "AgentConfig", "ContextSummarizer", "Model", "Workspace"]

--- a/src/mini_articraft/agent/harness.py
+++ b/src/mini_articraft/agent/harness.py
@@ -13,10 +13,11 @@ from typing import Any
 from pydantic import BaseModel
 
 import mini_articraft.agent.tools as tools
-from mini_articraft import ContextSummarizer, Model, Workspace, package_dir
+from mini_articraft import package_dir
 from mini_articraft.agent import events
 from mini_articraft.agent.compaction import SUMMARY_MAX_OUTPUT_TOKENS, prepare_compaction
 from mini_articraft.agent.images import PreparedImage, prepare_image
+from mini_articraft.agent.protocols import ContextSummarizer, Model, Workspace
 from mini_articraft.agent.record import Record, append_conversation
 from mini_articraft.agent.tools import ToolContext
 from mini_articraft.settings import DEFAULT_MAX_TURNS

--- a/src/mini_articraft/agent/protocols.py
+++ b/src/mini_articraft/agent/protocols.py
@@ -1,0 +1,53 @@
+"""The agent's swappable pieces.
+
+Three things vary between runs: which model answers, how context is compacted
+when it grows too long, and where the work lives. Each is a protocol rather
+than a base class so an implementation only has to match the shape -- the
+providers, the workspaces, and the test fakes all satisfy these structurally
+without importing them.
+
+These live here rather than at the package root because every implementation
+and every consumer is inside ``mini_articraft.agent``, and ``Workspace`` has to
+name the compiler's payload type to describe what a compile returns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from mini_articraft.compiler.result import CompilePayload
+
+
+class Model(Protocol):
+    async def query(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]: ...
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class ContextSummarizer(Protocol):
+    async def summarize_context(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        max_output_tokens: int,
+    ) -> dict[str, Any]: ...
+
+
+class Workspace(Protocol):
+    """Where the agent's work lives, and therefore where it runs.
+
+    Both halves vary together: whatever machine holds the run directory is the
+    machine that has to compile it.
+    """
+
+    def create_run(self, run_id: str) -> Path: ...
+    def compile_path(self, run_dir: Path | str) -> CompilePayload: ...
+
+
+__all__ = ["ContextSummarizer", "Model", "Workspace"]

--- a/src/mini_articraft/agent/provider/__init__.py
+++ b/src/mini_articraft/agent/provider/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mini_articraft import Model
+from mini_articraft.agent.protocols import Model
 from mini_articraft.agent.provider.anthropic import AnthropicModel
 from mini_articraft.agent.provider.anthropic import (
     context_window_tokens_for as anthropic_context_window_tokens_for,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from typing import Protocol
 import pytest
 from harness import TAPE_ROOT, ReplayHarness
 
-from mini_articraft import Model
+from mini_articraft.agent import Model
 
 
 @pytest.fixture(scope="session")

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -46,8 +46,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Generic, Literal, TypeVar, cast
 
-from mini_articraft import Model
-from mini_articraft.agent import Agent, events
+from mini_articraft.agent import Agent, Model, events
 from mini_articraft.agent.record import Record, read_conversation
 from mini_articraft.agent.tools import Tool, ToolContext
 from mini_articraft.agent.tools._core import schema as _tool_schema


### PR DESCRIPTION
> Not for merging yet — putting it up for review as asked.

The package root declared `Model`, `ContextSummarizer` and `Workspace`, and had to import the compiler to do it (`Workspace.compile_path` is annotated with `CompilePayload`). So `import mini_articraft` — which most modules do only to get `package_dir` — pulled in the compiler, and the root package depended on a subpackage.

That was **the one edge in the graph running the wrong way**.

### Before / after

```
before                              after
  __init__ -> compiler   ← inverted   agent    -> compiler
  agent    -> compiler                agent    -> __init__   (package_dir)
  agent    -> settings                compiler -> sdk
  compiler -> sdk                     cli      -> agent
  cli      -> agent                   ...
```

```
$ python -c "import mini_articraft; ..."
submodules pulled in by `import mini_articraft`: none
root __init__ outgoing: none — pure metadata
cycles: none
```

### Why `agent/protocols.py` and not `agent/__init__.py`

`agent/__init__.py` imports `harness`, and `harness` needs the protocols — routing that through `__init__` would cycle. So they live in their own module and `agent/__init__` re-exports them; `from mini_articraft.agent import Model` works.

### Why `CompilePayload` didn't move

It was suggested it belongs with `workspace`. It can't: `compiler/result.py`'s `to_payload()` *returns* it, so putting the type in `agent/workspace/` would make the compiler import from the agent — inverting the one edge that was already correct. The compiler produces the payload, so the type stays at or below the compiler.

### Public path change

`from mini_articraft import Model` → `from mini_articraft.agent import Model`. Only `agent/provider/__init__.py` and two test files used it. Arguably it *should* be the longer path — it's an agent-specific interface, not a package-level concept. `package_dir` is unaffected.

### Verification

`ruff check`, `ruff format --check`, repo-wide `basedpyright` clean; 504 pass. Swept for stale references across `src tests docs examples benchmarks scripts .github AGENTS.md README.md` — including `.github/`, which is what I missed on #92 — and ran the CI wheel smoke-test commands locally, which is the check that would have caught that break.