### PR TITLE
Add OpenAI context compaction

### DIFF
--- a/src/mini_articraft/agent/provider/openai.py
+++ b/src/mini_articraft/agent/provider/openai.py
@@ -100,6 +100,39 @@ class OpenAIModel:
             "response": response,
         }
 
+    async def summarize_context(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        max_output_tokens: int,
+    ) -> dict[str, Any]:
+        """Create a plain checkpoint without extending the active response chain."""
+
+        input_items = [
+            _input_message(message, self.config.openai_model)
+            for message in messages
+            if "type" not in message and message["role"] != "system"
+        ]
+        request = self._request(messages, input_items, None, None)
+        request["max_output_tokens"] = max_output_tokens
+        response = await self._send_with_retries(request, request)
+        text = _response_text(response)
+        _raise_for_bad_status(response, text)
+        if not text:
+            raise ModelError("OpenAI summary response did not contain output_text")
+
+        # The agent replaces its old messages with the checkpoint after this
+        # call. Reset the incremental state so the next query sends that new
+        # message list in full instead of continuing the old response chain.
+        self._input_items.clear()
+        self._previous_response_id = None
+        self._last_message_count = 0
+        return {
+            "text": text,
+            "token_usage": _response_token_usage(response),
+            "cost": _response_cost(response),
+        }
+
     async def close(self) -> None:
         await self._close_websocket()
 
@@ -216,7 +249,10 @@ class OpenAIModel:
                 continue
             if self._previous_response_id is not None and message["role"] == "assistant":
                 continue
-            new_items.append(_input_message(message, self.config.openai_model))
+            if message["role"] == "assistant":
+                new_items.extend(_input_assistant_items(message, self.config.openai_model))
+            else:
+                new_items.append(_input_message(message, self.config.openai_model))
         return new_items
 
 
@@ -327,6 +363,29 @@ def _input_message(message: dict[str, Any], model: str) -> dict[str, Any]:
         "role": message["role"],
         "content": _normalize_image_details(content, model),
     }
+
+
+def _input_assistant_items(message: dict[str, Any], model: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    if message.get("content"):
+        items.append(_input_message(message, model))
+    for call in message.get("tool_calls") or []:
+        if not isinstance(call, dict):
+            continue
+        arguments = call.get("arguments") or "{}"
+        items.append(
+            {
+                "type": "function_call",
+                "call_id": str(call.get("id") or ""),
+                "name": str(call.get("name") or ""),
+                "arguments": (
+                    arguments
+                    if isinstance(arguments, str)
+                    else json.dumps(arguments, sort_keys=True)
+                ),
+            }
+        )
+    return items
 
 
 def _normalize_image_details(value: Any, model: str) -> Any:

--- a/tests/test_openai_model.py
+++ b/tests/test_openai_model.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import pytest
 
+from mini_articraft.agent import ContextSummarizer
 from mini_articraft.agent.provider.openai import OpenAIModel, context_window_tokens_for
 from mini_articraft.errors import ModelError
 from mini_articraft.settings import DEFAULT_MAX_TURNS, Settings, get_settings
@@ -236,9 +237,11 @@ def test_openai_model_returns_estimated_cost_for_gpt_5_6_sol(
 
 
 def test_openai_model_exposes_context_window() -> None:
-    assert openai_model().config.openai_model == "gpt-5.5-2026-04-23"
+    model = openai_model()
+    assert model.config.openai_model == "gpt-5.5-2026-04-23"
+    assert isinstance(model, ContextSummarizer)
     assert DEFAULT_MAX_TURNS == 100
-    assert openai_model().context_window_tokens == 272_000
+    assert model.context_window_tokens == 272_000
     assert context_window_tokens_for("gpt-5.6-sol") == 272_000
     assert context_window_tokens_for("gpt-5.6") == 272_000
     assert context_window_tokens_for("gpt-5.6-terra") is None
@@ -246,6 +249,93 @@ def test_openai_model_exposes_context_window() -> None:
     assert context_window_tokens_for("gpt-5.5-pro") == 272_000
     assert context_window_tokens_for("gpt-5.4-mini-2026-03-17") == 400_000
     assert context_window_tokens_for("gpt-test") is None
+
+
+def test_openai_summary_resets_incremental_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    socket = FakeWebSocket(
+        [
+            response_event("first", response_id="resp_1"),
+            response_event(
+                "checkpoint",
+                response_id="resp_summary",
+                usage={"input_tokens": 100, "output_tokens": 20},
+            ),
+            response_event("done", response_id="resp_2"),
+        ]
+    )
+    patch_websocket(monkeypatch, socket)
+    model = openai_model()
+
+    run(model.query([{"role": "user", "content": "build"}]))
+    summary = run(
+        model.summarize_context(
+            [
+                {"role": "system", "content": "summarize the work"},
+                {"role": "user", "content": "old work"},
+            ],
+            max_output_tokens=8_192,
+        )
+    )
+    run(
+        model.query(
+            [
+                {"role": "system", "content": "agent instructions"},
+                {"role": "user", "content": "checkpoint"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "name": "compile",
+                            "arguments": "{}",
+                        }
+                    ],
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": '{"status": "success"}',
+                },
+                {"role": "user", "content": "continue"},
+            ]
+        )
+    )
+
+    assert summary == {
+        "text": "checkpoint",
+        "token_usage": {
+            "input_tokens": 100,
+            "cached_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "output_tokens": 20,
+            "total_tokens": 120,
+        },
+        "cost": 0.0011,
+    }
+    assert socket.sent[1]["input"] == [{"role": "user", "content": "old work"}]
+    assert socket.sent[1]["instructions"] == "summarize the work"
+    assert socket.sent[1]["max_output_tokens"] == 8_192
+    assert "previous_response_id" not in socket.sent[1]
+    assert socket.sent[2]["input"] == [
+        {"role": "user", "content": "checkpoint"},
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "compile",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": '{"status": "success"}',
+        },
+        {"role": "user", "content": "continue"},
+    ]
+    assert socket.sent[2]["instructions"] == "agent instructions"
+    assert "previous_response_id" not in socket.sent[2]
 
 
 def test_openai_model_sends_function_call_outputs_with_previous_response(


### PR DESCRIPTION
## What changed

The OpenAI adapter now provides context summaries for the agent compaction flow. After a summary, it clears the old response chain and sends the retained checkpoint in full on the next request.

The adapter also rebuilds retained assistant tool calls when it sends that checkpoint.

## Why

The agent only compacts context for providers that implement the summary interface. OpenAI was the default provider but did not implement it, so long runs kept growing until the provider rejected them.

## Impact

Long OpenAI runs can now replace old messages with a recorded checkpoint before reaching the context limit.

## Checks

`uv run pytest -q tests/test_openai_model.py tests/test_agent_harness.py tests/test_compaction.py`

`uv run ruff check src/mini_articraft/agent/provider/openai.py tests/test_openai_model.py`

`uv run ruff format --check src/mini_articraft/agent/provider/openai.py tests/test_openai_model.py`
