### PR TITLE
Remove unused compile payload fields

### DIFF
--- a/src/mini_articraft/agent/workspace/local.py
+++ b/src/mini_articraft/agent/workspace/local.py
@@ -72,7 +72,7 @@ class LocalWorkspace:
         workspace = run_dir / "workspace"
 
         if not (workspace / "main.py").is_file():
-            result = _error_result(run_dir, error="workspace/main.py is required")
+            result = _error_result(error="workspace/main.py is required")
             self._record_compile(run_dir)
             return result
 
@@ -106,7 +106,6 @@ class LocalWorkspace:
                     "model": {},
                 }
             return _error_result(
-                run_dir,
                 error=_timeout_error(self.config.timeout_seconds, compile_stats),
                 stdout=completed.stdout,
                 stderr=completed.stderr,
@@ -118,7 +117,6 @@ class LocalWorkspace:
             payload = json.loads(completed.stdout)
         except json.JSONDecodeError:
             return _error_result(
-                run_dir,
                 error="compile worker did not return JSON",
                 stdout=completed.stdout,
                 stderr=completed.stderr,
@@ -127,7 +125,6 @@ class LocalWorkspace:
 
         if not isinstance(payload, dict):
             return _error_result(
-                run_dir,
                 error="compile worker returned invalid JSON",
                 stdout=completed.stdout,
                 stderr=completed.stderr,
@@ -135,7 +132,6 @@ class LocalWorkspace:
             )
 
         return _finalize_payload(
-            run_dir,
             payload,
             stderr=completed.stderr,
             returncode=completed.returncode,
@@ -210,19 +206,7 @@ def _signal_worker_group(proc: subprocess.Popen[str], sig: signal.Signals) -> No
         return
 
 
-def _with_paths(run_dir: Path, result: CompilePayload) -> CompilePayload:
-    workspace = run_dir / "workspace"
-    result_dir = run_dir / "result"
-    result["run_id"] = run_dir.name
-    result["run"] = str(run_dir)
-    result["workspace"] = str(workspace)
-    result["entrypoint"] = str(workspace / "main.py")
-    result["result"] = str(result_dir)
-    return result
-
-
 def _finalize_payload(
-    run_dir: Path,
     payload: dict[str, Any],
     *,
     stderr: str,
@@ -232,20 +216,18 @@ def _finalize_payload(
 
     Single owner of result assembly for any worker transport: captured worker
     stderr is followed by process-level stderr, missing keys are defaulted,
-    and the compile report and run paths are attached here.
+    and the compile report is attached here.
     """
     result = CompileResult.from_payload(payload)
     result.stderr += stderr
-    return _finalize_result(run_dir, result, returncode)
+    return _finalize_result(result, returncode)
 
 
 def _finalize_result(
-    run_dir: Path,
     result: CompileResult,
     returncode: int | None,
 ) -> CompilePayload:
-    payload = with_compile_report(result.to_payload(include_returncode=True, returncode=returncode))
-    return _with_paths(run_dir, payload)
+    return with_compile_report(result.to_payload(include_returncode=True, returncode=returncode))
 
 
 def _read_compile_progress(run_dir: Path) -> dict[str, Any]:
@@ -276,7 +258,6 @@ def _timeout_error(timeout_seconds: float, compile_stats: dict[str, Any]) -> str
 
 
 def _error_result(
-    run_dir: Path,
     *,
     error: str,
     stdout: str = "",
@@ -285,7 +266,6 @@ def _error_result(
     compile_stats: dict[str, Any] | None = None,
 ) -> CompilePayload:
     return _finalize_result(
-        run_dir,
         CompileResult(
             error=error,
             stdout=stdout,

--- a/src/mini_articraft/compiler/feedback.py
+++ b/src/mini_articraft/compiler/feedback.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 from pathlib import PurePosixPath
 from typing import Any, Literal
 
-from mini_articraft.compiler.result import CompilePayload, CompileResult
+from mini_articraft.compiler.result import CompilePayload
 from mini_articraft.sdk import FailureKind, TestReport
 
 Severity = Literal["failure", "warning", "note"]
@@ -53,10 +53,6 @@ class CompileSignalBundle:
     status: Status
     summary: str
     signals: tuple[CompileSignal, ...] = ()
-
-
-def empty_compile_payload(*, error: str = "", stdout: str = "", stderr: str = "") -> CompilePayload:
-    return CompileResult(error=error, stdout=stdout, stderr=stderr).to_payload()
 
 
 def with_compile_report(payload: CompilePayload) -> CompilePayload:

--- a/src/mini_articraft/compiler/result.py
+++ b/src/mini_articraft/compiler/result.py
@@ -27,29 +27,18 @@ class _CompilePayloadBase(TypedDict):
 class CompilePayload(_CompilePayloadBase, total=False):
     """What one compile attempt looks like on the wire.
 
-    Assembled in three layers, which is why nothing owned its shape before: the
-    compiler produces the required fields above, the workspace attaches the
-    process-level ones as it collects the subprocess, and the agent's tools
-    attach the last group before the model sees the result.
+    The compiler produces the required fields above. The workspace attaches
+    process details and the report after it collects the subprocess.
     """
 
     compile_stats: dict[str, Any]
 
     # Attached by the workspace once the subprocess is collected.
     returncode: int | None
-    run: str
-    run_id: str
-    workspace: str
-    entrypoint: str
-    result: str
     # A dict on the wire and in the record; the agent's compile tool replaces it
     # with the rendered text before the model sees it. Any, because this type
     # exists to check key names -- the nested reports are their own shapes.
     compile_report: Any
-
-    # Attached by the agent's tools before the model sees it.
-    is_error: bool
-    raster_path: str
 
 
 @dataclass

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -804,17 +804,14 @@ class WarmEnvironment(LocalWorkspace):
         )
         if status == "timeout":
             return _error_result(
-                run_dir,
                 error=f"compile timed out after {self.config.timeout_seconds:g}s",
             )
         if payload is None:
             return _error_result(
-                run_dir,
                 error="compile worker exited mid-compile "
                 "(workspace code may have exited the process)",
             )
         return _finalize_payload(
-            run_dir,
             payload,
             stderr="",
             returncode=0 if payload["status"] == "success" else 1,

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -74,6 +74,7 @@ def test_compile_path_exports_usdz_but_only_updates_attempt_data(tmp_path) -> No
         "shapes": 1,
         "articulations": 0,
     }
+    assert not {"run", "run_id", "workspace", "entrypoint", "result"} & result.keys()
     assert "loading main.py and building the model" in result["compile_stats"]["phases"]
     assert not run_dir.joinpath("result", ".compile-progress.json").exists()
     manifest = json.loads(run_dir.joinpath("result", "model.json").read_text())


### PR DESCRIPTION
## What changed

The compile payload no longer includes five unused run path fields or two fields that belong to other tool results. The unused empty payload helper is gone, along with finalizer arguments that only supported the removed path fields.

## Why

The workspace created these values, but the agent compile tool removed them before any consumer could read them. Keeping them made the payload shape and finalization code larger without providing behavior.

## Impact

Compile results keep the status, artifact paths, process details, test report, and compile report that current consumers use.

## Checks

`uv run pytest -q tests/test_compile.py tests/test_harness.py tests/test_agent_tools.py`

`uv run ruff check src/mini_articraft/compiler/feedback.py src/mini_articraft/compiler/result.py src/mini_articraft/agent/workspace/local.py tests/harness.py tests/test_compile.py`

`uv run basedpyright src/mini_articraft/compiler src/mini_articraft/agent/workspace/local.py tests/harness.py`
