### PR TITLE
Keep a joint's axis when converting USD to MJCF

### DIFF
--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -442,17 +442,22 @@ def _read_scene(stage: Usd.Stage) -> _Scene:
 
 
 def _joint_axis(prim: Usd.Prim) -> tuple[float, float, float]:
-    """The joint's axis in the parent body's frame.
+    """The joint's axis in the child body's frame, which is what MJCF wants.
 
     UsdPhysics names one of three cardinal axes and then rotates the joint
     frame to point it wherever it belongs, so the token alone is only half the
     answer -- a hinge on -X is written as "X" plus a half turn. Reading the
     token by itself silently flips every joint whose axis is not a positive
     cardinal direction.
+
+    The rotation to apply is localRot1, not localRot0. MJCF writes the axis
+    inside the child body, and only localRot1 is the bare axis rotation;
+    localRot0 also folds in the joint origin's rpy, which is a different
+    quantity and produces a wrong axis for any joint with a rotated origin.
     """
 
     axis = np.array(_AXES.get(str(_attr(prim, "physics:axis", "Z")), (0.0, 0.0, 1.0)))
-    rotation = _attr(prim, "physics:localRot0")
+    rotation = _attr(prim, "physics:localRot1")
     if rotation is not None:
         axis = _quat_matrix(rotation) @ axis
     return (float(round(axis[0], 12)), float(round(axis[1], 12)), float(round(axis[2], 12)))

--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -433,12 +433,43 @@ def _read_scene(stage: Usd.Stage) -> _Scene:
                 parent=bodies[0][0].name,
                 child=bodies[1][0].name,
                 anchor=_triple(_attr(prim, "physics:localPos1", (0.0, 0.0, 0.0))),
-                axis=_AXES.get(str(_attr(prim, "physics:axis", "Z")), (0.0, 0.0, 1.0)),
+                axis=_joint_axis(prim),
                 lower=_number(_attr(prim, "physics:lowerLimit")),
                 upper=_number(_attr(prim, "physics:upperLimit")),
             )
         )
     return scene
+
+
+def _joint_axis(prim: Usd.Prim) -> tuple[float, float, float]:
+    """The joint's axis in the parent body's frame.
+
+    UsdPhysics names one of three cardinal axes and then rotates the joint
+    frame to point it wherever it belongs, so the token alone is only half the
+    answer -- a hinge on -X is written as "X" plus a half turn. Reading the
+    token by itself silently flips every joint whose axis is not a positive
+    cardinal direction.
+    """
+
+    axis = np.array(_AXES.get(str(_attr(prim, "physics:axis", "Z")), (0.0, 0.0, 1.0)))
+    rotation = _attr(prim, "physics:localRot0")
+    if rotation is not None:
+        axis = _quat_matrix(rotation) @ axis
+    return (float(round(axis[0], 12)), float(round(axis[1], 12)), float(round(axis[2], 12)))
+
+
+def _quat_matrix(rotation: Any) -> np.ndarray:
+    """Rotation matrix for a USD quaternion (real part plus imaginary vector)."""
+
+    w = float(rotation.GetReal())
+    x, y, z = (float(v) for v in rotation.GetImaginary())
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
 
 
 def _add_body(

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -203,3 +203,25 @@ def test_releasing_a_joint_produces_motion_worth_watching(tmp_path: Path) -> Non
     angles = [frame["joints"][0] for frame in result.trajectory.frames]
     assert max(angles) - min(angles) > 0.5  # radians
     assert result.peak_joint_speed is not None and result.peak_joint_speed > 1.0
+
+
+def _negative_axis_hinge() -> ArticulatedObject:
+    """The crate, hinged on -X instead of +X."""
+    model = _hinged_box()
+    model.articulations[-1].axis = (-1.0, 0.0, 0.0)
+    return model
+
+
+def test_a_negative_hinge_axis_survives_the_round_trip(tmp_path: Path) -> None:
+    """UsdPhysics names a cardinal axis and rotates the joint frame to aim it.
+
+    A -X hinge is written as "X" plus a half turn about Z, so reading the axis
+    token alone flips it. A flipped hinge does not fail loudly -- gravity simply
+    drives the joint the wrong way, and a lid that should hang shut swings open.
+    """
+    write_mjcf(_export(_negative_axis_hinge(), tmp_path), tmp_path / "sim")
+    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
+
+    assert joint is not None
+    axis = tuple(round(float(value), 6) for value in str(joint.get("axis")).split())
+    assert axis == (-1.0, 0.0, 0.0)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -205,10 +205,12 @@ def test_releasing_a_joint_produces_motion_worth_watching(tmp_path: Path) -> Non
     assert result.peak_joint_speed is not None and result.peak_joint_speed > 1.0
 
 
-def _negative_axis_hinge() -> ArticulatedObject:
-    """The crate, hinged on -X instead of +X."""
+def _negative_axis_hinge(rpy: tuple[float, float, float] = (0.0, 0.0, 0.0)) -> ArticulatedObject:
+    """The crate, hinged on -X instead of +X, optionally with a rotated origin."""
     model = _hinged_box()
-    model.articulations[-1].axis = (-1.0, 0.0, 0.0)
+    joint = model.articulations[-1]
+    joint.axis = (-1.0, 0.0, 0.0)
+    joint.origin = Origin(xyz=joint.origin.xyz, rpy=rpy)
     return model
 
 
@@ -220,6 +222,22 @@ def test_a_negative_hinge_axis_survives_the_round_trip(tmp_path: Path) -> None:
     drives the joint the wrong way, and a lid that should hang shut swings open.
     """
     write_mjcf(_export(_negative_axis_hinge(), tmp_path), tmp_path / "sim")
