### PR TITLE
Say six threads, since there are six

### DIFF
--- a/src/mini_articraft/sdk/__init__.py
+++ b/src/mini_articraft/sdk/__init__.py
@@ -4,7 +4,7 @@ Everything here is imported from the package root, and mesh recipes also from
 ``mini_articraft.sdk.mesh``. The modules below are how the source is organised,
 not extra import paths.
 
-Five threads run through this package:
+Six threads run through this package:
 
 - **structure** -- what the object is and how it moves. ``object`` holds
   ``Part`` and ``ArticulatedObject``; ``joints`` holds ``Articulation`` and
@@ -21,7 +21,6 @@ Five threads run through this package:
   which the authored ``run_tests()`` uses.
 - **inspect** -- seeing the result. ``visual`` renders views for the author to
   look at.
-
 - **publish** -- writing the result out. ``export`` turns a model into a
   validated USDZ package plus its manifest. It is imported explicitly rather
   than re-exported here, which keeps OpenUSD out of a plain


### PR DESCRIPTION
One-line docstring fix. `sdk/__init__.py` says "Five threads" and then lists six — `publish` was added when the #92 revert put `export` back in the SDK, and the count above it was never updated. Also drops a stray blank line before that bullet.

I caught this while reviewing #93 and fixed it locally, but pushed without committing the fix, so the defect landed. Reporting it as fixed when it wasn't was the actual error.

No code change; `ruff` and `basedpyright` clean.