### PR TITLE
Let compiler motion sweeps pass over driven and loop joints

### DIFF
--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1178,11 +1178,19 @@ class TestContext:
         gap_tol = _non_negative(gap_tol, "gap_tol")
         check_name = name or f"fail_if_articulation_separates_child(gap_tol={gap_tol:.6g})"
         findings: list[str] = []
+        _tree, loop_closures = partition_articulations(self.model.articulations)
+        loop_names = {item.name for item in loop_closures}
         for articulation in self.model.articulations:
             if articulation.articulation_type not in (
                 ArticulationType.REVOLUTE,
                 ArticulationType.CONTINUOUS,
             ):
+                continue
+            # A driven joint has no value of its own to sweep, and a loop
+            # closure never places its child; both move when the joints that
+            # drive them are swept, so skipping them here loses no coverage a
+            # posable sweep could give.
+            if articulation.drive is not None or articulation.name in loop_names:
                 continue
             parent = _part_name(articulation.parent, field_name="parent")
             child = _part_name(articulation.child, field_name="child")

--- a/tests/test_driven_joints.py
+++ b/tests/test_driven_joints.py
@@ -328,3 +328,27 @@ def test_driven_joints_cannot_be_posed_in_checks() -> None:
         ctx.sample_joint("ram_extension")
     with pytest.raises(ValidationError, match="is driven"), ctx.pose({"barrel_swivel": 0.2}):
         pass
+
+
+def test_internal_motion_sweep_skips_driven_and_loop_joints() -> None:
+    """Compiler-standard checks sweep every articulation; a model with drives
+    and closures must pass through them, not explode. This guard regressed a
+    live generation: the agent authored drives, compile failed, and it stripped
+    them all out."""
+
+    from articraft.sdk import TestContext
+
+    model = _ram_model(driven=True)
+    model.articulation(
+        "rod_eye_pin",
+        ArticulationType.REVOLUTE,
+        "arm",
+        "rod",
+        origin=Origin(xyz=ARM_EYE),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-3.0, upper=3.0),
+    )
+    ctx = TestContext(model)
+    ctx.fail_if_articulation_separates_child()
+    report = ctx.report()
+    assert not any("is driven" in failure.details for failure in report.failures)


### PR DESCRIPTION
The non-posable guard from #114 made `fail_if_articulation_separates_child` raise on any driven joint, so compile failed for every model that used drives — and a live generation reacted by stripping its drives out to ship. Caught by scoring a fresh excavator run: it authored the full loop-and-drive pattern, hit this error, grepped it, and deleted every `drive=` to get green.

Internal sweeps now skip driven joints and loop closures, whose motion is covered by sweeping the joints that drive them. Explicitly posing one still raises.

Verified by relaunching the same one-sentence prompts against the fixed tree:
- excavator: 3 loop pins, 6 drives, rest solutions 1e-16
- landing gear: 2 loop pins (including a pure four-bar drag brace closure, beyond the doc example), 2 drives
- locking pliers: 2 drives

Regression test named after the incident. 25 driven/loop tests green.