### PR TITLE
Allow clearing optional material fields

### DIFF
--- a/src/mini_articraft/sdk/materials.py
+++ b/src/mini_articraft/sdk/materials.py
@@ -36,6 +36,13 @@ Rgb: TypeAlias = tuple[float, float, float]
 Friction: TypeAlias = tuple[float, float]
 
 
+class _Unspecified:
+    pass
+
+
+_UNSPECIFIED = _Unspecified()
+
+
 @dataclass(frozen=True)
 class Material:
     """What a shape is made of, and everything that follows from it.
@@ -102,17 +109,18 @@ class Material:
         *,
         name: str | None = None,
         density: float | None = None,
-        friction: Friction | None = None,
-        restitution: float | None = None,
+        friction: Friction | None | _Unspecified = _UNSPECIFIED,
+        restitution: float | None | _Unspecified = _UNSPECIFIED,
         color: Sequence[float] | None = None,
         metallic: float | None = None,
         roughness: float | None = None,
-        emissive: Rgb | None = None,
+        emissive: Rgb | None | _Unspecified = _UNSPECIFIED,
     ) -> Material:
         """This material with some properties changed, keeping the rest.
 
         A derived material keeps its origin's texture, so brushed steel still
-        looks like steel when textures are enabled.
+        looks like steel when textures are enabled. Pass ``None`` to clear
+        friction, restitution, or emissive values.
         """
 
         changes: dict[str, object] = {}
@@ -120,9 +128,9 @@ class Material:
             changes["name"] = name
         if density is not None:
             changes["density"] = density
-        if friction is not None:
+        if friction is not _UNSPECIFIED:
             changes["friction"] = friction
-        if restitution is not None:
+        if restitution is not _UNSPECIFIED:
             changes["restitution"] = restitution
         if color is not None:
             changes["base_color"] = _as_color(color, field_name=f"material {self.name!r} color")
@@ -130,7 +138,7 @@ class Material:
             changes["metallic"] = metallic
         if roughness is not None:
             changes["roughness"] = roughness
-        if emissive is not None:
+        if emissive is not _UNSPECIFIED:
             changes["emissive"] = emissive
         return replace(self, **changes)  # pyright: ignore[reportArgumentType]
 

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -72,6 +72,22 @@ def test_a_derived_material_keeps_what_it_did_not_change() -> None:
     assert brushed == Material.STEEL.but(roughness=0.75)
 
 
+def test_a_derived_material_can_clear_optional_properties() -> None:
+    glowing = Material(
+        name="glowing",
+        density=1000.0,
+        friction=(0.5, 0.4),
+        restitution=0.3,
+        emissive=(1.0, 0.5, 0.0),
+    )
+
+    cleared = glowing.but(friction=None, restitution=None, emissive=None)
+
+    assert cleared.friction is None
+    assert cleared.restitution is None
+    assert cleared.emissive is None
+
+
 def test_an_invented_material_authors_no_friction_it_does_not_have() -> None:
     foam = Material(name="foam", density=60.0)
 


### PR DESCRIPTION
## What changed

`Material.but()` now distinguishes an omitted optional field from an explicit `None`. Callers can clear friction, restitution, and emissive values.

## Why

The previous defaults used `None` to mean "leave this field unchanged." That made it impossible to derive a material that intentionally removed an optional property.

## Impact

Existing calls that omit these fields still keep their current values. Passing `None` now clears the requested field.

## Checks

`uv run pytest -q tests/test_materials.py`

`uv run ruff check src/mini_articraft/sdk/materials.py tests/test_materials.py`

`uv run basedpyright src/mini_articraft/sdk/materials.py tests/test_materials.py`
