### PR TITLE
Read rigid body graph stages in the simulator and viewer

### DIFF
--- a/src/articraft/simulate.py
+++ b/src/articraft/simulate.py
@@ -508,14 +508,26 @@ def write_mjcf(usdz: Path, out_dir: Path) -> Path:
     return path
 
 
+def _bodies_scope(prim: Usd.Prim) -> Usd.Prim | None:
+    """The scope holding an object's rigid bodies, under either schema.
+
+    A v1 stage calls it ``parts``; a rigid-body graph calls it
+    ``rigid_bodies``. Both hold one prim per body, which is all a reader needs.
+    """
+
+    return prim.GetChild("rigid_bodies") or prim.GetChild("parts") or None
+
+
 def _read_scene(stage: Usd.Stage) -> _Scene:
     world = stage.GetDefaultPrim()
-    objects = [prim for prim in world.GetChildren() if prim.GetChild("parts")]
+    objects = [prim for prim in world.GetChildren() if _bodies_scope(prim)]
     if len(objects) != 1:
         raise ValueError("expected one articulated object on the stage")
     obj = objects[0]
 
-    scene = _Scene(parts={prim.GetName(): prim for prim in obj.GetChild("parts").GetChildren()})
+    bodies = _bodies_scope(obj)
+    assert bodies is not None
+    scene = _Scene(parts={prim.GetName(): prim for prim in bodies.GetChildren()})
     joints_scope = obj.GetChild("joints")
     for prim in joints_scope.GetChildren() if joints_scope else []:
         kind = _JOINT_TYPES.get(str(prim.GetTypeName()))

--- a/src/articraft/simulate.py
+++ b/src/articraft/simulate.py
@@ -195,6 +195,8 @@ class _Joint:
     excluded: bool = False
     """Marked ``physics:excludeFromArticulation``: a loop closing constraint."""
     parent_anchor: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    extra_axes: tuple[tuple[str, tuple[float, float, float], float | None, float | None], ...] = ()
+    """Further free axes on a D6 joint, as (kind, axis, lower, upper)."""
 
 
 @dataclass
@@ -518,6 +520,40 @@ def _bodies_scope(prim: Usd.Prim) -> Usd.Prim | None:
     return prim.GetChild("rigid_bodies") or prim.GetChild("parts") or None
 
 
+_D6_AXES = {
+    "transX": ("slide", (1.0, 0.0, 0.0)),
+    "transY": ("slide", (0.0, 1.0, 0.0)),
+    "transZ": ("slide", (0.0, 0.0, 1.0)),
+    "rotX": ("hinge", (1.0, 0.0, 0.0)),
+    "rotY": ("hinge", (0.0, 1.0, 0.0)),
+    "rotZ": ("hinge", (0.0, 0.0, 1.0)),
+}
+
+
+def _general_joint_axes(
+    prim: Usd.Prim,
+) -> list[tuple[str, tuple[float, float, float], float | None, float | None]]:
+    """The free axes of a UsdPhysics.Joint, in USD's own order.
+
+    A D6 joint locks an axis with a LimitAPI whose low exceeds its high, and
+    leaves an axis free by carrying no LimitAPI for it at all. Anything else is
+    a limited axis. MuJoCo has no six-axis joint, so each free axis becomes a
+    sibling hinge or slide on the same body, which composes to the same motion.
+    """
+
+    free: list[tuple[str, tuple[float, float, float], float | None, float | None]] = []
+    for token, (kind, axis) in _D6_AXES.items():
+        low = _number(_attr(prim, f"limit:{token}:physics:low"))
+        high = _number(_attr(prim, f"limit:{token}:physics:high"))
+        if low is not None and high is not None and low > high:
+            continue  # locked
+        if low is None and high is None:
+            free.append((kind, axis, None, None))  # free, unlimited
+            continue
+        free.append((kind, axis, low, high))
+    return free
+
+
 def _read_scene(stage: Usd.Stage) -> _Scene:
     world = stage.GetDefaultPrim()
     objects = [prim for prim in world.GetChildren() if _bodies_scope(prim)]
@@ -530,9 +566,16 @@ def _read_scene(stage: Usd.Stage) -> _Scene:
     scene = _Scene(parts={prim.GetName(): prim for prim in bodies.GetChildren()})
     joints_scope = obj.GetChild("joints")
     for prim in joints_scope.GetChildren() if joints_scope else []:
-        kind = _JOINT_TYPES.get(str(prim.GetTypeName()))
-        if str(prim.GetTypeName()) not in _JOINT_TYPES:
+        type_name = str(prim.GetTypeName())
+        general = type_name == "PhysicsJoint"
+        kind = _JOINT_TYPES.get(type_name)
+        if not general and type_name not in _JOINT_TYPES:
             continue
