### PR TITLE
Keep local dotenv values out of tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from harness import TAPE_ROOT, ReplayHarness
 
 from mini_articraft.agent import Model
+from mini_articraft.settings import Settings, get_settings
 
 
 @pytest.fixture(scope="session")
@@ -41,6 +42,16 @@ def _event_loop():
 def _use_session_loop(_event_loop):
     asyncio.set_event_loop(_event_loop)
     return _event_loop
+
+
+@pytest.fixture(autouse=True)
+def _ignore_local_dotenv(monkeypatch: pytest.MonkeyPatch):
+    """Keep developer settings out of tests unless a test opts in."""
+
+    monkeypatch.setitem(Settings.model_config, "env_file", None)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 @pytest.fixture

--- a/tests/test_anthropic_model.py
+++ b/tests/test_anthropic_model.py
@@ -696,6 +696,7 @@ def test_anthropic_model_wraps_provider_errors() -> None:
 
 def test_anthropic_model_loads_dotenv_key(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(Settings.model_config, "env_file", ".env")
     get_settings.cache_clear()
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     tmp_path.joinpath(".env").write_text(

--- a/tests/test_gemini_model.py
+++ b/tests/test_gemini_model.py
@@ -466,6 +466,7 @@ def test_gemini_model_rejects_incomplete_interactions() -> None:
 
 def test_gemini_model_loads_dotenv_key(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(Settings.model_config, "env_file", ".env")
     get_settings.cache_clear()
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     tmp_path.joinpath(".env").write_text(

--- a/tests/test_openai_model.py
+++ b/tests/test_openai_model.py
@@ -402,6 +402,7 @@ def test_openai_model_round_trips_response_items(
 
 def test_openai_model_loads_dotenv(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(Settings.model_config, "env_file", ".env")
     get_settings.cache_clear()
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("MINI_ARTICRAFT_OUTPUT_DIR", raising=False)

--- a/tests/test_openrouter_model.py
+++ b/tests/test_openrouter_model.py
@@ -330,6 +330,7 @@ def test_model_factory_selects_openrouter() -> None:
 
 def test_openrouter_settings_load_from_dotenv(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(Settings.model_config, "env_file", ".env")
     get_settings.cache_clear()
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("MINI_ARTICRAFT_OPENROUTER_MODEL", raising=False)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from mini_articraft.settings import DEFAULT_MAX_TURNS, Settings
+
+
+def test_settings_ignore_local_dotenv_by_default_in_tests(tmp_path, monkeypatch) -> None:
+    tmp_path.joinpath(".env").write_text("MINI_ARTICRAFT_MAX_TURNS=999\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert Settings().max_turns == DEFAULT_MAX_TURNS  # pyright: ignore[reportCallIssue]


### PR DESCRIPTION
## What changed

Tests now ignore local `.env` files unless a test explicitly opts in. The provider settings tests still load their own temporary `.env` files.

## Why

Developer settings could change test inputs. A local maximum turn setting caused a CLI test to fail even though the code under test had not changed.

## Impact

Test results no longer depend on the settings in a developer checkout. Production settings still load `.env` as before.

## Checks

`uv run pytest -q --replay`

`uv run ruff check .`

`uv run ruff format --check .`