+    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
+
+    assert joint is not None
+    axis = tuple(round(float(value), 6) for value in str(joint.get("axis")).split())
+    assert axis == (-1.0, 0.0, 0.0)
+
+
+def test_a_rotated_joint_origin_does_not_disturb_the_axis(tmp_path: Path) -> None:
+    """The axis rotation is localRot1; localRot0 also carries the origin's rpy.
+
+    Both frames agree when the origin is unrotated, so reading localRot0 passes
+    the simple case and then quietly bends the axis for any joint whose origin
+    is turned -- a -X hinge with a 90 degree yaw comes out as -Y.
+    """
+    model = _negative_axis_hinge(rpy=(0.0, 0.0, math.pi / 2))
+    write_mjcf(_export(model, tmp_path), tmp_path / "sim")
     joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
 
     assert joint is not None


### PR DESCRIPTION
### What happened

UsdPhysics doesn't store an axis vector. It names one of three cardinal axes and rotates the joint frame to aim it — our own exporter documents this: *"USD joints use their local X axis. The exporter rotates that X axis to the normalized SDK articulation axis."*

So a `-X` hinge is written as:

```
physics:axis      = X
physics:localRot0 = (6.12e-17, 0, 0, 1)      w≈0, z=1  →  180° about Z
```

The converter read the token and threw the rotation away:

```python
axis=_AXES.get(str(_attr(prim, "physics:axis", "Z")), (0.0, 0.0, 1.0))
```

Every joint whose axis wasn't a positive cardinal direction came out flipped. Non-cardinal axes were worse — they missed the dict and silently fell back to `Z`.

### Why it was invisible

Nothing errored. Limits, anchor, and body nesting were all correct, so the joint looked fine — gravity just drove it the wrong way. On the toolbox: `qfrc_bias = -3.52 N·m` accelerated the hinge *positive* (open) when the lid's centre of mass should have held it against the lower limit of 0. It swung open and landed on the floor at 55°.

```
                    before          after
lid angle at rest    54.8°           -0.1°
deepest penetration  -8.09 mm        -4.12 mm     (no longer flopping onto the floor)
```

### A wrong turn worth recording

I first found 3.6 cm³ of solid interpenetration between the closed lid and the body and called it the cause. It isn't — MuJoCo excludes parent/child contacts by default, and there were **0 contacts at t=0**. Overlapping adjacent links is normal for articulated bodies. The overlap is irrelevant here; I'd jumped on the first suspicious thing I measured.

### Test

`test_a_negative_hinge_axis_survives_the_round_trip` asserts the sign survives export → MJCF. Verified it **fails against the old reader** and passes with the fix, rather than assuming.

### Verification

`ruff check`, `ruff format --check`, repo-wide `basedpyright` clean; 505 pass (504 + the new one). Same two pre-existing failures as `main`.