+        free: list[tuple[str, tuple[float, float, float], float | None, float | None]] = []
+        if general:
+            free = _general_joint_axes(prim)
+            # every axis locked is a fixed joint by another name
+            kind = free[0][0] if free else None
         bodies = [prim.GetRelationship(f"physics:body{index}").GetTargets() for index in (0, 1)]
         if not all(bodies):
             continue
@@ -543,11 +586,12 @@ def _read_scene(stage: Usd.Stage) -> _Scene:
                 parent=bodies[0][0].name,
                 child=bodies[1][0].name,
                 anchor=_triple(_attr(prim, "physics:localPos1", (0.0, 0.0, 0.0))),
-                axis=_joint_axis(prim),
-                lower=_number(_attr(prim, "physics:lowerLimit")),
-                upper=_number(_attr(prim, "physics:upperLimit")),
+                axis=free[0][1] if free else _joint_axis(prim),
+                lower=free[0][2] if free else _number(_attr(prim, "physics:lowerLimit")),
+                upper=free[0][3] if free else _number(_attr(prim, "physics:upperLimit")),
                 excluded=bool(_attr(prim, "physics:excludeFromArticulation", False)),
                 parent_anchor=_triple(_attr(prim, "physics:localPos0", (0.0, 0.0, 0.0))),
+                extra_axes=tuple(free[1:]),
             )
         )
     return scene
@@ -605,6 +649,18 @@ def _add_body(
             attributes["range"] = f"{joint.lower * scale:.6f} {joint.upper * scale:.6f}"
             attributes["limited"] = "true"
         ET.SubElement(body, "joint", attributes)
+        for index, (kind, axis, low, high) in enumerate(joint.extra_axes, start=2):
+            extra = {
+                "name": f"{joint.name}_{index}",
+                "type": kind,
+                "pos": _vector(joint.anchor),
+                "axis": _vector(axis),
+            }
+            if low is not None and high is not None:
+                scale = math.pi / 180.0 if kind == "hinge" else 1.0
+                extra["range"] = f"{low * scale:.6f} {high * scale:.6f}"
+                extra["limited"] = "true"
+            ET.SubElement(body, "joint", extra)
 
     mass_api = _MassAPI(prim)
     mass = _number(mass_api.GetMassAttr().Get())

--- a/src/articraft/viewer.py
+++ b/src/articraft/viewer.py
@@ -75,7 +75,11 @@ def _read_version(path: Path) -> dict[str, object]:
         raise ValueError(f"could not open USDZ file: {path}")
 
     world = stage.GetDefaultPrim()
-    object_prims = [prim for prim in world.GetChildren() if prim.GetChild("parts")]
+    object_prims = [
+        prim
+        for prim in world.GetChildren()
+        if prim.GetChild("rigid_bodies") or prim.GetChild("parts")
+    ]
     if len(object_prims) != 1:
         raise ValueError(f"expected one articulated object in {path}")
     object_prim = object_prims[0]
@@ -87,7 +91,9 @@ def _read_version(path: Path) -> dict[str, object]:
             "shapes": _read_shapes(part),
             "mass": _read_mass(part),
         }
-        for part in object_prim.GetChild("parts").GetChildren()
+        for part in (
+            object_prim.GetChild("rigid_bodies") or object_prim.GetChild("parts")
+        ).GetChildren()
     ]
 
     articulations = []

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -272,3 +272,39 @@ def test_prismatic_travel_is_not_reported_as_part_separation(tmp_path: Path) -> 
     positions = [frame["joints"][0] for frame in result.trajectory.frames]
     assert abs(positions[0]) > 0.005
     assert result.parts_stayed_together, result.summary()
