### PR TITLE
Allow prismatic motion in simulation checks

### DIFF
--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -241,11 +241,11 @@ def simulate_usdz(
         mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, index) for index in range(1, model.nbody)
     )
     start = data.xpos[1:].copy()
-    separations = {
-        (a, b): float(np.linalg.norm(data.xpos[a] - data.xpos[b]))
-        for a in range(1, model.nbody)
-        for b in range(a + 1, model.nbody)
-    }
+    separations = _tracked_body_separations(
+        model,
+        data.xpos,
+        slide_joint_type=mujoco.mjtJoint.mjJNT_SLIDE,
+    )
 
     root_body = 1  # the free body; MuJoCo orders bodies from the world outward
     movable = [
@@ -352,6 +352,46 @@ def simulate_usdz(
             frames=tuple(frames),
         ),
     )
+
+
+def _tracked_body_separations(
+    model: Any,
+    positions: Any,
+    *,
+    slide_joint_type: Any,
+) -> dict[tuple[int, int], float]:
+    """Body distances that should stay fixed while joints move.
+
+    A slide joint moves its whole child subtree relative to the rest of the
+    object. Distances that cross that joint are expected to change, while
+    distances within either side still catch parts that come apart.
+    """
+
+    slide_roots = {
+        int(model.jnt_bodyid[index])
+        for index in range(model.njnt)
+        if model.jnt_type[index] == slide_joint_type
+    }
+    parents = model.body_parentid
+
+    def crosses_slide(first: int, second: int) -> bool:
+        return any(
+            _is_descendant(first, root, parents) != _is_descendant(second, root, parents)
+            for root in slide_roots
+        )
+
+    return {
+        (first, second): float(np.linalg.norm(positions[first] - positions[second]))
+        for first in range(1, model.nbody)
+        for second in range(first + 1, model.nbody)
+        if not crosses_slide(first, second)
+    }
+
+
+def _is_descendant(body: int, root: int, parents: Any) -> bool:
+    while body and body != root:
+        body = int(parents[body])
+    return body == root
 
 
 def _floor_friction(model: Any, data: Any) -> float | None:

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -203,3 +203,39 @@ def test_releasing_a_joint_produces_motion_worth_watching(tmp_path: Path) -> Non
     angles = [frame["joints"][0] for frame in result.trajectory.frames]
     assert max(angles) - min(angles) > 0.5  # radians
     assert result.peak_joint_speed is not None and result.peak_joint_speed > 1.0
+
+
+def test_prismatic_travel_is_not_reported_as_part_separation(tmp_path: Path) -> None:
+    model = ArticulatedObject("lift")
+    base = model.part("base")
+    base.add(
+        BoxGeometry((0.10, 0.10, 0.02)),
+        name="base_slab",
+        material=Material.STEEL,
+    )
+    body = model.part("body")
+    body.add(
+        BoxGeometry((0.08, 0.08, 0.10)).translate(0.0, 0.0, 0.06),
+        name="body_box",
+        material=Material.STEEL,
+    )
+    model.articulation(
+        "slide",
+        ArticulationType.PRISMATIC,
+        base,
+        body,
+        axis=(0.0, 0.0, 1.0),
+        motion_limits=MotionLimits(lower=0.0, upper=0.10),
+    )
+
+    result = simulate_usdz(
+        _export(model, tmp_path),
+        tmp_path / "sim",
+        seconds=1.0,
+        scenario="release",
+    )
+
+    assert result.trajectory is not None
+    positions = [frame["joints"][0] for frame in result.trajectory.frames]
+    assert abs(positions[0]) > 0.005
+    assert result.parts_stayed_together, result.summary()

--- a/tests/test_simulation_metrics.py
+++ b/tests/test_simulation_metrics.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from mini_articraft.simulate import _tracked_body_separations
+
+
+def test_prismatic_motion_is_not_counted_as_part_separation() -> None:
+    slide = 7
+    hinge = 8
+    model = SimpleNamespace(
+        nbody=4,
+        njnt=2,
+        jnt_type=np.array([slide, hinge]),
+        jnt_bodyid=np.array([2, 3]),
+        body_parentid=np.array([0, 0, 1, 2]),
+    )
+    start = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.1],
+            [0.0, 0.0, 0.2],
+        ]
+    )
+
+    separations = _tracked_body_separations(model, start, slide_joint_type=slide)
+
+    assert set(separations) == {(2, 3)}
+    end = start.copy()
+    end[2:, 2] += 0.08
+    drift = max(
+        abs(float(np.linalg.norm(end[a] - end[b])) - distance)
+        for (a, b), distance in separations.items()
+    )
+    assert drift < 1e-12


### PR DESCRIPTION
## What changed

The simulation separation check now excludes body distances that cross a prismatic joint. It still checks distances among bodies on the same side of each prismatic joint.

## Why

Prismatic joints are meant to change the distance between their two sides. The old check treated that intended travel as a part coming loose and could reject a valid model.

## Impact

Release simulations can use prismatic travel without failing the whole object check. Unexpected distance changes elsewhere are still reported.

## Checks

`uv run --group sim pytest -q tests/test_simulate.py tests/test_simulation_metrics.py`

`uv run ruff check src/mini_articraft/simulate.py tests/test_simulate.py tests/test_simulation_metrics.py`

`uv run ruff format --check src/mini_articraft/simulate.py tests/test_simulate.py tests/test_simulation_metrics.py`
