### PR TITLE
Solve closed loops that have no closed form

### DIFF
--- a/src/articraft/sdk/_collision.py
+++ b/src/articraft/sdk/_collision.py
@@ -10,7 +10,7 @@ import numpy as np
 import trimesh
 
 from articraft.sdk._mesh.core import MeshGeometry, geometry_to_trimesh
-from articraft.sdk.errors import ValidationError
+from articraft.sdk.errors import LoopClosureError, ValidationError
 from articraft.sdk.joints import (
     Articulation,
     ArticulationType,
@@ -106,6 +106,10 @@ class MeshCollisionKernel:
         self.model = model
         self.mesh_tolerance = float(mesh_tolerance)
         self._mesh_cache: dict[tuple[object, ...], _LocalMesh] = {}
+        self._loop_plan: tuple[list[Articulation], list[tuple[Articulation, np.ndarray]]] | None = (
+            None
+        )
+        self._loop_cache: dict[tuple[tuple[str, float], ...], dict[str, float]] = {}
 
     def part_world_position(self, part_name: str, pose: dict[str, float]) -> Vec3:
         transform = self.world_transforms(pose).get(part_name)
@@ -133,7 +137,79 @@ class MeshCollisionKernel:
         return self._selector_entries(part_name, shape_name, pose)[0].bounds
 
     def world_transforms(self, pose: dict[str, float]) -> dict[str, Mat4]:
-        return self._place(self._resolve_drives(pose))
+        return self._place(self._solve(pose))
+
+    def _solve(self, pose: dict[str, float]) -> dict[str, float]:
+        """Complete an authored pose: drives first, then any closed loops.
+
+        A ram is solved in closed form by its drives. A linkage with no closed
+        form -- a four bar hood hinge, a folding brace -- is solved numerically
+        instead, so its follower joints take the values that keep every loop pin
+        closed.
+        """
+
+        candidates, targets = self._loop_solution_plan()
+        # Whatever the caller posed leads; the rest of the ring follows.
+        followers = [item for item in candidates if item.name not in pose]
+        if not followers:
+            return self._resolve_drives(pose)
+        key = tuple(sorted((name, float(value)) for name, value in pose.items()))
+        cached = self._loop_cache.get(key)
+        if cached is not None:
+            return dict(cached)
+        solved = _solve_loops(self, pose, followers, targets)
+        if len(self._loop_cache) >= _LOOP_CACHE_LIMIT:
+            self._loop_cache.clear()
+        self._loop_cache[key] = dict(solved)
+        return solved
+
+    def _loop_solution_plan(
+        self,
+    ) -> tuple[list[Articulation], list[tuple[Articulation, np.ndarray]]]:
+        """Which joints follow, and where each loop pin sits in its child.
+
+        The pin location is read once at the authored rest pose, which is the
+        assembled configuration, so it is the same fact the exporter writes into
+        the USD joint frames.
+        """
+
+        if self._loop_plan is not None:
+            return self._loop_plan
+        tree, loops = partition_articulations(self.model.articulations)
+        candidates: list[Articulation] = []
+        targets: list[tuple[Articulation, np.ndarray]] = []
+        if loops:
+            parent_of = {item.child: item for item in tree}
+
+            def chain(part: str) -> list[Articulation]:
+                walked: list[Articulation] = []
+                while part in parent_of:
+                    walked.append(parent_of[part])
+                    part = parent_of[part].parent
+                return walked
+
+            rest = self._place(self._resolve_drives({}))
+            for closure in loops:
+                # Every movable joint on either side of the pin belongs to the
+                # loop. Which of them lead and which follow is decided per pose:
+                # whatever the caller poses drives, the rest are solved for.
+                ring = {
+                    item.name: item
+                    for item in (*chain(closure.parent), *chain(closure.child))
+                    if item.drive is None and item.articulation_type != ArticulationType.FIXED
+                }
+                if not ring:
+                    continue
+                pin = _apply(
+                    rest[closure.parent] @ _origin_matrix(closure.origin),
+                    np.zeros(3),
+                )
+                targets.append((closure, _apply(np.linalg.inv(rest[closure.child]), pin)))
+                candidates.extend(
+                    item for item in ring.values() if all(item is not seen for seen in candidates)
+                )
+        self._loop_plan = (candidates, targets)
+        return self._loop_plan
 
     def _resolve_drives(self, pose: dict[str, float]) -> dict[str, float]:
         """Fill in the joints the mechanism decides rather than the author.
@@ -690,6 +766,80 @@ def _axis_angle_matrix(axis: np.ndarray, angle: float) -> Mat4:
         trimesh.transformations.rotation_matrix(angle, axis),
         dtype=np.float64,
     )
+
+
+_LOOP_CACHE_LIMIT = 512
+_LOOP_TOLERANCE = 1e-6
+_LOOP_STEPS = 5
+
+
+def _solve_loops(
+    kernel: MeshCollisionKernel,
+    pose: dict[str, float],
+    followers: list[Articulation],
+    targets: list[tuple[Articulation, np.ndarray]],
+) -> dict[str, float]:
+    """Find follower values that keep every loop pin closed at this pose.
+
+    Walks from the rest pose to the authored one in a few steps, solving at each
+    and carrying the answer forward. A linkage has more than one way to be
+    assembled -- a four bar can sit elbow up or elbow down -- and stepping out
+    from rest keeps the model on the branch it was authored in instead of
+    letting it snap through itself. Rest is exact by construction: drives solve
+    to zero there and the pins were measured there.
+    """
+
+    def assemble(scale: float, values: np.ndarray) -> dict[str, float]:
+        stepped = kernel._resolve_drives({name: value * scale for name, value in pose.items()})
+        stepped.update(
+            {item.name: float(value) for item, value in zip(followers, values, strict=True)}
+        )
+        return stepped
+
+    def residual(scale: float, values: np.ndarray) -> np.ndarray:
+        placed = kernel._place(assemble(scale, values))
+        rows: list[float] = []
+        for closure, local in targets:
+            pin = _apply(placed[closure.parent] @ _origin_matrix(closure.origin), np.zeros(3))
+            rows.extend(pin - _apply(placed[closure.child], local))
+        return np.asarray(rows, dtype=np.float64)
+
+    values = np.zeros(len(followers), dtype=np.float64)
+    for step in range(1, _LOOP_STEPS + 1):
+        scale = step / _LOOP_STEPS
+        damping = 1e-6
+        for _ in range(40):
+            current = residual(scale, values)
+            error = float(np.linalg.norm(current))
+            if error < _LOOP_TOLERANCE:
+                break
+            jacobian = np.empty((len(current), len(values)), dtype=np.float64)
+            for index in range(len(values)):
+                nudged = values.copy()
+                nudged[index] += 1e-6
+                jacobian[:, index] = (residual(scale, nudged) - current) / 1e-6
+            # Levenberg-Marquardt: an over-center linkage passes through poses
+            # where the Jacobian is singular, and plain Gauss-Newton throws the
+            # mechanism across the room there.
+            normal = jacobian.T @ jacobian + damping * np.eye(len(values))
+            delta = np.linalg.solve(normal, -jacobian.T @ current)
+            trial = values + delta
+            if float(np.linalg.norm(residual(scale, trial))) < error:
+                values, damping = trial, max(damping * 0.5, 1e-9)
+            else:
+                damping *= 8.0
+                if damping > 1e6:
+                    break
+
+    error = float(np.linalg.norm(residual(1.0, values)))
+    if error > 1e-4:
+        names = ", ".join(repr(closure.name) for closure, _ in targets)
+        raise LoopClosureError(
+            f"pose leaves loop closure {names} open by {error * 1000:.1f} mm; the mechanism "
+            "cannot reach this pose. Tighten the driving joint's motion limits or fix the "
+            "link geometry that sets the range."
+        )
+    return assemble(1.0, values)
 
 
 def _apply(matrix: Mat4, point: np.ndarray) -> np.ndarray:

--- a/src/articraft/sdk/errors.py
+++ b/src/articraft/sdk/errors.py
@@ -11,3 +11,13 @@ class SDKError(MiniArticraftError):
 
 class ValidationError(SDKError):
     """Raised when an articulated object definition is invalid."""
+
+
+class LoopClosureError(ValidationError):
+    """Raised when a pose cannot keep a closed loop assembled.
+
+    The mechanism was driven past what its linkage allows, so no placement of
+    the follower joints keeps the loop's pin closed. The pose is unreachable,
+    not merely awkward: tighten the driving joint's motion limits, or fix the
+    link geometry that decides the range.
+    """

--- a/tests/test_loop_closure_solver.py
+++ b/tests/test_loop_closure_solver.py
@@ -1,0 +1,210 @@
+"""Loops with no closed form are solved numerically when a pose is placed.
+
+Drives handle a ram, whose geometry is a triangle. A four bar has no such
+identity, so its follower joints are solved from the pin instead.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from build123d import Box
+
+from articraft.sdk import ArticulatedObject, ArticulationType, MotionLimits, Origin
+from articraft.sdk._collision import MeshCollisionKernel, _origin_matrix
+from articraft.sdk.errors import LoopClosureError
+from articraft.sdk.joints import partition_articulations
+
+
+def _bar(model: ArticulatedObject, name: str, length: float):
+    part = model.part(name)
+    part.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+    return part
+
+
+# A planar four bar, laid out so the closing pin sits at the rocker's far end:
+# ground A--D, crank A--B, coupler B--C, rocker D--C.
+GROUND_A = (-0.2, 0.0, 0.1)
+GROUND_D = (0.25, 0.0, 0.1)
+CRANK = 0.2
+ROCKER = 0.25
+POINT_B = (GROUND_A[0] + CRANK, 0.0, GROUND_A[2])
+POINT_C = (GROUND_D[0], 0.0, GROUND_D[2] + ROCKER)
+COUPLER = math.dist(POINT_B, POINT_C)
+COUPLER_TILT = -math.atan2(POINT_C[2] - POINT_B[2], POINT_C[0] - POINT_B[0])
+
+
+def _four_bar(*, coupler: float = COUPLER) -> ArticulatedObject:
+    model = ArticulatedObject("four_bar")
+    ground = _bar(model, "ground", 0.5)
+    crank = _bar(model, "crank", CRANK)
+    coupler_part = _bar(model, "coupler", coupler)
+    rocker_part = _bar(model, "rocker", ROCKER)
+    model.articulation(
+        "crank_pin",
+        ArticulationType.REVOLUTE,
+        ground,
+        crank,
+        origin=Origin(xyz=GROUND_A),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-0.6, upper=0.6),
+    )
+    model.articulation(
+        "coupler_pin",
+        ArticulationType.REVOLUTE,
+        crank,
+        coupler_part,
+        origin=Origin(xyz=(CRANK, 0.0, 0.0), rpy=(0.0, COUPLER_TILT, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.5, upper=1.5),
+    )
+    model.articulation(
+        "rocker_pin",
+        ArticulationType.REVOLUTE,
+        ground,
+        rocker_part,
+        origin=Origin(xyz=GROUND_D, rpy=(0.0, -math.pi / 2, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.5, upper=1.5),
+    )
+    model.articulation(
+        "closing_pin",
+        ArticulationType.REVOLUTE,
+        coupler_part,
+        rocker_part,
+        origin=Origin(xyz=(coupler, 0.0, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-2.0, upper=2.0),
+    )
+    model.validate()
+    return model
+
+
+def _worst_pin_gap(model: ArticulatedObject, poses: list[dict[str, float]]) -> float:
+    kernel = MeshCollisionKernel(model, mesh_tolerance=0.002)
+    _tree, loops = partition_articulations(model.articulations)
+    rest = kernel.world_transforms({})
+    worst = 0.0
+    for pose in poses:
+        transforms = kernel.world_transforms(pose)
+        for closure in loops:
+            pin_rest = (rest[closure.parent] @ _origin_matrix(closure.origin))[:3, 3]
+            local = np.linalg.inv(rest[closure.child]) @ np.array([*pin_rest, 1.0])
+            pin = (transforms[closure.parent] @ _origin_matrix(closure.origin))[:3, 3]
+            worst = max(worst, float(np.linalg.norm(pin - (transforms[closure.child] @ local)[:3])))
+    return worst
+
+
+def _rocker_tip(kernel: MeshCollisionKernel, pose: dict[str, float]) -> np.ndarray:
+    transforms = kernel.world_transforms(pose)
+    return (transforms["rocker"] @ np.array([ROCKER, 0.0, 0.0, 1.0]))[:3]
+
+
+def test_four_bar_stays_closed_across_its_crank() -> None:
+    model = _four_bar()
+    poses = [{"crank_pin": float(value)} for value in np.linspace(-0.55, 0.55, 15)]
+    assert _worst_pin_gap(model, poses) < 1e-6
+
+
+def test_the_follower_actually_swings() -> None:
+    """A loop frozen in place would also score a zero gap."""
+
+    kernel = MeshCollisionKernel(_four_bar(), mesh_tolerance=0.002)
+    swept = [_rocker_tip(kernel, {"crank_pin": angle}) for angle in (-0.5, 0.5)]
+    assert float(np.linalg.norm(swept[0] - swept[1])) > 0.15
+
+
+def test_the_coupler_traces_a_curve_no_single_hinge_could() -> None:
+    """The point of a four bar: the coupler translates while it rotates.
+
+    Its pinned end rides the crank's circle, but its far end sweeps a coupler
+    curve, covering very different distances for equal crank steps. A single
+    hinge could only ever draw a constant radius arc.
+    """
+
+    kernel = MeshCollisionKernel(_four_bar(), mesh_tolerance=0.002)
+    path = [
+        (
+            kernel.world_transforms({"crank_pin": float(angle)})["coupler"]
+            @ np.array([COUPLER, 0.0, 0.0, 1.0])
+        )[:3]
+        for angle in np.linspace(-0.5, 0.5, 5)
+    ]
+    spans = [float(np.linalg.norm(path[index + 1] - path[index])) for index in range(4)]
+    assert min(spans) > 0.005
+    assert max(spans) / min(spans) > 2.0
+
+
+def test_whatever_the_caller_poses_leads() -> None:
+    """Pose the rocker instead and the crank becomes the follower."""
+
+    model = _four_bar()
+    assert _worst_pin_gap(model, [{"rocker_pin": -0.2}]) < 1e-6
+    kernel = MeshCollisionKernel(model, mesh_tolerance=0.002)
+    driven_by_rocker = kernel.world_transforms({"rocker_pin": -0.2})["crank"]
+    assert not np.allclose(driven_by_rocker, kernel.world_transforms({})["crank"])
+
+
+def test_solutions_are_deterministic_and_history_free() -> None:
+    model = _four_bar()
+    fresh = MeshCollisionKernel(model, mesh_tolerance=0.002)
+    used = MeshCollisionKernel(model, mesh_tolerance=0.002)
+    used.world_transforms({"crank_pin": -0.55})
+    used.world_transforms({"crank_pin": 0.55})
+    assert np.allclose(
+        fresh.world_transforms({"crank_pin": 0.1})["rocker"],
+        used.world_transforms({"crank_pin": 0.1})["rocker"],
+    )
+
+
+def test_unreachable_pose_is_an_error_not_a_broken_placement() -> None:
+    """Swung past where the linkage can follow, no assembly exists: say so.
+
+    The bound is real: with this geometry the rocker pin can be carried until
+    the crank and coupler are stretched into a line, and no further.
+    """
+
+    kernel = MeshCollisionKernel(_four_bar(), mesh_tolerance=0.002)
+    with pytest.raises(LoopClosureError, match="cannot reach this pose"):
+        kernel.world_transforms({"crank_pin": 2.6})
+
+
+def test_the_reachable_bound_matches_the_geometry() -> None:
+    """Where the solver gives up should be where the linkage actually binds."""
+
+    kernel = MeshCollisionKernel(_four_bar(), mesh_tolerance=0.002)
+    span = COUPLER + CRANK
+    for angle in (0.1, -0.1, -0.3):
+        offset = np.array([ROCKER * math.sin(angle), 0.0, ROCKER * math.cos(angle)])
+        reach = float(np.linalg.norm(np.array(GROUND_D) + offset - np.array(GROUND_A)))
+        assert reach <= span  # analytically reachable
+        kernel.world_transforms({"rocker_pin": angle})  # so the solver must place it
+
+    offset = np.array([ROCKER * math.sin(0.25), 0.0, ROCKER * math.cos(0.25)])
+    reach = float(np.linalg.norm(np.array(GROUND_D) + offset - np.array(GROUND_A)))
+    assert reach > span  # analytically out of reach
+    with pytest.raises(LoopClosureError):
+        kernel.world_transforms({"rocker_pin": 0.25})
+
+
+def test_models_without_loops_are_untouched() -> None:
+    model = ArticulatedObject("plain")
+    base = _bar(model, "base", 0.3)
+    arm = _bar(model, "arm", 0.3)
+    model.articulation(
+        "hinge",
+        ArticulationType.REVOLUTE,
+        base,
+        arm,
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.0, upper=1.0),
+    )
+    kernel = MeshCollisionKernel(model, mesh_tolerance=0.002)
+    candidates, targets = kernel._loop_solution_plan()
+    assert candidates == [] and targets == []
+    assert np.allclose(
+        kernel.world_transforms({"hinge": 0.4})["arm"],
+        kernel._place({"hinge": 0.4})["arm"],
+    )


### PR DESCRIPTION
Drives cover a hydraulic ram because its geometry is a triangle. A **four bar** — a hood hinge, a folding drag brace, a scissor arm — has no such identity: the follower angles are transcendental in the driver's. Until now, placing one left the loop open, so the mechanism came apart in renders, viewer poses and geometry checks while `validate()` stayed green.

`world_transforms` now *completes* a pose rather than merely walking it: whatever the caller poses leads, and every other movable joint in the ring is solved from the pin.

## Measured

| model | worst pin gap across its full swing |
|---|---|
| four bar (test fixture) | < 1 nm |
| four bar car hood (generated today, one sentence prompt) | 0.0003 mm |
| landing gear drag brace (generated) | 0.0004 mm |
| excavator, 3 rams | 0.000000 mm |
| hydraulic ram doc example | 0.000000 mm |

## Design notes

- **Levenberg-Marquardt**, not plain Gauss-Newton: an over-center linkage (your locking pliers) passes through singular configurations where Gauss-Newton diverges.
- **Continuation from rest**, five steps. A four bar has two assembly branches; walking out from the authored rest pose keeps the model on the branch it was authored in instead of snapping through itself mid-sweep. Rest is exact by construction — drives solve to zero there (enforced at export) and pins are measured there.
- **Unreachable poses raise `LoopClosureError`** naming the closure and the gap. No placement is correct there, and a silently broken one is the thing this feature exists to end. A test pins the bound against the linkage's analytic reach.
- **No loops, no cost**: an early return, so models without closures are bit-for-bit unchanged.

## Tests

8 new tests: closure held across the crank, follower actually swings, coupler traces a genuine coupler curve (not a constant-radius arc), either joint can lead, determinism regardless of call history, unreachable raises, reachable bound matches geometry, tree models untouched.

Full suite: **620 passed**.

Follow-ups not in this PR: the browser viewer solves nothing yet (its sliders still pose along the tree), and a check that a loop's follower limits admit its driver's range would have caught the landing gear authoring its knee limits inverted.