### PR TITLE
Teach fixed length links, and catch the ones that only point

### DIFF
--- a/src/articraft/compiler/worker.py
+++ b/src/articraft/compiler/worker.py
@@ -325,6 +325,8 @@ def _run_baseline_tests(
         ctx.fail_if_parts_overlap_in_current_pose()
     with tracker.phase("checking articulation motion"):
         ctx.fail_if_articulation_separates_child()
+    with tracker.phase("checking aimed links reach their anchors"):
+        ctx.fail_if_aimed_link_never_reaches()
     report = _without_allowance_notes(ctx.report())
     # Most baseline checks report as diagnostics so a run still produces a model.
     # Missing mass is different: with the physics lane on, a part without mass has

--- a/src/articraft/sdk/docs/common/00_quickstart.md
+++ b/src/articraft/sdk/docs/common/00_quickstart.md
@@ -83,6 +83,8 @@ Read only the executable example closest to the current task:
 - Mixed build123d and mesh assembly: `docs/sdk/examples/mixed_articulated_assembly.py`.
 - Closed loop linkage (a hydraulic ram) posed through drives:
   `docs/sdk/examples/hydraulic_ram_loop.py`.
+- Fixed length link pinned at both ends (a four bar):
+  `docs/sdk/examples/four_bar_linkage.py`.
 - Molding a handle/protrusion into a body (no mounting pads):
   `docs/sdk/examples/molded_mug.py`.
 - Mass properties from materials and geometry:

--- a/src/articraft/sdk/docs/common/35_joints.md
+++ b/src/articraft/sdk/docs/common/35_joints.md
@@ -320,6 +320,13 @@ posed. A `drive` reads a point on a part the joint does not move.
 A hydraulic ram uses both: the barrel aims at the far eye and the rod spans to
 it.
 
+Reach for a drive only when the mechanism *changes length*. A fixed length link
+-- a pitman arm, a pull rod, a drag brace, a hood hinge link -- is one rigid
+part pinned at both ends, and no formula gives its angle: it needs a loop
+closure, and its follower angles are then solved for you. `AimAt` on such a link
+points it at the anchor and leaves it hanging there, which `compile` reports as
+a link that never attaches. See `docs/sdk/examples/four_bar_linkage.py`.
+
 ```python
 model.articulation(
     "boom_ram_pivot",

--- a/src/articraft/sdk/docs/examples/four_bar_linkage.py
+++ b/src/articraft/sdk/docs/examples/four_bar_linkage.py
@@ -1,0 +1,162 @@
+"""A four bar linkage: a fixed length link pinned at both ends.
+
+This is the other half of the loop vocabulary. A hydraulic ram *changes length*,
+so its two joints are solved in closed form by drives -- see
+``hydraulic_ram_loop.py``. A pitman arm, a pull rod, a drag brace, a hood hinge
+link or a scissor arm does not change length: it is one rigid part pinned at
+both ends, and no formula gives its angle. Declare the second pin as one more
+articulation and it becomes a loop closure. Posing the crank then swings the
+whole ring, because the follower angles are solved from the pin.
+
+The mistake this example exists to prevent is reaching for ``AimAt`` here.
+``AimAt`` points a part at an anchor; it never makes the part *reach* it. A link
+that only aims ends up hanging in space with its far eye nowhere near the pin it
+is supposed to hold, and every check still passes.
+
+Layout, all in metres: ground A--D, crank A--B, coupler B--C, rocker D--C.
+"""
+
+from __future__ import annotations
+
+import math
+
+from build123d import Box, Cylinder, Pos, Rot
+
+from articraft.sdk import (
+    ArticulatedObject,
+    ArticulationType,
+    Material,
+    MotionLimits,
+    Origin,
+    TestContext,
+    TestReport,
+)
+
+GROUND_A = (-0.20, 0.0, 0.10)  # crank pin on the ground link
+GROUND_D = (0.25, 0.0, 0.10)  # rocker pin on the ground link
+CRANK = 0.20  # A to B
+ROCKER = 0.25  # D to C
+
+POINT_B = (GROUND_A[0] + CRANK, 0.0, GROUND_A[2])
+POINT_C = (GROUND_D[0], 0.0, GROUND_D[2] + ROCKER)
+COUPLER = math.dist(POINT_B, POINT_C)  # B to C: the fixed length link
+# Aim the coupler's own +X down its length, so its far end sits at (COUPLER, 0, 0).
+COUPLER_TILT = -math.atan2(POINT_C[2] - POINT_B[2], POINT_C[0] - POINT_B[0])
+
+STEEL = Material.STEEL.but(roughness=0.35)
+
+
+def _link(part, length: float, radius: float = 0.018) -> None:
+    """A round bar along +X from the part's own origin, with an eye at each end."""
+
+    part.add(Rot(Y=90) * Pos(Z=length / 2) * Cylinder(radius, length), name="bar", material=STEEL)
+    for name, x in (("near_eye", 0.0), ("far_eye", length)):
+        part.add(
+            Pos(X=x) * Cylinder(radius * 1.8, radius * 1.6, rotation=(90, 0, 0)),
+            name=name,
+            material=STEEL,
+        )
+
+
+def build_object_model() -> ArticulatedObject:
+    model = ArticulatedObject("four_bar_linkage")
+
+    ground = model.part("ground")
+    ground.add(Box(0.62, 0.06, 0.05), name="bed", material=STEEL, color=(0.24, 0.26, 0.30))
+    for name, anchor in (("crank_post", GROUND_A), ("rocker_post", GROUND_D)):
+        ground.add(
+            Pos(X=anchor[0], Z=anchor[2] / 2) * Box(0.05, 0.05, anchor[2]),
+            name=name,
+            material=STEEL,
+            color=(0.24, 0.26, 0.30),
+        )
+
+    crank = model.part("crank")
+    _link(crank, CRANK, radius=0.022)
+
+    coupler = model.part("coupler")
+    _link(coupler, COUPLER)
+
+    rocker = model.part("rocker")
+    _link(rocker, ROCKER, radius=0.020)
+
+    # The tree: three joints, each the first to reach its child.
+    model.articulation(
+        "crank_pin",
+        ArticulationType.REVOLUTE,
+        ground,
+        crank,
+        origin=Origin(xyz=GROUND_A),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-0.55, upper=0.55),
+    )
+    model.articulation(
+        "coupler_pin",
+        ArticulationType.REVOLUTE,
+        crank,
+        coupler,
+        # The coupler hangs off the crank's far end, tilted to point at C.
+        origin=Origin(xyz=(CRANK, 0.0, 0.0), rpy=(0.0, COUPLER_TILT, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.5, upper=1.5),
+    )
+    model.articulation(
+        "rocker_pin",
+        ArticulationType.REVOLUTE,
+        ground,
+        rocker,
+        # Rotated so the rocker's own +X points up at C.
+        origin=Origin(xyz=GROUND_D, rpy=(0.0, -math.pi / 2, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.5, upper=1.5),
+    )
+    # The closure: the coupler's far end is pinned to the rocker's far end. The
+    # rocker already has a parent, so this second articulation reaching it closes
+    # the ring rather than re-parenting it. No drive belongs here: the coupler is
+    # a fixed length, and its angle has no closed form.
+    model.articulation(
+        "closing_pin",
+        ArticulationType.REVOLUTE,
+        coupler,
+        rocker,
+        origin=Origin(xyz=(COUPLER, 0.0, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-2.0, upper=2.0),
+    )
+    return model
+
+
+object_model = build_object_model()
+
+
+def run_tests() -> TestReport:
+    ctx = TestContext(object_model)
+
+    # Pose only the crank. The coupler and rocker are followers: their angles
+    # are solved so the closing pin stays shut, which is what makes this a
+    # mechanism rather than three loose bars.
+    poses = ctx.sample_joint("crank_pin", samples=7)
+
+    # The far end of the coupler and the far end of the rocker are the same
+    # physical pin, so they must ride together everywhere in the sweep.
+    ctx.expect_distance_at_poses(
+        "coupler",
+        "rocker",
+        poses,
+        shape_a="far_eye",
+        shape_b="far_eye",
+        maximum=0.002,
+        name="closing pin stays shut",
+    )
+
+    # A frozen mechanism would also pass the check above, so prove the rocker
+    # actually swings, and that its far end covers real ground.
+    swept = ctx.track_point("rocker", (ROCKER, 0.0, 0.0), poses)
+    travel = max(math.dist(swept[0], point) for point in swept)
+    ctx.check(
+        "the rocker swings through the crank's range",
+        travel > 0.05,
+        details=f"rocker end travelled {travel * 1000:.0f} mm",
+    )
+    ctx.record_metric("rocker_end_travel_m", travel)
+    return ctx.report()

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -25,12 +25,21 @@ from articraft.sdk._collision import (
 from articraft.sdk._mesh.core import geometry_to_trimesh
 from articraft.sdk._mesh.health import MeshHealthIssue, analyze_mesh_health
 from articraft.sdk.errors import ValidationError
-from articraft.sdk.joints import Articulation, ArticulationType, partition_articulations
+from articraft.sdk.joints import (
+    AimAt,
+    Articulation,
+    ArticulationType,
+    partition_articulations,
+)
 from articraft.sdk.mass import resolve_mass
 from articraft.sdk.materials import LIBRARY
 from articraft.sdk.object import ArticulatedObject, Part, PartRef
 
 DEFAULT_MESH_TOLERANCE = 0.001
+# How far the gap between an aimed part and its anchor may wander before the two
+# are clearly not pinned together. A real pin holds it fixed; mesh tessellation
+# moves it by a hair.
+_AIM_REACH_TOLERANCE = 0.005
 DEFAULT_CONTACT_TOLERANCE = 1e-6
 DEFAULT_OVERLAP_TOLERANCE = 0.005
 DEFAULT_OVERLAP_VOLUME_TOLERANCE = 5e-7
@@ -1153,6 +1162,144 @@ class TestContext:
         name: str | None = None,
     ) -> bool:
         return self._check_disconnected_geometry(contact_tol=contact_tol, name=name, warn=True)
+
+    def fail_if_aimed_link_never_reaches(
+        self,
+        *,
+        samples: int = 5,
+        name: str | None = None,
+    ) -> bool:
+        """Fail if a joint aims a part at an anchor the part never reaches.
+
+        ``AimAt`` points a part at an anchor; it does not attach it. That is the
+        right tool for the barrel of a ram, whose rod extends the rest of the
+        way. It is the wrong tool for a fixed length link -- a pitman arm, a
+        pull rod, a drag brace -- which is one rigid part pinned at both ends
+        and needs a loop closure instead.
+
+        The failure is silent without this check: the link swings, points the
+        right way, and hangs in space with its far eye nowhere near its pin,
+        while every other check passes. So for each aimed joint, this asks
+        whether the child can physically reach the anchor it is aiming at.
+        """
+
+        samples = max(2, int(samples))
+        check_name = name or "fail_if_aimed_link_never_reaches()"
+        aimed = [
+            item
+            for item in self.model.articulations
+            if isinstance(item.drive, AimAt) and item.drive.part in self._part_names()
+        ]
+        if not aimed:
+            return self._record(check_name, True, "")
+
+        kernel = self._kernel()
+        findings: list[str] = []
+        for articulation in aimed:
+            drive = articulation.drive
+            assert isinstance(drive, AimAt)
+            # A ram aims its barrel but reaches with its rod, so the whole
+            # driven assembly counts: the aimed part plus everything a drive
+            # extends from it.
+            # A ram aims its barrel but reaches with its rod, so the whole
+            # driven assembly counts: the aimed part plus everything a drive
+            # extends from it. Each is tracked separately, because it only
+            # takes one of them to be pinned for the assembly to be attached.
+            tracked: dict[str, list[float]] = {
+                name: [] for name in self._driven_extent(articulation.child)
+            }
+            for pose in self._aim_probe_poses(articulation, samples):
+                transforms = kernel.world_transforms(pose)
+                target = transforms.get(drive.part)
+                if target is None:
+                    continue
+                anchor = target[:3, :3] @ np.asarray(drive.point, dtype=float) + target[:3, 3]
+                for part_name in tracked:
+                    if part_name not in transforms:
+                        continue
+                    vertices = kernel.part_world_vertices(part_name, pose)
+                    tracked[part_name].append(
+                        float(np.linalg.norm(vertices - anchor, axis=1).min())
+                    )
+            drifts = [max(values) - min(values) for values in tracked.values() if len(values) > 1]
+            if not drifts:
+                continue
+            gaps = [min(drifts)]
+            # Distance alone says nothing: a rod eye ring sits a bore radius away
+            # from the pin it holds. What separates a pinned link from one that
+            # merely points is whether that distance *stays put* as the mechanism
+            # moves. A pin holds it constant; an aim lets it wander.
+            drift = gaps[0]
+            if drift > _AIM_REACH_TOLERANCE:
+                findings.append(
+                    f"{articulation.name!r} aims {articulation.child!r} at {drive.part!r} but "
+                    f"never attaches: the gap between them wanders by {drift * 1000:.0f} mm as "
+                    f"{drive.part!r} moves. AimAt points a part at an anchor, it does not pin "
+                    f"it there. A fixed length link needs a loop closure: declare a second "
+                    f"articulation pinning {articulation.child!r} to {drive.part!r}."
+                )
+        return self._record(check_name, not findings, "; ".join(findings))
+
+    def _driven_extent(self, part: str) -> set[str]:
+        """A part and everything a drive extends from it.
+
+        A hydraulic ram is two parts: the barrel aims, the rod reaches. Asking
+        whether the barrel alone touches its anchor would condemn every correct
+        ram, so the rod it drives out counts as part of the same reach.
+        """
+
+        reached = {part}
+        frontier = [part]
+        while frontier:
+            current = frontier.pop()
+            for articulation in self.model.articulations:
+                if (
+                    articulation.parent == current
+                    and articulation.drive is not None
+                    and articulation.child not in reached
+                ):
+                    reached.add(articulation.child)
+                    frontier.append(articulation.child)
+        return reached
+
+    def _part_names(self) -> set[str]:
+        return {part.name for part in self.model.parts}
+
+    def _aim_probe_poses(self, articulation: Articulation, samples: int) -> list[dict[str, float]]:
+        """Poses that move the anchor around, so a fixed gap cannot hide.
+
+        The anchor rides another part, so the joints that place *that* part are
+        what must be swept -- the aimed joint itself is driven and follows.
+        """
+
+        tree, _loops = partition_articulations(self.model.articulations)
+        parent_of = {item.child: item for item in tree}
+        walked: list[Articulation] = []
+        part = articulation.drive.part if articulation.drive is not None else None
+        while part in parent_of:
+            walked.append(parent_of[part])
+            part = parent_of[part].parent
+        movable = [
+            item
+            for item in walked
+            if item.drive is None
+            and item.articulation_type != ArticulationType.FIXED
+            and item.motion_limits is not None
+            and item.motion_limits.lower is not None
+            and item.motion_limits.upper is not None
+        ]
+        if not movable:
+            return [dict(self._pose)]
+        poses: list[dict[str, float]] = []
+        for index in range(samples):
+            blend = index / (samples - 1)
+            pose = dict(self._pose)
+            for item in movable:
+                limits = item.motion_limits
+                assert limits is not None and limits.lower is not None and limits.upper is not None
+                pose[item.name] = limits.lower + (limits.upper - limits.lower) * blend
+            poses.append(pose)
+        return poses
 
     def fail_if_articulation_separates_child(
         self,

--- a/tests/test_aimed_link_reach.py
+++ b/tests/test_aimed_link_reach.py
@@ -1,0 +1,177 @@
+"""An aimed link must be pinned, not merely pointed.
+
+``AimAt`` turns a part to face an anchor. That is right for the barrel of a ram,
+whose rod extends the rest of the way, and wrong for a fixed length link -- a
+pitman arm, a pull rod -- which needs a loop closure. Reaching for the first
+where the second was needed leaves the link hanging in space, and every other
+check passes.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from build123d import Box, Cylinder, Pos, Rot
+
+from articraft.sdk import (
+    AimAt,
+    ArticulatedObject,
+    ArticulationType,
+    MotionLimits,
+    Origin,
+    Part,
+    SpanTo,
+    TestContext,
+)
+
+ANCHOR = (0.30, 0.0, 0.0)  # on the rocking beam, in its own frame
+
+
+def _beam_and_crank() -> tuple[ArticulatedObject, Part, Part]:
+    model = ArticulatedObject("linkage")
+    base = model.part("base")
+    base.add(Box(0.4, 0.1, 0.05), name="bed")
+    beam = model.part("beam")
+    beam.add(Pos(X=0.15) * Box(0.34, 0.05, 0.05), name="beam")
+    crank = model.part("crank")
+    crank.add(Pos(X=0.06) * Box(0.14, 0.04, 0.04), name="web")
+    model.articulation(
+        "beam_rocker",
+        ArticulationType.REVOLUTE,
+        base,
+        beam,
+        origin=Origin(xyz=(-0.1, 0.0, 0.25)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-0.35, upper=0.35),
+    )
+    model.articulation(
+        "crank_rotation",
+        ArticulationType.REVOLUTE,
+        base,
+        crank,
+        origin=Origin(xyz=(0.12, 0.0, 0.05)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-0.6, upper=0.6),
+    )
+    return model, crank, beam
+
+
+def _link_only_aimed() -> ArticulatedObject:
+    """The mistake: a fixed length rod that points at the beam and never touches."""
+
+    model, crank, _beam = _beam_and_crank()
+    rod = model.part("rod")
+    rod.add(Rot(Y=90) * Pos(Z=0.11) * Cylinder(0.012, 0.22), name="rod")
+    model.articulation(
+        "rod_pin",
+        ArticulationType.REVOLUTE,
+        crank,
+        rod,
+        origin=Origin(xyz=(0.12, 0.0, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.4, upper=1.4),
+        drive=AimAt("beam", ANCHOR),
+    )
+    model.validate()
+    return model
+
+
+def _proper_ram() -> ArticulatedObject:
+    """The correct use: the barrel aims, and the rod it drives reaches."""
+
+    model, crank, _beam = _beam_and_crank()
+    barrel = model.part("barrel")
+    barrel.add(Rot(Y=90) * Pos(Z=0.06) * Cylinder(0.02, 0.12), name="tube")
+    rod = model.part("rod")
+    rod.add(Rot(Y=90) * Pos(Z=0.06) * Cylinder(0.01, 0.12), name="shaft")
+    rod.add(Pos(X=0.16) * Cylinder(0.02, 0.03, rotation=(90, 0, 0)), name="eye")
+    kernel_model = model
+    barrel_joint = model.articulation(
+        "barrel_pivot",
+        ArticulationType.REVOLUTE,
+        crank,
+        barrel,
+        origin=Origin(xyz=(0.12, 0.0, 0.0)),
+        axis=(0.0, 1.0, 0.0),
+        motion_limits=MotionLimits(lower=-1.6, upper=1.6),
+        drive=AimAt("beam", ANCHOR),
+    )
+    assert barrel_joint.drive is not None
+    model.articulation(
+        "ram_stroke",
+        ArticulationType.PRISMATIC,
+        barrel,
+        rod,
+        axis=(1.0, 0.0, 0.0),
+        motion_limits=MotionLimits(lower=-0.3, upper=0.4),
+        drive=SpanTo("beam", ANCHOR, rest_length=0.16),
+    )
+    kernel_model.validate()
+    return model
+
+
+def _report(model: ArticulatedObject):
+    ctx = TestContext(model)
+    ctx.fail_if_aimed_link_never_reaches()
+    return ctx.report()
+
+
+def test_a_link_that_only_points_is_caught() -> None:
+    report = _report(_link_only_aimed())
+    assert not report.passed
+    details = report.failures[0].details
+    assert "never attaches" in details
+    assert "loop closure" in details  # the message says what to do instead
+
+
+def test_a_ram_whose_rod_reaches_passes() -> None:
+    assert _report(_proper_ram()).passed
+
+
+def test_the_gap_really_does_wander_on_the_broken_one() -> None:
+    """Pin the physics the check is reading, not just its verdict."""
+
+    from articraft.sdk._collision import MeshCollisionKernel
+
+    model = _link_only_aimed()
+    kernel = MeshCollisionKernel(model, mesh_tolerance=0.002)
+    gaps = []
+    for angle in np.linspace(-0.35, 0.35, 5):
+        transforms = kernel.world_transforms({"beam_rocker": float(angle)})
+        beam = transforms["beam"]
+        anchor = beam[:3, :3] @ np.asarray(ANCHOR) + beam[:3, 3]
+        vertices = kernel.part_world_vertices("rod", {"beam_rocker": float(angle)})
+        gaps.append(float(np.linalg.norm(vertices - anchor, axis=1).min()))
+    assert max(gaps) - min(gaps) > 0.02
+
+
+def test_models_with_no_aimed_joints_pass_trivially() -> None:
+    model, _crank, _beam = _beam_and_crank()
+    model.validate()
+    assert _report(model).passed
+
+
+def test_the_shipped_examples_are_clean() -> None:
+    """Both doc examples must model their linkage the way they teach it."""
+
+    import runpy
+
+    from articraft import package_dir
+
+    for name in ("hydraulic_ram_loop.py", "four_bar_linkage.py"):
+        values = runpy.run_path(str(package_dir / "sdk" / "docs" / "examples" / name))
+        assert _report(values["object_model"]).passed, name
+
+
+def test_four_bar_example_holds_its_pin_and_swings() -> None:
+    import runpy
+
+    from articraft import package_dir
+
+    values = runpy.run_path(str(package_dir / "sdk" / "docs" / "examples" / "four_bar_linkage.py"))
+    report = values["run_tests"]()
+    assert report.passed, report.failures
+    travel = next(metric for metric in report.metrics if metric.name == "rocker_end_travel_m")
+    assert travel.value > 0.05
+    assert math.isfinite(travel.value)


### PR DESCRIPTION
Two objects generated against current main made the same mistake: a pumpjack's **pitman arm** and a swingarm's **pull rod** — each a rigid link pinned at both ends — were authored with an `AimAt` drive. `AimAt` turns a part to face an anchor; it never attaches it. Both hung in space while `validate()`, `compile`, and the models' own checks passed.

| link | authored as | result |
|---|---|---|
| pumpjack pitman | `AimAt` | gap to its pin wanders **250 → 1543 mm** |
| swingarm pull rod | `AimAt` | gap wanders 46 → 11 mm, never touches |
| swingarm shock | closure + drives | ✅ 0.000000 mm |
| hood, drag brace, dump bed, excavator rams | closure / drives | ✅ 0 – 0.0004 mm |

This is a teaching gap, not a solver gap (#120 is behaving). The only worked linkage example is a hydraulic ram, which *legitimately* uses drives because a ram changes length — so a ram is what the agent writes, even when the mechanism is a fixed-length link that needs a loop closure.

## What's here

**`four_bar_linkage.py`** — an executable doc example: crank, coupler, rocker, one closing pin, **zero drives**. Its own checks assert the pin stays shut across the sweep *and* that the rocker actually swings, so a frozen mechanism can't pass. Routed from the quickstart; `35_joints.md` now states the rule (drive = changes length, closure = fixed length).

**`fail_if_aimed_link_never_reaches()`** — runs in `compile`, so the agent sees it inside its own repair loop.

The interesting part is the criterion. Absolute distance proves nothing: a correct rod eye ring sits a bore radius (80 mm on the excavator) from the pin it holds. What separates *pinned* from *pointed* is whether that distance **stays put while the anchor moves** — a pin holds it constant, an aim lets it wander. Measured per part across the aimed assembly, since a ram aims its barrel and reaches with its rod, and it only takes one to be pinned.

## Tests

6 new, including a fixture pair (broken link vs proper ram), a test pinning the underlying physics rather than just the verdict, and a guard that both shipped examples stay clean. Full suite **626 passed**, pyright clean.

Next: regenerating the pumpjack and swingarm against this branch to confirm the example transfers, the way the ram example did.