### PR TITLE
Exercise joint frame conversion in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv sync --group dev --frozen
+        run: uv sync --group dev --group sim --frozen
 
       - name: Check repository hygiene
         run: uv run --frozen python scripts/check_repo_hygiene.py

--- a/src/mini_articraft/app.py
+++ b/src/mini_articraft/app.py
@@ -26,7 +26,7 @@ def generate(
     image: Path | None = typer.Option(
         None,
         "--image",
-        exists=True,
+        exists=False,
         file_okay=True,
         dir_okay=False,
         readable=True,
@@ -69,6 +69,9 @@ def generate(
     ),
 ) -> None:
     """Generate an object from a prompt."""
+    if image is not None and not image.exists():
+        typer.echo(f"reference image does not exist: {image}", err=True)
+        raise typer.Exit(2)
     settings = _settings(provider, model, output_dir, effort, compile_timeout, physics)
     if image is not None and settings.provider == "openrouter":
         typer.echo("OpenRouter does not support reference images.", err=True)

--- a/src/mini_articraft/simulate.py
+++ b/src/mini_articraft/simulate.py
@@ -31,7 +31,13 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from pxr import Usd, UsdGeom, UsdPhysics, UsdShade  # pyright: ignore[reportAttributeAccessIssue]
+from pxr import (
+    Gf,
+    Usd,
+    UsdGeom,
+    UsdPhysics,
+    UsdShade,  # pyright: ignore[reportAttributeAccessIssue]
+)
 from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
 
 # USD joint prim type -> MJCF joint type. A fixed joint welds the bodies, which
@@ -482,39 +488,20 @@ def _read_scene(stage: Usd.Stage) -> _Scene:
 
 
 def _joint_axis(prim: Usd.Prim) -> tuple[float, float, float]:
-    """The joint's axis in the child body's frame, which is what MJCF wants.
+    """Return the USD joint axis in body1's frame, as MJCF requires."""
+    token = str(_attr(prim, "physics:axis", "X"))
+    axis = _AXES.get(token)
+    if axis is None:
+        raise ValueError(f"unsupported USD joint axis: {token!r}")
 
-    UsdPhysics names one of three cardinal axes and then rotates the joint
-    frame to point it wherever it belongs, so the token alone is only half the
-    answer -- a hinge on -X is written as "X" plus a half turn. Reading the
-    token by itself silently flips every joint whose axis is not a positive
-    cardinal direction.
-
-    The rotation to apply is localRot1, not localRot0. MJCF writes the axis
-    inside the child body, and only localRot1 is the bare axis rotation;
-    localRot0 also folds in the joint origin's rpy, which is a different
-    quantity and produces a wrong axis for any joint with a rotated origin.
-    """
-
-    axis = np.array(_AXES.get(str(_attr(prim, "physics:axis", "Z")), (0.0, 0.0, 1.0)))
     rotation = _attr(prim, "physics:localRot1")
-    if rotation is not None:
-        axis = _quat_matrix(rotation) @ axis
-    return (float(round(axis[0], 12)), float(round(axis[1], 12)), float(round(axis[2], 12)))
+    if rotation is None:
+        return axis
 
-
-def _quat_matrix(rotation: Any) -> np.ndarray:
-    """Rotation matrix for a USD quaternion (real part plus imaginary vector)."""
-
-    w = float(rotation.GetReal())
-    x, y, z = (float(v) for v in rotation.GetImaginary())
-    return np.array(
-        [
-            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
-            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
-            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
-        ]
-    )
+    frame = Gf.Matrix4d(1.0)
+    frame.SetRotate(rotation)
+    transformed = frame.TransformDir(Gf.Vec3d(*axis)).GetNormalized()
+    return (float(transformed[0]), float(transformed[1]), float(transformed[2]))
 
 
 def _add_body(

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -205,44 +205,37 @@ def test_releasing_a_joint_produces_motion_worth_watching(tmp_path: Path) -> Non
     assert result.peak_joint_speed is not None and result.peak_joint_speed > 1.0
 
 
-def _negative_axis_hinge(rpy: tuple[float, float, float] = (0.0, 0.0, 0.0)) -> ArticulatedObject:
-    """The crate, hinged on -X instead of +X, optionally with a rotated origin."""
+def _hinge_with_axis(
+    axis: tuple[float, float, float],
+    rpy: tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> ArticulatedObject:
     model = _hinged_box()
     joint = model.articulations[-1]
-    joint.axis = (-1.0, 0.0, 0.0)
+    joint.axis = axis
     joint.origin = Origin(xyz=joint.origin.xyz, rpy=rpy)
     return model
 
 
-def test_a_negative_hinge_axis_survives_the_round_trip(tmp_path: Path) -> None:
-    """UsdPhysics names a cardinal axis and rotates the joint frame to aim it.
-
-    A -X hinge is written as "X" plus a half turn about Z, so reading the axis
-    token alone flips it. A flipped hinge does not fail loudly -- gravity simply
-    drives the joint the wrong way, and a lid that should hang shut swings open.
-    """
-    write_mjcf(_export(_negative_axis_hinge(), tmp_path), tmp_path / "sim")
-    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
-
-    assert joint is not None
-    axis = tuple(round(float(value), 6) for value in str(joint.get("axis")).split())
-    assert axis == (-1.0, 0.0, 0.0)
-
-
-def test_a_rotated_joint_origin_does_not_disturb_the_axis(tmp_path: Path) -> None:
-    """The axis rotation is localRot1; localRot0 also carries the origin's rpy.
-
-    Both frames agree when the origin is unrotated, so reading localRot0 passes
-    the simple case and then quietly bends the axis for any joint whose origin
-    is turned -- a -X hinge with a 90 degree yaw comes out as -Y.
-    """
-    model = _negative_axis_hinge(rpy=(0.0, 0.0, math.pi / 2))
+@pytest.mark.parametrize(
+    "axis",
+    [
+        (-1.0, 0.0, 0.0),
+        (0.0, 1.0, 1.0),
+        (1.0, -2.0, 3.0),
+    ],
+)
+def test_joint_axis_survives_the_usd_to_mjcf_round_trip(
+    tmp_path: Path, axis: tuple[float, float, float]
+) -> None:
+    model = _hinge_with_axis(axis, rpy=(0.2, -0.3, math.pi / 2))
     write_mjcf(_export(model, tmp_path), tmp_path / "sim")
     joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
 
     assert joint is not None
-    axis = tuple(round(float(value), 6) for value in str(joint.get("axis")).split())
-    assert axis == (-1.0, 0.0, 0.0)
+    actual = tuple(float(value) for value in str(joint.get("axis")).split())
+    length = math.hypot(*axis)
+    expected = tuple(value / length for value in axis)
+    assert actual == pytest.approx(expected, abs=1e-6)
 
 
 def test_prismatic_travel_is_not_reported_as_part_separation(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- install the `sim` dependency group in CI so the MuJoCo-backed simulation tests run instead of skipping
- derive MJCF joint axes with OpenUSD's own frame transform instead of maintaining quaternion algebra locally
- cover negative and non-cardinal axes with a rotated joint origin in the USD-to-MJCF round trip
- report missing reference images consistently even when Typer would truncate a long path

## Why `localRot1` is correct

OpenUSD defines `physics:localRot1` as the orientation of the joint frame relative to body 1. MuJoCo defines a joint's position and axis in the frame of the body containing the joint, which is the child body in our generated kinematic tree. The converter therefore needs `localPos1` and the schema axis transformed by `localRot1`.

References:

- https://openusd.org/release/api/class_usd_physics_joint.html
- https://openusd.org/release/api/class_usd_physics_revolute_joint.html
- https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-joint

## Verification

- `uv run pytest -q --replay` — 551 passed, 2 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright` — 0 errors, 0 warnings