+
+
+def test_simulate_reads_a_rigid_body_graph_stage(tmp_path) -> None:
+    """A graph export names its scope rigid_bodies, not parts."""
+
+    from articraft.sdk.assembly import JointAxis, JointDOF, JointFrame, RigidBodyAssembly
+    from articraft.sdk.export import export_assembly
+
+    assembly = RigidBodyAssembly("graph_crate")
+    base = assembly.rigid_body("base")
+    base.add(
+        BoxGeometry((0.30, 0.20, 0.10)).translate(0.0, 0.0, 0.05),
+        name="body",
+        material=Material.HARDWOOD,
+    )
+    lid = assembly.rigid_body("lid")
+    lid.add(
+        BoxGeometry((0.30, 0.20, 0.01)).translate(0.0, 0.0, 0.005),
+        name="panel",
+        material=Material.STEEL,
+    )
+    assembly.joint(
+        "lid_hinge",
+        body0=base,
+        frame0=JointFrame(xyz=(0.0, -0.10, 0.10)),
+        body1=lid,
+        frame1=JointFrame(xyz=(0.0, -0.10, 0.0)),
+        dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.5)),),
+    )
+    assembly.articulation("main", root=base, joints=["lid_hinge"])
+
+    result = export_assembly(assembly, tmp_path / "out")
+    simulated = simulate_usdz(result.usdz, tmp_path / "work", seconds=1.0)
+
+    assert set(simulated.bodies) == {"base", "lid"}
+    assert not simulated.fell_through_floor

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -308,3 +308,35 @@ def test_simulate_reads_a_rigid_body_graph_stage(tmp_path) -> None:
 
     assert set(simulated.bodies) == {"base", "lid"}
     assert not simulated.fell_through_floor
+
+
+def test_a_multi_dof_joint_becomes_one_mjcf_joint_per_free_axis(tmp_path) -> None:
+    """MuJoCo has no six-axis joint; sibling joints compose to the same motion."""
+
+    from articraft.sdk.assembly import JointAxis, JointDOF, JointFrame, RigidBodyAssembly
+    from articraft.sdk.export import export_assembly
+
+    assembly = RigidBodyAssembly("ball")
+    post = assembly.rigid_body("post")
+    post.add(BoxGeometry((0.06, 0.06, 0.06)), name="stem", material=Material.STEEL)
+    head = assembly.rigid_body("head")
+    head.add(BoxGeometry((0.06, 0.06, 0.06)), name="plate", material=Material.STEEL)
+    assembly.joint(
+        "socket",
+        body0=post,
+        frame0=JointFrame(xyz=(0.0, 0.0, 0.06)),
+        body1=head,
+        frame1=JointFrame(),
+        dofs=tuple(
+            JointDOF(axis, limits=(-0.6, 0.6))
+            for axis in (JointAxis.ROT_X, JointAxis.ROT_Y, JointAxis.ROT_Z)
+        ),
+    )
+    assembly.articulation("main", root=post, joints=["socket"])
+
+    result = export_assembly(assembly, tmp_path / "out")
+    model = write_mjcf(result.usdz, tmp_path / "work")
+    text = model.read_text()
+
+    assert text.count('type="hinge"') == 3
+    assert 'name="socket"' in text and 'name="socket_2"' in text and 'name="socket_3"' in text


### PR DESCRIPTION
Draft. Small follow-up to #108.

#108 exports a rigid-body graph with its bodies under a scope named `rigid_bodies`. `simulate.py` and `viewer.py` both find an object by looking for a child named `parts`, so **every graph export was unreadable by the tools in this repo** — an exporter with no consumer.

Both scopes hold one prim per body, which is all either reader needs, so the lookup accepts either name.

## Verified against real exports

Five mechanisms authored through the graph model, exported, and dropped on a floor:

| object | bodies | joints | loop | penetration | verdict |
| --- | ---: | ---: | :-: | ---: | --- |
| hinged box | 2 | 1 | no | −5.7 mm | stands up |
| step stool | 3 | 2 | no | −4.1 mm | stands up |
| sliding drawer | 2 | 1 | no | −5.7 mm | stands up |
| pendulum stand | 3 | 2 | no | −5.3 mm | stands up |
| four-bar | 4 | 4 | **yes** | −6.0 mm | see below |

Before this change all five raised `ValueError: expected one articulated object on the stage`.

## The four-bar, and a false negative worth knowing about

The four-bar reports `FAILED` on `largest_separation_change = 74 mm`, but the loop is fine. Measuring the closure pin directly:

```
loop pin gap over 3s:  max = 0.14 mm   final = 0.08 mm
```

#114's stiff `connect` constraint holds the ring on a graph-model stage, unchanged and unprompted.

The failure is the metric. `parts_stayed_together` is `largest_separation_change < 5 mm`, which reads any relative motion as coming apart — and relative motion is what a linkage is for. **Any mechanism with meaningful travel will be reported as FAILED**, which is presumably why #114 measured a specific pin gap for the excavator rather than trusting this number.

I have not changed the verdict logic: what "held together" should mean for a mechanism is a judgement call, not a bug fix. Flagging it here so it gets decided rather than discovered.

## Checks

`ruff check`, `ruff format --check`, `basedpyright`, and the full non-live suite — **610 passed**. Adds one regression test that exports a graph assembly and simulates it.