### PR TITLE
Fail clearly when mass union fails

### DIFF
--- a/src/mini_articraft/sdk/mass.py
+++ b/src/mini_articraft/sdk/mass.py
@@ -258,7 +258,7 @@ def _triple(values) -> tuple[float, float, float]:
 
 
 def _combine(meshes: list[trimesh.Trimesh], *, part_name: str) -> trimesh.Trimesh | None:
-    """One solid for the part: a union when it succeeds, else the closed shapes."""
+    """Combine closed shapes without silently counting overlapping volume twice."""
 
     solids: list[trimesh.Trimesh] = []
     open_shapes = 0
@@ -289,13 +289,17 @@ def _combine(meshes: list[trimesh.Trimesh], *, part_name: str) -> trimesh.Trimes
         # Shapes are deliberately embedded in each other, so a union avoids
         # counting the shared volume twice.
         union = trimesh.boolean.union(solids)
-        if union is not None and union.is_watertight and float(union.volume) > 0.0:
-            return union
-    except Exception:
-        pass
-    # Fall back to treating the shapes as one body: mass and inertia still add up
-    # (parallel-axis, via trimesh's concatenation), overlaps just count twice.
-    return trimesh.util.concatenate(solids)
+    except Exception as exc:
+        raise ValidationError(
+            f"part {part_name!r} shapes could not be combined for mass measurement; "
+            "simplify the geometry or set explicit mass properties"
+        ) from exc
+    if union is None or not union.is_watertight or float(union.volume) <= 0.0:
+        raise ValidationError(
+            f"part {part_name!r} shapes did not produce a closed solid for mass measurement; "
+            "simplify the geometry or set explicit mass properties"
+        )
+    return union
 
 
 def _quaternion(rotation: np.ndarray) -> tuple[float, float, float, float]:

--- a/tests/test_mass_properties.py
+++ b/tests/test_mass_properties.py
@@ -110,6 +110,26 @@ def test_overlapping_shapes_do_not_double_count_mass() -> None:
     assert resolved.mass == pytest.approx(union_volume * 1000.0, rel=1e-3)
 
 
+def test_union_failure_does_not_silently_double_count_mass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _box((0.1, 0.1, 0.1))
+    second = _box((0.1, 0.1, 0.1))
+    second.apply_translation((0.05, 0.0, 0.0))
+
+    def fail_union(_meshes):
+        raise RuntimeError("boolean engine failed")
+
+    monkeypatch.setattr(trimesh.boolean, "union", fail_union)
+
+    with pytest.raises(ValidationError, match="could not be combined"):
+        resolve_mass(
+            MassProperties(density=1000.0),
+            [(first, None), (second, None)],
+            part_name="pair",
+        )
+
+
 def test_export_writes_mass_api_attributes(tmp_path) -> None:
     model = ArticulatedObject("massed")
     part = model.part("body")


### PR DESCRIPTION
## What changed

Mass measurement now raises a clear validation error when multiple shapes cannot be combined into one valid closed solid.

## Why

The previous fallback concatenated the meshes. Overlapping volume was then counted more than once, which could silently produce the wrong mass and inertia.

## Impact

Authors now get an error that asks them to simplify the geometry or provide explicit mass properties. The code no longer returns a result known to be unreliable.

## Checks

`uv run pytest -q tests/test_mass_properties.py`

`uv run ruff check src/mini_articraft/sdk/mass.py tests/test_mass_properties.py`

`uv run ruff format --check src/mini_articraft/sdk/mass.py tests/test_mass_properties.py`
