### PR TITLE
Anchor joint frames to body geometry

### DIFF
--- a/benchmarks/sdk_benchmark.py
+++ b/benchmarks/sdk_benchmark.py
@@ -96,10 +96,8 @@ def _collision_model() -> RigidBodyAssembly:
             joints.append(
                 model.joint(
                     f"joint_{index:02d}",
-                    body0=previous,
-                    frame0=JointFrame(xyz=(0.03, 0.0, 0.0)),
-                    body1=part,
-                    frame1=JointFrame(),
+                    previous.at(JointFrame(xyz=(0.03, 0.0, 0.0))),
+                    part.at(),
                 ).name
             )
         previous = part

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -65,7 +65,7 @@ the tree of joints the simulator solves.
 ```python
 from build123d import Box
 
-from articraft.sdk import JointAxis, JointDOF, JointFrame
+from articraft.sdk import JointAxis, JointDOF
 
 
 lid = model.rigid_body("lid")
@@ -73,17 +73,16 @@ lid.add(Box(0.1, 0.1, 0.01), name="panel")
 
 model.joint(
     "body_to_lid",
-    body0="body",
-    frame0=JointFrame(xyz=(0.0, 0.05, 0.05)),
-    body1="lid",
-    frame1=JointFrame(),
+    model.get_rigid_body("body").at((0.0, 0.05, 0.05)),
+    lid.at(),
     dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.8)),),
 )
 model.articulation("main", root="body", joints=["body_to_lid"])
 ```
 
-Place each joint endpoint with a `JointFrame` in that body's local coordinates.
-The two frames coincide at zero. `body0` and `body1` are symmetric; the
+`body.at(...)` binds a point or a build123d `Location`, `Plane`, `Axis`, face,
+edge, or vertex to the body whose coordinates it uses. The two endpoint frames
+coincide at zero. The endpoints are symmetric; the
 articulation independently selects the solver's rooted spanning tree. Closed
 loops author every physical joint and omit the closing constraint from that tree.
 

--- a/examples/hinged_box/main.py
+++ b/examples/hinged_box/main.py
@@ -10,12 +10,11 @@ Compile it:  python -m articraft.compiler.worker <run_dir>
 
 from __future__ import annotations
 
-from build123d import Box
+from build123d import Align, Axis, Box
 
 from articraft.sdk import (
     JointAxis,
     JointDOF,
-    JointFrame,
     Material,
     RigidBodyAssembly,
     TestContext,
@@ -29,16 +28,20 @@ def build_object_model() -> RigidBodyAssembly:
     base = model.rigid_body("base")
     # Saying what a shape is made of settles its mass, how it behaves on contact,
     # and how it looks. Aluminum comes out light and metallic without asking.
-    base.add(Box(0.10, 0.08, 0.04), name="body", material=Material.ALUMINUM)
+    base_shape = Box(0.10, 0.08, 0.04)
+    base.add(base_shape, name="body", material=Material.ALUMINUM)
 
     lid = model.rigid_body("lid")
+    lid_shape = Box(
+        0.10,
+        0.08,
+        0.015,
+        align=(Align.CENTER, Align.MIN, Align.MIN),
+    )
     lid.add(
-        # Body geometry is authored in the body's LOCAL frame; the two hinge
-        # frames map it into the assembly. Local (0, 0.04,
-        # 0.007) therefore lands the lid at world (0, 0, 0.027): its knuckle
-        # edge sits 0.5 mm into the base, a small designed embed that keeps
-        # the parts physically connected (declared below with allow_overlap).
-        Box(0.10, 0.08, 0.015).translate((0.0, 0.04, 0.007)),
+        # The rear-bottom edge is the body's local origin, so it can be selected
+        # directly as the matching hinge feature below.
+        lid_shape,
         name="body",
         # A recolor keeps the material -- still plastic, still 1050 kg/m^3 --
         # and only changes what it looks like: an amber lid on a metal base.
@@ -46,16 +49,18 @@ def build_object_model() -> RigidBodyAssembly:
         color=(0.62, 0.45, 0.16),
     )
 
-    # The hinge line is the lid/base contact edge: rotating around it keeps the
-    # parts touching instead of pulling the lid off the box. Both frames sit on
-    # that edge, each in its own body's coordinates, so they coincide at rest.
+    base_edge = base_shape.edges().filter_by(Axis.X).group_by(Axis.Y)[0].sort_by(Axis.Z)[-1]
+    lid_edge = lid_shape.edges().filter_by(Axis.X).group_by(Axis.Y)[0].sort_by(Axis.Z)[0]
+    base_hinge = base.at(Axis(base_edge.center(), Axis.X.direction))
+    lid_hinge = lid.at(Axis(lid_edge.center(), Axis.X.direction))
+
+    # The hinge frames are anchored to the actual contact edges. Axis directions
+    # become local Z, so ROT_Z opens the lid around the selected edge.
     model.joint(
         "lid_hinge",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, -0.04, 0.02)),
-        body1=lid,
-        frame1=JointFrame(),
-        dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.5708)),),
+        base_hinge,
+        lid_hinge,
+        dofs=(JointDOF(JointAxis.ROT_Z, limits=(0.0, 1.5708)),),
     )
     model.articulation("main", root=base, joints=["lid_hinge"])
     return model
@@ -66,12 +71,23 @@ object_model = build_object_model()
 
 def run_tests() -> TestReport:
     ctx = TestContext(object_model)
-    ctx.allow_overlap(
-        "base",
-        "lid",
-        reason="hinge knuckle embedded in the base",
-        shape_a="body",
-        shape_b="body",
-    )
     ctx.expect_contact("base", "lid")
+    base = object_model.get_rigid_body("base")
+    lid = object_model.get_rigid_body("lid")
+    base_shape = base.shape("body")
+    lid_shape = lid.shape("body")
+    assert isinstance(base_shape, Box)
+    assert isinstance(lid_shape, Box)
+    base_edge = base_shape.edges().filter_by(Axis.X).group_by(Axis.Y)[0].sort_by(Axis.Z)[-1]
+    lid_edge = lid_shape.edges().filter_by(Axis.X).group_by(Axis.Y)[0].sort_by(Axis.Z)[0]
+    ctx.expect_coaxial(
+        base.at(Axis(base_edge.center(), Axis.X.direction)),
+        lid.at(Axis(lid_edge.center(), Axis.X.direction)),
+    )
+    with ctx.pose(lid_hinge=0.8):
+        ctx.expect_coaxial(
+            base.at(Axis(base_edge.center(), Axis.X.direction)),
+            lid.at(Axis(lid_edge.center(), Axis.X.direction)),
+            name="hinge_edges_stay_coaxial_while_opening",
+        )
     return ctx.report()

--- a/examples/mesh_knob/main.py
+++ b/examples/mesh_knob/main.py
@@ -50,6 +50,6 @@ object_model = build_object_model()
 
 def run_tests() -> TestReport:
     ctx = TestContext(object_model)
-    body = object_model.get_rigid_body("knob").get_shape("body")
+    body = object_model.get_rigid_body("knob").shape("body")
     ctx.check("body_is_watertight", body.is_watertight, "the union must stay watertight")
     return ctx.report()

--- a/src/articraft/prompts/system.md
+++ b/src/articraft/prompts/system.md
@@ -150,15 +150,21 @@ grippy like rubber. Add `color=` to tint one shape. For anything more, derive a
 variant with `Material.STEEL.but(roughness=0.75)` and give it a name to reuse.
 Build a new one only when the library has nothing close: `Material(name="ceramic",
 density=2400.0)`. Never encode material semantics in the shape name.
-Use `body.get_shape(name)` when a named shape is needed later. Do not invent a
+Use `body.shape(name)` when a named shape is needed later. Do not invent a
 `GeometryElement` API, and do not pass geometry to `model.rigid_body(...)`.
 
-Motion is two steps. `model.joint(...)` connects two bodies at a `JointFrame` on
-each, and its `dofs` say which axes are free: no `JointDOF` is a fixed joint, one
-rotational axis is a hinge, one linear axis is a slide, three rotational axes are
-a ball. Then `model.articulation(root=..., joints=[...])` names the spanning tree
-the simulator solves. Use the exact signatures in the current SDK docs. Do not
-use build123d joints to describe articraft motion.
+Motion is two steps. `body.at(...)` binds a point or a build123d `Location`,
+`Plane`, `Axis`, face, edge, or vertex to that body. Prefer geometry features:
+they survive dimension changes and avoid copied coordinate arithmetic.
+An axis direction, face normal, or edge tangent becomes frame-local Z.
+`model.joint(name, body0.at(...), body1.at(...), dofs=...)` connects two bound
+frames. No `JointDOF` is fixed, one rotational axis is a hinge, one linear axis
+is a slide, and three rotational axes are a ball. Then
+`model.articulation(root=..., joints=[...])` names the spanning tree the
+simulator solves. Use `model.frame_in(frame, other_body)` when the same physical
+frame must be expressed on another body, especially for loop closures. Use the
+exact signatures in the current SDK docs. Do not use build123d joints to
+describe articraft motion.
 
 Count the pivots before writing joints. A body pinned in two places takes two
 joints, and that makes the mechanism a ring rather than a chain -- linkages,
@@ -167,11 +173,12 @@ Author every joint the mechanism physically has, then leave the ring-closing one
 out of the articulation. Authoring a ring as a chain is a modelling error: the
 bodies export and then flap loose under simulation.
 
-The two frames of a joint coincide at rest, so place each in its own body's
-coordinates. All linear values are meters. Use radians for `JointFrame.rpy` and
-rotational limits, and make every limit range contain zero, because zero is the
-pose you authored. Use the same meter scale for build123d coordinates, mesh helper inputs,
-prismatic travel, and test distances.
+The two bound frames of a joint coincide at rest. All linear values are meters.
+Use radians for explicit `JointFrame.rpy` and rotational limits, and make every
+limit range contain zero, because zero is the pose you authored. Build123d
+locations keep build123d's degree convention and are converted exactly by
+`body.at(...)`. Use the same meter scale for build123d coordinates, mesh helper
+inputs, prismatic travel, and test distances.
 </authoring_contract>
 
 <testing>

--- a/src/articraft/prompts/system.md
+++ b/src/articraft/prompts/system.md
@@ -156,7 +156,9 @@ Use `body.shape(name)` when a named shape is needed later. Do not invent a
 Motion is two steps. `body.at(...)` binds a point or a build123d `Location`,
 `Plane`, `Axis`, face, edge, or vertex to that body. Prefer geometry features:
 they survive dimension changes and avoid copied coordinate arithmetic.
-An axis direction, face normal, or edge tangent becomes frame-local Z.
+The feature's natural axis becomes frame-local Z: an axis direction, a flat
+face's normal, a straight edge's tangent, or a round feature's axis of
+symmetry (a cylindrical face or hole rim anchors the hinge that spins about it).
 `model.joint(name, body0.at(...), body1.at(...), dofs=...)` connects two bound
 frames. No `JointDOF` is fixed, one rotational axis is a hinge, one linear axis
 is a slide, and three rotational axes are a ball. Then

--- a/src/articraft/sdk/__init__.py
+++ b/src/articraft/sdk/__init__.py
@@ -58,17 +58,16 @@ from articraft.sdk._mesh.sweeps import (
     WirePolylineGeometry,
 )
 from articraft.sdk.assembly import (
-    WORLD,
     Articulation,
     Joint,
     JointAxis,
     JointDOF,
-    JointFrame,
     PhysicsState,
     RigidBodyAssembly,
 )
 from articraft.sdk.bodies import RigidBody
 from articraft.sdk.errors import LoopClosureError, SDKError, ValidationError
+from articraft.sdk.frames import WORLD, BodyFrame, JointFrame
 from articraft.sdk.mass import MassProperties
 from articraft.sdk.materials import Material
 from articraft.sdk.physics import EARTH_GRAVITY, BodyState, PhysicsScene
@@ -105,6 +104,7 @@ __all__ = [
     "AllowedOverlap",
     "ArcPipeGeometry",
     "Articulation",
+    "BodyFrame",
     "BodyState",
     "BoxGeometry",
     "CapsuleGeometry",

--- a/src/articraft/sdk/_collision.py
+++ b/src/articraft/sdk/_collision.py
@@ -325,7 +325,7 @@ class MeshCollisionKernel:
             raise ValidationError(f"unknown part: {part.name!r}")
         if shape_name is not None:
             shape_name = str(shape_name).strip()
-            geometry = part.get_shape(shape_name)
+            geometry = part.shape(shape_name)
             return [self._entry(part.name, shape_name, geometry, transform)]
         return [
             self._entry(part.name, shape.name, shape.geometry, transform)

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -13,10 +13,10 @@ import trimesh
 from articraft.sdk._values import _as_identifier, _as_name
 from articraft.sdk.bodies import RigidBody, RigidBodyRef
 from articraft.sdk.errors import LoopClosureError, ValidationError
+from articraft.sdk.frames import WORLD, BodyFrame, JointFrame, _WorldEndpoint
 from articraft.sdk.mass import MassProperties
 from articraft.sdk.physics import BodyState, PhysicsScene
 
-Vec3: TypeAlias = tuple[float, float, float]
 Mat4: TypeAlias = np.ndarray
 Matrix4: TypeAlias = tuple[tuple[float, float, float, float], ...]
 
@@ -38,18 +38,6 @@ class JointAxis(StrEnum):
     @property
     def component(self) -> int:
         return {"X": 0, "Y": 1, "Z": 2}[self.value[-1]]
-
-
-@dataclass(frozen=True, slots=True)
-class JointFrame:
-    """A joint endpoint pose in its rigid body, in metres and radians."""
-
-    xyz: Vec3 = (0.0, 0.0, 0.0)
-    rpy: Vec3 = (0.0, 0.0, 0.0)
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "xyz", _as_vec3(self.xyz, field_name="joint frame xyz"))
-        object.__setattr__(self, "rpy", _as_vec3(self.rpy, field_name="joint frame rpy"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,17 +72,7 @@ class JointDOF:
         object.__setattr__(self, "limits", (lower, upper))
 
 
-@dataclass(frozen=True, slots=True)
-class _WorldEndpoint:
-    def __repr__(self) -> str:
-        return "WORLD"
-
-
-WORLD = _WorldEndpoint()
-"""The USD world endpoint. A joint may connect one rigid body to ``WORLD``."""
-
 JointEndpoint: TypeAlias = RigidBody | _WorldEndpoint
-JointEndpointRef: TypeAlias = RigidBodyRef | _WorldEndpoint
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -209,6 +187,22 @@ class PhysicsState:
             return np.asarray(self.body_poses[name], dtype=np.float64)
         except KeyError as exc:
             raise ValidationError(f"physics state has no pose for rigid body {name!r}") from exc
+
+    def frame_in(
+        self,
+        source: BodyFrame,
+        body: RigidBody | _WorldEndpoint = WORLD,
+    ) -> BodyFrame:
+        """Express one body-bound frame in another body's coordinates."""
+
+        source_world = self._body_matrix(source.body) @ _frame_matrix(source.frame)
+        local = np.linalg.inv(self._body_matrix(body)) @ source_world
+        return BodyFrame(body, _matrix_frame(local))
+
+    def _body_matrix(self, body: RigidBody | _WorldEndpoint) -> Mat4:
+        if body is WORLD:
+            return np.identity(4, dtype=np.float64)
+        return self.matrix(cast(RigidBody, body))
 
 
 @dataclass(frozen=True, slots=True)
@@ -440,25 +434,44 @@ class RigidBodyAssembly:
     def joint(
         self,
         name: str,
+        endpoint0: BodyFrame,
+        endpoint1: BodyFrame,
         *,
-        body0: JointEndpointRef,
-        frame0: JointFrame | None = None,
-        body1: JointEndpointRef,
-        frame1: JointFrame | None = None,
         dofs: Iterable[JointDOF] = (),
     ) -> Joint:
+        if not isinstance(endpoint0, BodyFrame) or not isinstance(endpoint1, BodyFrame):
+            raise ValidationError("joint endpoints must be body.at(...) or WORLD.at(...) frames")
         joint = Joint(
             name=name,
-            body0=self._endpoint(body0, field_name="body0"),
-            frame0=JointFrame() if frame0 is None else frame0,
-            body1=self._endpoint(body1, field_name="body1"),
-            frame1=JointFrame() if frame1 is None else frame1,
+            body0=self._endpoint(endpoint0.body, field_name="endpoint0"),
+            frame0=endpoint0.frame,
+            body1=self._endpoint(endpoint1.body, field_name="endpoint1"),
+            frame1=endpoint1.frame,
             dofs=tuple(dofs),
         )
         if any(existing.name == joint.name for existing in self.joints):
             raise ValidationError(f"duplicate joint name: {joint.name!r}")
         self.joints.append(joint)
         return joint
+
+    def frame_in(
+        self,
+        source: BodyFrame,
+        body: RigidBody | _WorldEndpoint = WORLD,
+    ) -> BodyFrame:
+        """Express a frame in another body at the assembly's reference state."""
+
+        if not isinstance(source, BodyFrame):
+            raise ValidationError("source must be a body.at(...) or WORLD.at(...) frame")
+        if source.body is not WORLD:
+            source_body = self.get_rigid_body(cast(RigidBody, source.body))
+            if source_body is not source.body:
+                raise ValidationError("source frame belongs to another assembly")
+        if body is not WORLD:
+            resolved_body = self.get_rigid_body(cast(RigidBody, body))
+            if resolved_body is not body:
+                raise ValidationError("target body belongs to another assembly")
+        return self.resolve().reference_state.frame_in(source, body)
 
     def articulation(
         self,
@@ -558,13 +571,16 @@ class RigidBodyAssembly:
     ) -> PhysicsState:
         return self.resolve().validate_state(PhysicsState(body_poses, dof_positions=dof_positions))
 
-    def _endpoint(self, endpoint: JointEndpointRef, *, field_name: str) -> JointEndpoint:
+    def _endpoint(self, endpoint: JointEndpoint, *, field_name: str) -> JointEndpoint:
         if endpoint is WORLD:
             return WORLD
         try:
-            return self.get_rigid_body(cast(RigidBodyRef, endpoint))
+            resolved = self.get_rigid_body(cast(RigidBodyRef, endpoint))
         except ValidationError as exc:
             raise ValidationError(f"unknown {field_name} rigid body: {endpoint!r}") from exc
+        if resolved is not endpoint:
+            raise ValidationError(f"{field_name} frame belongs to another assembly")
+        return resolved
 
     def _root(self, root: ArticulationRootRef) -> RigidBody | Joint:
         if isinstance(root, RigidBody):
@@ -1175,18 +1191,6 @@ def _body_name(value: RigidBodyRef, *, field_name: str) -> str:
     return _as_name(value if isinstance(value, str) else value.name, field_name=field_name)
 
 
-def _as_vec3(value: Sequence[float], *, field_name: str) -> Vec3:
-    if isinstance(value, (str, bytes)):
-        raise ValidationError(f"{field_name} must have 3 numeric values")
-    try:
-        values = tuple(float(component) for component in value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValidationError(f"{field_name} must have 3 numeric values") from exc
-    if len(values) != 3 or any(not math.isfinite(component) for component in values):
-        raise ValidationError(f"{field_name} must have 3 finite numeric values")
-    return cast(Vec3, values)
-
-
 def _finite(value: object, *, field_name: str) -> float:
     try:
         result = float(value)  # type: ignore[arg-type]
@@ -1225,3 +1229,11 @@ def _as_matrix4(value: object, *, field_name: str) -> Mat4:
 
 def _matrix_tuple(matrix: Mat4) -> Matrix4:
     return cast(Matrix4, tuple(tuple(float(value) for value in row) for row in matrix))
+
+
+def _matrix_frame(matrix: Mat4) -> JointFrame:
+    rpy = trimesh.transformations.euler_from_matrix(matrix, axes="sxyz")
+    return JointFrame(
+        xyz=(float(matrix[0, 3]), float(matrix[1, 3]), float(matrix[2, 3])),
+        rpy=(float(rpy[0]), float(rpy[1]), float(rpy[2])),
+    )

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -193,7 +193,12 @@ class PhysicsState:
         source: BodyFrame,
         body: RigidBody | _WorldEndpoint = WORLD,
     ) -> BodyFrame:
-        """Express one body-bound frame in another body's coordinates."""
+        """Express one body-bound frame in another body's coordinates.
+
+        A state stores poses by body *name*, so bodies here resolve by name
+        alone. ``RigidBodyAssembly.frame_in`` additionally checks identity;
+        prefer it while authoring.
+        """
 
         source_world = self._body_matrix(source.body) @ _frame_matrix(source.frame)
         local = np.linalg.inv(self._body_matrix(body)) @ source_world
@@ -471,7 +476,15 @@ class RigidBodyAssembly:
             resolved_body = self.get_rigid_body(cast(RigidBody, body))
             if resolved_body is not body:
                 raise ValidationError("target body belongs to another assembly")
-        return self.resolve().reference_state.frame_in(source, body)
+        try:
+            reference = self.resolve().reference_state
+        except ValidationError as exc:
+            raise ValidationError(
+                "frame_in reads the assembly's reference state, so the bodies and "
+                "joints that place both frames must be authored first; "
+                f"resolving failed: {exc}"
+            ) from exc
+        return reference.frame_in(source, body)
 
     def articulation(
         self,

--- a/src/articraft/sdk/bodies.py
+++ b/src/articraft/sdk/bodies.py
@@ -9,6 +9,7 @@ from build123d.topology import Shape
 from articraft.sdk._mesh.core import MeshGeometry
 from articraft.sdk._values import _as_identifier, _as_name
 from articraft.sdk.errors import ValidationError
+from articraft.sdk.frames import BodyFrame, FrameSource, _as_joint_frame
 from articraft.sdk.mass import MassProperties
 from articraft.sdk.materials import Color, Material, _as_color, _as_material
 from articraft.sdk.physics import BodyState
@@ -113,12 +114,17 @@ class RigidBody:
         )
         return shape
 
-    def get_shape(self, name: str) -> Geometry:
+    def shape(self, name: str) -> Geometry:
         shape_name = _as_name(name, field_name="shape name")
         entry = self._shapes.get(shape_name)
         if entry is None:
             raise ValidationError(f"unknown shape {shape_name!r} on rigid body {self.name!r}")
         return entry.geometry
+
+    def at(self, source: FrameSource = None) -> BodyFrame:
+        """Bind a local point or build123d geometric feature to this body."""
+
+        return BodyFrame(self, _as_joint_frame(source))
 
     def _iter_shapes(self) -> Iterator[_ShapeData]:
         return iter(self._shapes.values())

--- a/src/articraft/sdk/docs/common/00_quickstart.md
+++ b/src/articraft/sdk/docs/common/00_quickstart.md
@@ -41,28 +41,27 @@ say which axes are free: none is fixed, one rotational is a hinge, one linear is
 rotational is a ball. `model.articulation(...)` then names the tree the simulator solves.
 
 ```python
-from articraft.sdk import JointAxis, JointDOF, JointFrame
+from articraft.sdk import JointAxis, JointDOF
 
 
 lid = model.rigid_body("lid")
 lid.add(Box(0.8, 0.5, 0.02), name="panel")
 model.joint(
     "lid_hinge",
-    body0=body,
-    frame0=JointFrame(xyz=(0.0, 0.25, 0.02)),
-    body1=lid,
-    frame1=JointFrame(xyz=(0.0, 0.25, -0.01)),
+    body.at((0.0, 0.25, 0.02)),
+    lid.at((0.0, 0.25, -0.01)),
     # The hinge edge runs along X, so ROT_X; negative angles open the lid.
     dofs=(JointDOF(JointAxis.ROT_X, limits=(-1.9, 0.0)),),
 )
 model.articulation("main", root=body, joints=["lid_hinge"])
 ```
 
-Each frame is the joint *in that body's coordinates*; the two coincide at rest.
-Limits are radians or meters and must contain zero.
+`body.at(...)` accepts a point or build123d location, plane, axis, face, edge,
+or vertex. Prefer a feature over a copied coordinate. Endpoint frames coincide
+at rest. Limits use radians or meters and must contain zero.
 
-**Count the pivots.** A body pinned in two places takes two joints, which makes the mechanism a
-ring -- linkages, four-bars, grippers and scissors all are. Author every joint it has, then leave
+**Count the pivots.** A body pinned in two places takes two joints, making the mechanism a
+ring -- linkages, four-bars, grippers, scissors. Author every joint it has, then leave
 the ring-closing one out of the articulation. See `docs/sdk/common/35_joints.md`.
 
 Read only the reference that applies to the next piece of geometry:

--- a/src/articraft/sdk/docs/common/10_errors.md
+++ b/src/articraft/sdk/docs/common/10_errors.md
@@ -67,7 +67,7 @@ Lookup helpers raise `ValidationError` when a name cannot be resolved:
 
 ```python
 body = model.get_rigid_body("body")
-shape = body.get_shape("housing")
+shape = body.shape("housing")
 joint = model.get_joint("body_to_lid")
 ```
 

--- a/src/articraft/sdk/docs/common/20_core_types.md
+++ b/src/articraft/sdk/docs/common/20_core_types.md
@@ -22,9 +22,11 @@ Read [assemblies and rigid bodies](30_assembly.md) for structure and
 
 ## Physics graphs
 
-`JointFrame`, `JointDOF`, `JointAxis`, and `Joint` describe physical
-constraints. `Articulation` independently selects a reduced-coordinate tree.
-`PhysicsState` stores authoritative world-space body poses.
+`BodyFrame`, `JointFrame`, `JointDOF`, `JointAxis`, and `Joint` describe physical
+constraints. A `BodyFrame` binds local coordinates to a `RigidBody` or `WORLD`,
+so a joint endpoint cannot accidentally pair one body's frame with another body.
+`Articulation` independently selects a reduced-coordinate tree. `PhysicsState`
+stores authoritative world-space body poses.
 
 Read [joints and articulations](35_joints.md) for frames, D6 axes, loops, and
 kinematics.

--- a/src/articraft/sdk/docs/common/30_assembly.md
+++ b/src/articraft/sdk/docs/common/30_assembly.md
@@ -94,9 +94,13 @@ body.at(source=None) -> BodyFrame
 
 `body.at(...)` binds a local frame to that body. `source` may be a three-number
 point, `JointFrame`, build123d `Location`, `Plane`, `Axis`, `Face`, `Edge`,
-`Vertex`, or `Shape`, or a `MeshGeometry`. Faces use their center and normal;
-edges use their center and tangent; axes use their position and direction. The
-feature direction becomes frame-local Z. Whole shapes and meshes use their
+`Vertex`, or `Shape`, or a `MeshGeometry`. The feature direction becomes
+frame-local Z. Flat faces use their center and normal; rotational faces --
+cylinders, cones, spheres, tori -- use their axis of symmetry, positioned where
+the face sits along it, so a bore or pin surface anchors the hinge that spins
+about it. Straight and freeform edges use their midpoint and tangent; circles,
+arcs, and ellipses use the axis through their center, normal to their plane.
+Axes use their position and direction. Whole shapes and meshes use their
 bounding-box center. Build123d locations are converted from their exact
 transform, including their degree-based rotation convention.
 

--- a/src/articraft/sdk/docs/common/30_assembly.md
+++ b/src/articraft/sdk/docs/common/30_assembly.md
@@ -83,8 +83,43 @@ Overlapping shapes within one body are allowed and count as connected. Extend
 a protrusion's own end slightly into the surface it meets instead of adding a
 decorative patch to hide a gap.
 
-Use `body.get_shape(name)` to retrieve an authored shape and
+Use `body.shape(name)` to retrieve an authored shape and
 `model.get_rigid_body(body_or_name)` to retrieve a body.
+
+## Geometry-anchored frames
+
+```python
+body.at(source=None) -> BodyFrame
+```
+
+`body.at(...)` binds a local frame to that body. `source` may be a three-number
+point, `JointFrame`, build123d `Location`, `Plane`, `Axis`, `Face`, `Edge`,
+`Vertex`, or `Shape`, or a `MeshGeometry`. Faces use their center and normal;
+edges use their center and tangent; axes use their position and direction. The
+feature direction becomes frame-local Z. Whole shapes and meshes use their
+bounding-box center. Build123d locations are converted from their exact
+transform, including their degree-based rotation convention.
+
+Use build123d's ordinary topology queries instead of copying coordinates:
+
+```python
+from build123d import Axis
+
+top = housing_shape.faces().sort_by(Axis.Z)[-1]
+top_frame = housing_body.at(top)
+hinge_axis = lid_body.at(lid_shape.edges().filter_by(Axis.X)[0])
+```
+
+`WORLD.at(...)` creates the world endpoint. A raw `JointFrame` is the compact
+USD-local value used when exact numbers are already the clearest input.
+
+```python
+model.frame_in(source: BodyFrame, body: RigidBody | WORLD = WORLD) -> BodyFrame
+```
+
+`frame_in(...)` expresses the same reference-state frame in another body's
+coordinates. It is useful for deriving the second endpoint of a closure or
+fixed mount without repeating transform arithmetic.
 
 ## Resolution
 

--- a/src/articraft/sdk/docs/common/35_joints.md
+++ b/src/articraft/sdk/docs/common/35_joints.md
@@ -23,9 +23,11 @@ pitch, and yaw in radians.
 
 Normally create a `BodyFrame` with `body.at(...)` or `WORLD.at(...)`. This binds
 the local `JointFrame` to its endpoint before the joint is authored. Points and
-build123d locations, planes, axes, faces, edges, and vertices are accepted. An
-axis direction, face normal, or edge tangent becomes frame-local Z; use
-`ROT_Z` or `TRANS_Z` to move along that selected feature.
+build123d locations, planes, axes, faces, edges, and vertices are accepted. The
+feature's natural axis becomes frame-local Z: an axis direction, a flat face's
+normal, a straight edge's tangent -- and for round features, the axis of
+symmetry, so a cylindrical face or a hole's rim circle anchors the hinge that
+spins about it. Use `ROT_Z` or `TRANS_Z` to move along the selected feature.
 
 Rotating a frame expresses an axis that is not aligned with the body's axes. To
 hinge about a diagonal in the XY plane, yaw the frame and use its local X axis.

--- a/src/articraft/sdk/docs/common/35_joints.md
+++ b/src/articraft/sdk/docs/common/35_joints.md
@@ -5,7 +5,7 @@ tree selected from those joints. Keeping them separate is what lets one physical
 assembly contain closed loops.
 
 ```python
-from articraft.sdk import WORLD, JointAxis, JointDOF, JointFrame
+from articraft.sdk import WORLD, BodyFrame, JointAxis, JointDOF, JointFrame
 ```
 
 ## `JointFrame`
@@ -20,6 +20,12 @@ JointFrame(
 Every joint has one local frame per endpoint. The two frames coincide in the
 authored zero configuration. `xyz` is meters and `rpy` is extrinsic XYZ roll,
 pitch, and yaw in radians.
+
+Normally create a `BodyFrame` with `body.at(...)` or `WORLD.at(...)`. This binds
+the local `JointFrame` to its endpoint before the joint is authored. Points and
+build123d locations, planes, axes, faces, edges, and vertices are accepted. An
+axis direction, face normal, or edge tangent becomes frame-local Z; use
+`ROT_Z` or `TRANS_Z` to move along that selected feature.
 
 Rotating a frame expresses an axis that is not aligned with the body's axes. To
 hinge about a diagonal in the XY plane, yaw the frame and use its local X axis.
@@ -43,17 +49,15 @@ limits for an unbounded axis.
 ```python
 model.joint(
     name: str,
+    endpoint0: BodyFrame,
+    endpoint1: BodyFrame,
     *,
-    body0: RigidBody | str | WORLD,
-    frame0: JointFrame = JointFrame(),
-    body1: RigidBody | str | WORLD,
-    frame1: JointFrame = JointFrame(),
     dofs: Iterable[JointDOF] = (),
 ) -> Joint
 ```
 
-`body0` and `body1` are symmetric; neither means parent. One endpoint may be
-`WORLD`. A joint cannot connect `WORLD` to itself.
+The endpoints are symmetric; neither means parent. One may come from
+`WORLD.at(...)`. A joint cannot connect `WORLD` to itself.
 
 | DOFs | Physical joint |
 | --- | --- |
@@ -65,10 +69,8 @@ model.joint(
 ```python
 lid_hinge = model.joint(
     "lid_hinge",
-    body0=base,
-    frame0=JointFrame(xyz=(0.0, -0.04, 0.02)),
-    body1=lid,
-    frame1=JointFrame(xyz=(0.0, -0.04, 0.0)),
+    base.at((0.0, -0.04, 0.02)),
+    lid.at((0.0, -0.04, 0.0)),
     dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.57)),),
 )
 ```
@@ -107,30 +109,20 @@ swing = (JointDOF(JointAxis.ROT_Y, limits=(-1.5, 1.5)),)
 
 ground_crank = model.joint(
     "ground_crank",
-    body0=ground,
-    body1=crank,
+    ground.at(),
+    crank.at(),
     dofs=swing,
 )
 crank_coupler = model.joint(
     "crank_coupler",
-    body0=crank,
-    frame0=JointFrame(xyz=(CRANK_LENGTH, 0.0, 0.0)),
-    body1=coupler,
+    crank.at((CRANK_LENGTH, 0.0, 0.0)),
+    coupler.at(),
     dofs=swing,
 )
 ground_rocker = model.joint(
     "ground_rocker",
-    body0=ground,
-    frame0=JointFrame(xyz=(GROUND_SPAN, 0.0, 0.0)),
-    body1=rocker,
-    dofs=swing,
-)
-model.joint(
-    "closing_pin",
-    body0=coupler,
-    frame0=JointFrame(xyz=(COUPLER_LENGTH, 0.0, 0.0)),
-    body1=rocker,
-    frame1=JointFrame(xyz=(ROCKER_LENGTH, 0.0, 0.0)),
+    ground.at((GROUND_SPAN, 0.0, 0.0)),
+    rocker.at(),
     dofs=swing,
 )
 
@@ -138,6 +130,14 @@ model.articulation(
     "main",
     root=ground,
     joints=(ground_crank, crank_coupler, ground_rocker),
+)
+
+coupler_tip = coupler.at((COUPLER_LENGTH, 0.0, 0.0))
+model.joint(
+    "closing_pin",
+    coupler_tip,
+    model.frame_in(coupler_tip, rocker),
+    dofs=swing,
 )
 ```
 
@@ -149,6 +149,10 @@ Do not pose the closing joint directly; its value follows from the body poses.
 Supply a tree DOF to `forward_kinematics(...)` or `TestContext.pose(...)` and
 the graph solver determines unspecified coordinates needed to close the ring.
 An unreachable pose raises `LoopClosureError`.
+
+When the intended rocker pin is a build123d edge or axis, also check it with
+`TestContext.expect_coaxial(...)`. This proves that the exact derived closure
+still lands on the authored geometry feature.
 
 ```python
 state = model.resolve().forward_kinematics({"ground_crank.rotY": 0.4})

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -56,6 +56,28 @@ coordinates needed by closed loops. `ctx.state(physics_state)` instead uses a
 complete authoritative `PhysicsState`; use it for maximal-coordinate states,
 multiple articulation trees, or poses recorded by a physics backend.
 
+## Frame intent checks
+
+Frame checks consume the same `BodyFrame` values as `model.joint(...)` and use
+the current pose.
+
+```python
+ctx.expect_coincident(base.at(base_pin), arm.at(arm_pin))
+ctx.expect_coaxial(base.at(base_axis), arm.at(arm_axis), axis="z")
+```
+
+`expect_coincident(first, second, *, position_tol=1e-6, angle_tol=1e-6,
+name=None)` checks both origins and full orientations. `expect_coaxial(first,
+second, *, axis="z", position_tol=1e-6, angle_tol=1e-6, name=None)` checks that
+the selected local X, Y, or Z axes lie on the same infinite line; opposite
+directions count as aligned. Linear tolerances use meters and angular tolerances
+use radians.
+
+Use these for pins, bearings, hinge edges, and derived loop closures. Use
+`expect_contact(...)` for actual surface touching and `expect_within(...)` or
+`expect_gap(...)` for seating and support relationships; those are mesh checks,
+not frame checks.
+
 ## Reports
 
 ### `TestFailure`

--- a/src/articraft/sdk/docs/examples/closed_loop_linkage.py
+++ b/src/articraft/sdk/docs/examples/closed_loop_linkage.py
@@ -14,12 +14,15 @@ the parts still export, and then flap loose the moment anything touches them.
 
 from __future__ import annotations
 
+from build123d import Align, Axis, Box
+from build123d.topology import Shape
+
 from articraft.sdk import (
-    BoxGeometry,
+    BodyFrame,
     JointAxis,
     JointDOF,
-    JointFrame,
     Material,
+    RigidBody,
     RigidBodyAssembly,
     TestContext,
     TestReport,
@@ -30,15 +33,29 @@ RISE = 0.080  # crank length
 BAR = 0.010  # bar thickness
 
 
+def pin(body: RigidBody, direction: Axis, end: int) -> BodyFrame:
+    """Select a bar endpoint from its geometry and give the pin a Y axis."""
+
+    shape = body.shape("arm")
+    if not isinstance(shape, Shape):
+        raise TypeError("this example expects build123d bar geometry")
+    face = shape.faces().sort_by(direction)[end]
+    return body.at(Axis(face.center(), Axis.Y.direction))
+
+
 def build_object_model() -> RigidBodyAssembly:
     model = RigidBodyAssembly("four_bar_linkage")
 
     def bar(name: str, length: float, upright: bool = False):
         body = model.rigid_body(name)
         size = (BAR, BAR, length) if upright else (length, BAR, BAR)
-        offset = (0.0, 0.0, length / 2.0) if upright else (length / 2.0, 0.0, 0.0)
+        align = (
+            (Align.CENTER, Align.CENTER, Align.MIN)
+            if upright
+            else (Align.MIN, Align.CENTER, Align.CENTER)
+        )
         body.add(
-            BoxGeometry(size).translate(*offset),
+            Box(*size, align=align),
             name="arm",
             material=Material.STEEL if name == "ground" else Material.ALUMINUM,
         )
@@ -49,42 +66,27 @@ def build_object_model() -> RigidBodyAssembly:
     coupler = bar("coupler", SPAN)
     right_crank = bar("right_crank", RISE, upright=True)
 
-    swing = (JointDOF(JointAxis.ROT_Y, limits=(-0.6, 0.6)),)
+    # `pin(...)` aligns each selected physical axis with frame-local Z.
+    swing = (JointDOF(JointAxis.ROT_Z, limits=(-0.6, 0.6)),)
 
     # Around the ring. Each pair of frames coincides at rest, so the rectangle
     # closes exactly in the authored pose.
     model.joint(
         "ground_left",
-        body0=ground,
-        frame0=JointFrame(),
-        body1=left_crank,
-        frame1=JointFrame(),
+        pin(ground, Axis.X, 0),
+        pin(left_crank, Axis.Z, 0),
         dofs=swing,
     )
     model.joint(
         "left_coupler",
-        body0=left_crank,
-        frame0=JointFrame(xyz=(0.0, 0.0, RISE)),
-        body1=coupler,
-        frame1=JointFrame(),
+        pin(left_crank, Axis.Z, -1),
+        pin(coupler, Axis.X, 0),
         dofs=swing,
     )
     model.joint(
         "coupler_right",
-        body0=coupler,
-        frame0=JointFrame(xyz=(SPAN, 0.0, 0.0)),
-        body1=right_crank,
-        frame1=JointFrame(xyz=(0.0, 0.0, RISE)),
-        dofs=swing,
-    )
-    # The fourth joint closes the ring. It is real, and it is left out of the
-    # articulation below.
-    model.joint(
-        "ground_right",
-        body0=ground,
-        frame0=JointFrame(xyz=(SPAN, 0.0, 0.0)),
-        body1=right_crank,
-        frame1=JointFrame(),
+        pin(coupler, Axis.X, -1),
+        pin(right_crank, Axis.Z, -1),
         dofs=swing,
     )
 
@@ -92,6 +94,16 @@ def build_object_model() -> RigidBodyAssembly:
         "main",
         root=ground,
         joints=["ground_left", "left_coupler", "coupler_right"],
+    )
+
+    # Derive the second endpoint from the already-authored spanning tree. The
+    # closure is exact even when upstream dimensions or transforms change.
+    ground_right = pin(ground, Axis.X, -1)
+    model.joint(
+        "ground_right",
+        ground_right,
+        model.frame_in(ground_right, right_crank),
+        dofs=swing,
     )
     return model
 
@@ -114,4 +126,17 @@ def run_tests() -> TestReport:
         excluded == ["ground_right"],
         f"expected ground_right to be the loop closer, found {excluded}",
     )
+    ctx.expect_coincident(
+        pin(object_model.get_rigid_body("ground"), Axis.X, -1),
+        pin(object_model.get_rigid_body("right_crank"), Axis.Z, 0),
+        name="right_pin_lands_on_both_bars",
+    )
+    with ctx.pose(ground_left=0.3):
+        ctx.expect_coaxial(
+            pin(object_model.get_rigid_body("ground"), Axis.X, -1),
+            pin(object_model.get_rigid_body("right_crank"), Axis.Z, 0),
+            position_tol=1e-5,
+            angle_tol=1e-5,
+            name="right_pin_stays_coaxial_while_moving",
+        )
     return ctx.report()

--- a/src/articraft/sdk/docs/examples/mass_properties.py
+++ b/src/articraft/sdk/docs/examples/mass_properties.py
@@ -22,7 +22,6 @@ from articraft.sdk import (
     CylinderGeometry,
     JointAxis,
     JointDOF,
-    JointFrame,
     Material,
     RigidBodyAssembly,
     RoundedBoxGeometry,
@@ -86,19 +85,11 @@ def build_object_model() -> RigidBodyAssembly:
     )
 
     # No free axes is a fixed joint: the body is welded to its base.
-    model.joint(
-        "body_to_base",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.006)),
-        body1=body_part,
-        frame1=JointFrame(),
-    )
+    model.joint("body_to_base", base.at((0.0, 0.0, 0.006)), body_part.at())
     model.joint(
         "lid_hinge",
-        body0=body_part,
-        frame0=JointFrame(xyz=(0.0, HINGE_Y, HEIGHT)),
-        body1=lid,
-        frame1=JointFrame(),
+        body_part.at((0.0, HINGE_Y, HEIGHT)),
+        lid.at(),
         dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.9)),),
     )
     model.articulation("main", root=base, joints=["body_to_base", "lid_hinge"])

--- a/src/articraft/sdk/docs/examples/mixed_articulated_assembly.py
+++ b/src/articraft/sdk/docs/examples/mixed_articulated_assembly.py
@@ -6,7 +6,6 @@ from articraft.sdk import (
     BoxGeometry,
     JointAxis,
     JointDOF,
-    JointFrame,
     RigidBodyAssembly,
     TestContext,
     TestReport,
@@ -26,10 +25,8 @@ def build_object_model() -> RigidBodyAssembly:
     # The frames meet: on top of the plinth, and at the arm's foot.
     model.joint(
         "base_to_arm",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.05)),
-        body1=arm,
-        frame1=JointFrame(),
+        base.at((0.0, 0.0, 0.05)),
+        arm.at(),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(-0.8, 0.8)),),
     )
     model.articulation("main", root=base, joints=["base_to_arm"])

--- a/src/articraft/sdk/frames.py
+++ b/src/articraft/sdk/frames.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+import numpy as np
+import trimesh
+from build123d import Axis, Location, Plane, Vector
+from build123d.topology import Edge, Face, Shape, Vertex
+
+from articraft.sdk._mesh.core import MeshGeometry
+from articraft.sdk.errors import ValidationError
+
+if TYPE_CHECKING:
+    from articraft.sdk.bodies import RigidBody
+
+Vec3: TypeAlias = tuple[float, float, float]
+
+
+@dataclass(frozen=True, slots=True)
+class JointFrame:
+    """A USD joint frame local to one rigid-body endpoint, in metres and radians."""
+
+    xyz: Vec3 = (0.0, 0.0, 0.0)
+    rpy: Vec3 = (0.0, 0.0, 0.0)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "xyz", _vec3(self.xyz, field_name="joint frame xyz"))
+        object.__setattr__(self, "rpy", _vec3(self.rpy, field_name="joint frame rpy"))
+
+
+FrameSource: TypeAlias = (
+    JointFrame | Location | Plane | Axis | Vector | Shape | MeshGeometry | Sequence[float] | None
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _WorldEndpoint:
+    def at(self, source: FrameSource = None) -> BodyFrame:
+        """Bind a frame to the USD world endpoint."""
+
+        return BodyFrame(self, _as_joint_frame(source))
+
+    def __repr__(self) -> str:
+        return "WORLD"
+
+
+WORLD = _WorldEndpoint()
+"""The USD world endpoint. A joint may connect one rigid body to ``WORLD``."""
+
+
+@dataclass(frozen=True, slots=True)
+class BodyFrame:
+    """A joint frame bound to the rigid body whose coordinates it uses."""
+
+    body: RigidBody | _WorldEndpoint
+    frame: JointFrame = field(default_factory=JointFrame)
+
+    def __post_init__(self) -> None:
+        from articraft.sdk.bodies import RigidBody
+
+        if self.body is not WORLD and not isinstance(self.body, RigidBody):
+            raise ValidationError("body frame must belong to a RigidBody or WORLD")
+        if not isinstance(self.frame, JointFrame):
+            raise ValidationError("body frame must contain a JointFrame")
+
+    @property
+    def xyz(self) -> Vec3:
+        return self.frame.xyz
+
+    @property
+    def rpy(self) -> Vec3:
+        return self.frame.rpy
+
+
+def _as_joint_frame(source: FrameSource) -> JointFrame:
+    if source is None:
+        return JointFrame()
+    if isinstance(source, JointFrame):
+        return source
+    if isinstance(source, Plane | Axis):
+        return _location_frame(source.location)
+    if isinstance(source, Location):
+        return _location_frame(source)
+    if isinstance(source, Face):
+        return _location_frame(Plane(origin=source.center(), z_dir=source.normal_at()).location)
+    if isinstance(source, Edge):
+        return _location_frame(Axis(source.center(), source.tangent_at()).location)
+    if isinstance(source, Vertex):
+        return JointFrame(xyz=_vec3(source.center(), field_name="vertex center"))
+    if isinstance(source, Shape):
+        return JointFrame(
+            xyz=_vec3(source.bounding_box().center(), field_name="shape bounds center")
+        )
+    if isinstance(source, MeshGeometry):
+        source.validate()
+        if not source.vertices:
+            raise ValidationError("mesh frame source must contain vertices")
+        vertices = np.asarray(source.vertices, dtype=np.float64)
+        center = (vertices.min(axis=0) + vertices.max(axis=0)) * 0.5
+        return JointFrame(xyz=_vec3(center, field_name="mesh bounds center"))
+    return JointFrame(xyz=_vec3(source, field_name="body frame point"))
+
+
+def _location_frame(location: Location) -> JointFrame:
+    transform = location.wrapped.Transformation()
+    matrix = np.identity(4, dtype=np.float64)
+    for row in range(3):
+        for column in range(4):
+            matrix[row, column] = transform.Value(row + 1, column + 1)
+    orientation = trimesh.transformations.euler_from_matrix(matrix, axes="sxyz")
+    return JointFrame(
+        xyz=(float(matrix[0, 3]), float(matrix[1, 3]), float(matrix[2, 3])),
+        rpy=(
+            float(orientation[0]),
+            float(orientation[1]),
+            float(orientation[2]),
+        ),
+    )
+
+
+def _vec3(value: Iterable[float], *, field_name: str) -> Vec3:
+    if isinstance(value, (str, bytes)):
+        raise ValidationError(f"{field_name} must have 3 numeric values")
+    try:
+        values = tuple(float(component) for component in value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValidationError(f"{field_name} must have 3 numeric values") from exc
+    if len(values) != 3 or any(not math.isfinite(component) for component in values):
+        raise ValidationError(f"{field_name} must have 3 finite numeric values")
+    return cast(Vec3, values)
+
+
+__all__ = ["WORLD", "BodyFrame", "FrameSource", "JointFrame"]

--- a/src/articraft/sdk/frames.py
+++ b/src/articraft/sdk/frames.py
@@ -85,9 +85,9 @@ def _as_joint_frame(source: FrameSource) -> JointFrame:
     if isinstance(source, Location):
         return _location_frame(source)
     if isinstance(source, Face):
-        return _location_frame(Plane(origin=source.center(), z_dir=source.normal_at()).location)
+        return _location_frame(_face_location(source))
     if isinstance(source, Edge):
-        return _location_frame(Axis(source.center(), source.tangent_at()).location)
+        return _location_frame(_edge_location(source))
     if isinstance(source, Vertex):
         return JointFrame(xyz=_vec3(source.center(), field_name="vertex center"))
     if isinstance(source, Shape):
@@ -102,6 +102,39 @@ def _as_joint_frame(source: FrameSource) -> JointFrame:
         center = (vertices.min(axis=0) + vertices.max(axis=0)) * 0.5
         return JointFrame(xyz=_vec3(center, field_name="mesh bounds center"))
     return JointFrame(xyz=_vec3(source, field_name="body frame point"))
+
+
+def _face_location(face: Face) -> Location:
+    """The frame a face means when it anchors a joint.
+
+    A rotational surface -- a bore, a pin, a cone seat -- means its axis of
+    symmetry, not the outward normal at some surface point: a hinge anchored
+    to a cylindrical face should spin about the cylinder, so local Z becomes
+    the rotation axis, positioned where the face sits along it. A flat face
+    keeps its center and normal.
+    """
+
+    rotation_axis = face.axis_of_rotation
+    if rotation_axis is None:
+        return Plane(origin=face.center(), z_dir=face.normal_at()).location
+    direction = Vector(rotation_axis.direction).normalized()
+    offset = Vector(face.center()) - Vector(rotation_axis.position)
+    origin = Vector(rotation_axis.position) + direction * offset.dot(direction)
+    return Axis(origin, direction).location
+
+
+def _edge_location(edge: Edge) -> Location:
+    """The frame an edge means when it anchors a joint.
+
+    A circle or an arc -- a hole rim, a fillet edge -- means the axis through
+    its center, normal to its plane; the on-curve tangent it would otherwise
+    yield is never the hinge a rim is selected for. A straight or freeform
+    edge keeps its midpoint and tangent.
+    """
+
+    if str(edge.geom_type).rsplit(".", 1)[-1] in {"CIRCLE", "ELLIPSE"}:
+        return Axis(edge.arc_center, edge.normal()).location
+    return Axis(edge.center(), edge.tangent_at()).location
 
 
 def _location_frame(location: Location) -> JointFrame:

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -31,9 +31,11 @@ from articraft.sdk.assembly import (
     JointDOF,
     PhysicsState,
     RigidBodyAssembly,
+    _frame_matrix,
 )
 from articraft.sdk.bodies import RigidBody, RigidBodyRef
 from articraft.sdk.errors import LoopClosureError, ValidationError
+from articraft.sdk.frames import BodyFrame
 from articraft.sdk.mass import resolve_mass
 from articraft.sdk.materials import LIBRARY
 
@@ -299,8 +301,8 @@ class TestContext:
         self.model.get_rigid_body(part_b_name)
         shape_a = str(shape_a).strip()
         shape_b = str(shape_b).strip()
-        self.model.get_rigid_body(part_a_name).get_shape(shape_a)
-        self.model.get_rigid_body(part_b_name).get_shape(shape_b)
+        self.model.get_rigid_body(part_a_name).shape(shape_a)
+        self.model.get_rigid_body(part_b_name).shape(shape_b)
         reason = str(reason or "").strip()
         if not reason:
             raise ValueError("allow_overlap requires a non-empty reason")
@@ -335,7 +337,7 @@ class TestContext:
         part_name = _part_name(part, field_name="part")
         model_part = self.model.get_rigid_body(part_name)
         shape_name = str(shape).strip()
-        model_part.get_shape(shape_name)
+        model_part.shape(shape_name)
         if isinstance(issues, (str, MeshHealthIssue)):
             issue_values = (MeshHealthIssue(issues),)
         else:
@@ -452,6 +454,67 @@ class TestContext:
             raise ValidationError(f"unknown part: {part_name!r}")
         world = transform @ np.asarray([*local, 1.0], dtype=np.float64)
         return (float(world[0]), float(world[1]), float(world[2]))
+
+    def expect_coincident(
+        self,
+        first: BodyFrame,
+        second: BodyFrame,
+        *,
+        position_tol: float = 1e-6,
+        angle_tol: float = 1e-6,
+        name: str | None = None,
+    ) -> bool:
+        """Check that two authored frames occupy the same world transform."""
+
+        first_world = self._world_frame_matrix(first, field_name="first")
+        second_world = self._world_frame_matrix(second, field_name="second")
+        position_tol = _non_negative(position_tol, "position_tol")
+        angle_tol = _non_negative(angle_tol, "angle_tol")
+        position_error = float(np.linalg.norm(first_world[:3, 3] - second_world[:3, 3]))
+        angle_error = _rotation_angle(first_world[:3, :3].T @ second_world[:3, :3])
+        check_name = name or (
+            f"expect_coincident({_body_frame_name(first)},{_body_frame_name(second)})"
+        )
+        return self._record(
+            check_name,
+            position_error <= position_tol and angle_error <= angle_tol,
+            f"position_error={position_error:.9g} position_tol={position_tol:.9g} "
+            f"angle_error={angle_error:.9g} angle_tol={angle_tol:.9g}",
+        )
+
+    def expect_coaxial(
+        self,
+        first: BodyFrame,
+        second: BodyFrame,
+        *,
+        axis: str = "z",
+        position_tol: float = 1e-6,
+        angle_tol: float = 1e-6,
+        name: str | None = None,
+    ) -> bool:
+        """Check that the chosen local axes lie on the same infinite world line."""
+
+        first_world = self._world_frame_matrix(first, field_name="first")
+        second_world = self._world_frame_matrix(second, field_name="second")
+        axis_name = _axis_name(axis)
+        axis_index = _axis_index(axis_name)
+        position_tol = _non_negative(position_tol, "position_tol")
+        angle_tol = _non_negative(angle_tol, "angle_tol")
+        first_axis = first_world[:3, axis_index]
+        second_axis = second_world[:3, axis_index]
+        alignment = float(np.clip(abs(first_axis @ second_axis), 0.0, 1.0))
+        angle_error = math.acos(alignment)
+        offset = second_world[:3, 3] - first_world[:3, 3]
+        radial_error = float(np.linalg.norm(offset - (offset @ first_axis) * first_axis))
+        check_name = name or (
+            f"expect_coaxial({_body_frame_name(first)},{_body_frame_name(second)},axis={axis_name})"
+        )
+        return self._record(
+            check_name,
+            radial_error <= position_tol and angle_error <= angle_tol,
+            f"radial_error={radial_error:.9g} position_tol={position_tol:.9g} "
+            f"angle_error={angle_error:.9g} angle_tol={angle_tol:.9g}",
+        )
 
     def measure_geometry(
         self,
@@ -1462,7 +1525,7 @@ class TestContext:
         if selected_part is not None:
             self.model.get_rigid_body(selected_part)
             if shape is not None:
-                self.model.get_rigid_body(selected_part).get_shape(shape)
+                self.model.get_rigid_body(selected_part).shape(shape)
         if not meshes:
             raise ValidationError("geometry selector did not match any shapes")
         return meshes
@@ -1487,7 +1550,7 @@ class TestContext:
         if selected_part is not None:
             self.model.get_rigid_body(selected_part)
             if shape is not None:
-                self.model.get_rigid_body(selected_part).get_shape(shape)
+                self.model.get_rigid_body(selected_part).shape(shape)
         if not geometries:
             raise ValidationError("geometry selector did not match any shapes")
         return geometries
@@ -1547,6 +1610,19 @@ class TestContext:
             self._kernel_cache = MeshCollisionKernel(self.model, mesh_tolerance=self.mesh_tolerance)
         return self._kernel_cache
 
+    def _world_frame_matrix(self, frame: BodyFrame, *, field_name: str) -> np.ndarray:
+        if not isinstance(frame, BodyFrame):
+            raise ValidationError(f"{field_name} must be a body.at(...) or WORLD.at(...) frame")
+        if frame.body is WORLD:
+            body_matrix = np.identity(4, dtype=np.float64)
+        else:
+            body = self.model.get_rigid_body(cast(RigidBody, frame.body))
+            if body is not frame.body:
+                raise ValidationError(f"{field_name} frame belongs to another assembly")
+            transforms = self._kernel().world_transforms(self._placement())
+            body_matrix = transforms[body.name]
+        return body_matrix @ _frame_matrix(frame.frame)
+
     def _placement(self) -> dict[str, float] | PhysicsState:
         return self._state if self._state is not None else self._pose
 
@@ -1563,6 +1639,15 @@ def _plain_name(value: object, field_name: str) -> str:
     if not name:
         raise ValidationError(f"{field_name} must be non-empty")
     return name
+
+
+def _body_frame_name(frame: BodyFrame) -> str:
+    return "WORLD" if frame.body is WORLD else cast(RigidBody, frame.body).name
+
+
+def _rotation_angle(rotation: np.ndarray) -> float:
+    cosine = float(np.clip((np.trace(rotation) - 1.0) * 0.5, -1.0, 1.0))
+    return math.acos(cosine)
 
 
 def _artifact_kind(path: Path) -> str:

--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -57,10 +57,8 @@ def build_object_model() -> RigidBodyAssembly:
     pin.add(Box(0.05, 0.05, 0.2), name="body")
     model.joint(
         "press_fit_pin",
-        body0=base,
-        frame0=JointFrame(),
-        body1=pin,
-        frame1=JointFrame(),
+        base.at(),
+        pin.at(),
     )
     return model
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -412,14 +412,14 @@ def test_exec_command_renders_public_sdk_previews_before_compile(tmp_path) -> No
 )
 
 object_model = RigidBodyAssembly("slider")
-object_model.rigid_body("base").add(BoxGeometry((0.5, 0.5, 0.5)), name="base")
-object_model.rigid_body("slider").add(BoxGeometry((0.2, 0.2, 0.2)), name="block")
+base = object_model.rigid_body("base")
+base.add(BoxGeometry((0.5, 0.5, 0.5)), name="base")
+slider = object_model.rigid_body("slider")
+slider.add(BoxGeometry((0.2, 0.2, 0.2)), name="block")
 object_model.joint(
     "slide",
-    body0="base",
-    frame0=JointFrame(),
-    body1="slider",
-    frame1=JointFrame(),
+    base.at(),
+    slider.at(),
     dofs=(JointDOF(JointAxis.TRANS_X, limits=(0.0, 1.0)),),
 )
 

--- a/tests/test_articulation_motion.py
+++ b/tests/test_articulation_motion.py
@@ -28,10 +28,8 @@ def _hinged_lid(pivot: tuple[float, float, float]) -> RigidBodyAssembly:
     lid.add(BoxGeometry((0.10, 0.10, 0.02)).translate(*offset), name="lid_slab")
     model.joint(
         "lid_hinge",
-        body0=base,
-        frame0=JointFrame(xyz=pivot),
-        body1=lid,
-        frame1=JointFrame(),
+        base.at(JointFrame(xyz=pivot)),
+        lid.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.2)),),
     )
     return model
@@ -65,10 +63,8 @@ def test_separation_check_ignores_prismatic_liftoff() -> None:
     body.add(BoxGeometry((0.08, 0.08, 0.10)).translate(0.0, 0.0, 0.06), name="body_box")
     model.joint(
         "lift",
-        body0=base,
-        frame0=JointFrame(),
-        body1=body,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        body.at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_Z, limits=(0.0, 0.10)),),
     )
     ctx = TestContext(model)
@@ -93,18 +89,14 @@ def test_a_loop_closing_joint_is_left_out_of_the_separation_sweep() -> None:
     swing = (JointDOF(JointAxis.ROT_X, limits=(-1.0, 1.0)),)
     model.joint(
         "left_pivot",
-        body0=body,
-        frame0=JointFrame(xyz=(-0.05, 0.0, 0.05)),
-        body1=handle,
-        frame1=JointFrame(xyz=(-0.05, 0.0, 0.05)),
+        body.at(JointFrame(xyz=(-0.05, 0.0, 0.05))),
+        handle.at(JointFrame(xyz=(-0.05, 0.0, 0.05))),
         dofs=swing,
     )
     model.joint(
         "right_pivot",
-        body0=body,
-        frame0=JointFrame(xyz=(0.05, 0.0, 0.05)),
-        body1=handle,
-        frame1=JointFrame(xyz=(0.05, 0.0, 0.05)),
+        body.at(JointFrame(xyz=(0.05, 0.0, 0.05))),
+        handle.at(JointFrame(xyz=(0.05, 0.0, 0.05))),
         dofs=swing,
     )
     model.articulation("main", root=body, joints=["left_pivot"])

--- a/tests/test_collision_shapes.py
+++ b/tests/test_collision_shapes.py
@@ -115,10 +115,8 @@ def test_exported_stage_passes_openusd_physics_validation(tmp_path: Path) -> Non
     )
     model.joint(
         "pivot",
-        body0=base,
-        frame0=JointFrame(),
-        body1=arm,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        arm.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.5)),),
     )
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -296,10 +296,8 @@ base = object_model.rigid_body("base"); base.add(Box(1, 1, 1), name="body")
 child = object_model.rigid_body("child"); child.add(Box(1, 1, 1), name="body")
 object_model.joint(
     "mount",
-    body0=base,
-    frame0=JointFrame(),
-    body1=child,
-    frame1=JointFrame(),
+    base.at(),
+    child.at(),
     dofs=(),
 )
 
@@ -399,10 +397,8 @@ shaft = object_model.rigid_body("shaft"); shaft.add(Box(1, 1, 1), name="steel")
 hub = object_model.rigid_body("hub"); hub.add(Box(1, 1, 1), name="liner")
 object_model.joint(
     "mount",
-    body0=shaft,
-    frame0=JointFrame(),
-    body1=hub,
-    frame1=JointFrame(),
+    shaft.at(),
+    hub.at(),
     dofs=(),
 )
 

--- a/tests/test_evidence_sdk.py
+++ b/tests/test_evidence_sdk.py
@@ -133,10 +133,8 @@ def _slider_model() -> RigidBodyAssembly:
     model.rigid_body("slider").add(BoxGeometry((0.2, 0.2, 0.2)), name="block")
     model.joint(
         "slide",
-        body0="base",
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1="slider",
-        frame1=JointFrame(),
+        model.get_rigid_body("base").at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        model.get_rigid_body("slider").at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=(0.0, 1.0)),),
     )
     return model

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -156,3 +156,42 @@ def test_context_checks_frame_coincidence_and_axis_alignment() -> None:
     failures = context.report().failures
     assert "position_error=1" in failures[0].details
     assert "radial_error=1" in failures[1].details
+
+
+def test_round_features_anchor_their_axis_of_symmetry() -> None:
+    """A bore, pin, or rim means the axis it spins about, not a surface point."""
+
+    import math
+
+    from build123d import Cylinder, Rot
+
+    model = RigidBodyAssembly("round_anchors")
+    body = model.rigid_body("body")
+    pin = Pos(1.0, 2.0, 3.0) * Rot(0.0, 30.0, 0.0) * Cylinder(0.01, 0.05)
+    body.add(pin, name="pin")
+    direction = np.array([math.sin(math.radians(30.0)), 0.0, math.cos(math.radians(30.0))])
+
+    lateral = next(f for f in pin.faces() if "CYLINDER" in str(f.geom_type).upper())
+    frame = _frame_matrix(body.at(lateral).frame)
+    assert abs(abs(float(frame[:3, 2] @ direction)) - 1.0) < 1e-9
+    radial = (frame[:3, 3] - (1.0, 2.0, 3.0)) - (
+        (frame[:3, 3] - (1.0, 2.0, 3.0)) @ direction
+    ) * direction
+    assert np.linalg.norm(radial) < 1e-9
+
+    top = pin.faces().sort_by(Axis((1.0, 2.0, 3.0), tuple(direction)))[-1]
+    rim = top.edges()[0]
+    rim_frame = _frame_matrix(body.at(rim).frame)
+    assert abs(abs(float(rim_frame[:3, 2] @ direction)) - 1.0) < 1e-9
+    assert np.allclose(rim_frame[:3, 3], np.array([1.0, 2.0, 3.0]) + 0.025 * direction)
+
+
+def test_frame_in_before_the_graph_connects_names_the_precondition() -> None:
+    model = RigidBodyAssembly("early")
+    first = model.rigid_body("first")
+    first.add(Box(1.0, 1.0, 1.0), name="shape")
+    second = model.rigid_body("second")
+    second.add(Box(1.0, 1.0, 1.0), name="shape")
+
+    with pytest.raises(ValidationError, match="authored first"):
+        model.frame_in(first.at(), second)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from build123d import Axis, Box, Location, Plane, Pos
+
+from articraft.sdk import (
+    WORLD,
+    BodyFrame,
+    BoxGeometry,
+    JointAxis,
+    JointDOF,
+    JointFrame,
+    MeshGeometry,
+    RigidBody,
+    RigidBodyAssembly,
+    TestContext,
+)
+from articraft.sdk.assembly import _frame_matrix
+from articraft.sdk.errors import ValidationError
+
+
+def test_body_at_accepts_points_and_build123d_features() -> None:
+    model = RigidBodyAssembly("anchors")
+    body = model.rigid_body("body")
+    shape = Pos(1.0, 2.0, 3.0) * Box(2.0, 4.0, 6.0)
+    body.add(shape, name="box")
+    top = shape.faces().sort_by(Axis.Z)[-1]
+
+    assert body.at().frame == JointFrame()
+    assert body.at((1.0, 2.0, 3.0)).xyz == (1.0, 2.0, 3.0)
+    assert body.at(top.center()).xyz == pytest.approx((1.0, 2.0, 6.0))
+    assert body.at(body.shape("box")).xyz == pytest.approx((1.0, 2.0, 3.0))
+    assert body.at(top).xyz == pytest.approx((1.0, 2.0, 6.0))
+    assert np.allclose(_frame_matrix(body.at(top).frame)[:3, 2], (0.0, 0.0, 1.0))
+
+    edge = top.edges().filter_by(Axis.X)[0]
+    assert np.allclose(
+        abs(_frame_matrix(body.at(edge).frame)[:3, 2]),
+        (1.0, 0.0, 0.0),
+    )
+
+
+def test_body_at_accepts_native_locations_axes_planes_and_meshes() -> None:
+    model = RigidBodyAssembly("native_frames")
+    body = model.rigid_body("body")
+    body.add(Box(1.0, 1.0, 1.0), name="box")
+
+    location = Location((1.0, 2.0, 3.0), (10.0, 20.0, 30.0))
+    located = body.at(location)
+    assert located.xyz == (1.0, 2.0, 3.0)
+    transform = location.wrapped.Transformation()
+    expected = np.identity(4)
+    for row in range(3):
+        for column in range(4):
+            expected[row, column] = transform.Value(row + 1, column + 1)
+    assert np.allclose(_frame_matrix(located.frame), expected)
+    assert np.allclose(
+        _frame_matrix(body.at(Axis((1.0, 2.0, 3.0), (1.0, 0.0, 0.0))).frame)[:3, 2],
+        (1.0, 0.0, 0.0),
+    )
+    assert body.at(Plane(origin=(4.0, 5.0, 6.0))).xyz == (4.0, 5.0, 6.0)
+
+    mesh = BoxGeometry((2.0, 4.0, 6.0)).translate(3.0, 4.0, 5.0)
+    assert body.at(mesh).xyz == pytest.approx((3.0, 4.0, 5.0))
+    with pytest.raises(ValidationError, match="must contain vertices"):
+        body.at(MeshGeometry())
+
+
+def test_frame_in_derives_an_exact_closure_frame_without_coordinate_arithmetic() -> None:
+    model = RigidBodyAssembly("derived_closure")
+    base = model.rigid_body("base")
+    base.add(Box(1.0, 1.0, 1.0), name="shape")
+    link = model.rigid_body("link")
+    link.add(Box(1.0, 1.0, 1.0), name="shape")
+    hinge = model.joint(
+        "hinge",
+        base.at((2.0, 0.0, 0.0)),
+        link.at(),
+        dofs=(JointDOF(JointAxis.ROT_Z),),
+    )
+    model.articulation("main", root=base, joints=(hinge,))
+
+    link_tip = link.at((1.0, 0.0, 0.0))
+    same_frame_on_base = model.frame_in(link_tip, base)
+    same_frame_in_world = model.frame_in(link_tip)
+
+    assert isinstance(same_frame_on_base, BodyFrame)
+    assert same_frame_on_base.body is base
+    assert same_frame_on_base.xyz == pytest.approx((3.0, 0.0, 0.0))
+    assert same_frame_in_world.body is WORLD
+    assert same_frame_in_world.xyz == pytest.approx((3.0, 0.0, 0.0))
+
+    model.joint(
+        "closure",
+        same_frame_on_base,
+        link_tip,
+        dofs=(JointDOF(JointAxis.ROT_Z),),
+    )
+    resolved = model.resolve()
+    assert resolved.has_closed_loops
+    assert resolved.get_joint("closure").exclude_from_articulation
+
+    foreign_base = RigidBody("base")
+    foreign_base.add(Box(1.0, 1.0, 1.0), name="shape")
+    with pytest.raises(ValidationError, match="source frame belongs"):
+        model.frame_in(foreign_base.at())
+    with pytest.raises(ValidationError, match="target body belongs"):
+        model.frame_in(link_tip, foreign_base)
+
+
+def test_joint_endpoints_are_body_bound_frames() -> None:
+    model = RigidBodyAssembly("bound")
+    first = model.rigid_body("first")
+    first.add(Box(1.0, 1.0, 1.0), name="shape")
+    second = model.rigid_body("second")
+    second.add(Box(1.0, 1.0, 1.0), name="shape")
+
+    joint = model.joint("fixed", first.at(), second.at())
+    assert joint.body0 is first
+    assert joint.body1 is second
+
+    with pytest.raises(ValidationError, match=r"body\.at"):
+        model.joint(
+            "unbound",
+            JointFrame(),  # pyright: ignore[reportArgumentType]
+            second.at(),
+        )
+
+    with pytest.raises(ValidationError, match="RigidBody or WORLD"):
+        BodyFrame("first")  # pyright: ignore[reportArgumentType]
+
+    same_named_foreign = RigidBody("first")
+    same_named_foreign.add(Box(1.0, 1.0, 1.0), name="shape")
+    with pytest.raises(ValidationError, match="belongs to another assembly"):
+        model.joint("foreign", same_named_foreign.at(), second.at())
+
+
+def test_context_checks_frame_coincidence_and_axis_alignment() -> None:
+    model = RigidBodyAssembly("frame_checks")
+    base = model.rigid_body("base")
+    base.add(Box(1.0, 1.0, 1.0), name="shape")
+    link = model.rigid_body("link")
+    link.add(Box(1.0, 1.0, 1.0), name="shape")
+    model.joint("mount", base.at((1.0, 0.0, 0.0)), link.at())
+    context = TestContext(model)
+
+    assert context.expect_coincident(base.at((1.0, 0.0, 0.0)), link.at())
+    assert context.expect_coaxial(
+        base.at(Axis((1.0, 0.0, 0.0), (0.0, 0.0, 1.0))),
+        link.at(Axis((0.0, 0.0, 0.0), (0.0, 0.0, -1.0))),
+    )
+    assert not context.expect_coincident(base.at(), link.at())
+    assert not context.expect_coaxial(base.at(), link.at(), axis="z")
+
+    failures = context.report().failures
+    assert "position_error=1" in failures[0].details
+    assert "radial_error=1" in failures[1].details

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -36,10 +36,8 @@ def _model() -> RigidBodyAssembly:
     lid.add(BoxGeometry([0.2, 0.2, 0.02]), name="cap", color=(0.2, 0.3, 0.8))
     model.joint(
         "hinge",
-        body0=base,
-        frame0=JointFrame(),
-        body1=lid,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        lid.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Z, limits=(0.0, 1.5)),),
     )
     return model

--- a/tests/test_rigid_body_assembly.py
+++ b/tests/test_rigid_body_assembly.py
@@ -34,34 +34,30 @@ def four_bar(*, second_closure: bool = False) -> RigidBodyAssembly:
     coupler = add_body(assembly, "coupler")
     rocker = add_body(assembly, "rocker")
     revolute = (JointDOF(JointAxis.ROT_Z),)
-    ground_crank = assembly.joint("ground_crank", body0=ground, body1=crank, dofs=revolute)
+    ground_crank = assembly.joint("ground_crank", ground.at(), crank.at(), dofs=revolute)
     crank_coupler = assembly.joint(
         "crank_coupler",
-        body0=crank,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=coupler,
+        crank.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        coupler.at(),
         dofs=revolute,
     )
     coupler_rocker = assembly.joint(
         "coupler_rocker",
-        body0=coupler,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=rocker,
+        coupler.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        rocker.at(),
         dofs=revolute,
     )
     assembly.joint(
         "rocker_ground",
-        body0=rocker,
-        body1=ground,
-        frame1=JointFrame(xyz=(2.0, 0.0, 0.0)),
+        rocker.at(),
+        ground.at(JointFrame(xyz=(2.0, 0.0, 0.0))),
         dofs=revolute,
     )
     if second_closure:
         assembly.joint(
             "crank_rocker",
-            body0=crank,
-            frame0=JointFrame(xyz=(2.0, 0.0, 0.0)),
-            body1=rocker,
+            crank.at(JointFrame(xyz=(2.0, 0.0, 0.0))),
+            rocker.at(),
             dofs=revolute,
         )
     assembly.articulation(
@@ -78,8 +74,8 @@ def test_joint_dofs_are_usd_d6_axes_and_unlisted_axes_are_locked() -> None:
     moving = add_body(assembly, "moving")
     joint = assembly.joint(
         "motion",
-        body0=base,
-        body1=moving,
+        base.at(),
+        moving.at(),
         dofs=(
             JointDOF("rotZ", limits=(-1.0, 1.0)),
             JointDOF(JointAxis.TRANS_X, limits=(-0.2, 0.3)),
@@ -105,8 +101,8 @@ def test_joint_limits_must_include_the_frame_defined_zero_configuration() -> Non
         b = add_body(assembly, "b")
         assembly.joint(
             "joint",
-            body0=a,
-            body1=b,
+            a.at(),
+            b.at(),
             dofs=(JointDOF("rotX"), JointDOF("rotX")),
         )
 
@@ -118,17 +114,11 @@ def test_ordinary_tree_articulation_is_inferred_and_supports_forward_kinematics(
     tip = add_body(assembly, "tip")
     hinge = assembly.joint(
         "hinge",
-        body0=base,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=link,
+        base.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        link.at(),
         dofs=(JointDOF(JointAxis.ROT_Z, limits=(-math.pi, math.pi)),),
     )
-    assembly.joint(
-        "tip_mount",
-        body0=link,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=tip,
-    )
+    assembly.joint("tip_mount", link.at(JointFrame(xyz=(1.0, 0.0, 0.0))), tip.at())
     assembly.articulation("arm", root=base)
 
     resolved = assembly.resolve()
@@ -203,13 +193,8 @@ def test_world_joint_is_the_fixed_articulation_root() -> None:
     assembly = RigidBodyAssembly("mounted")
     base = add_body(assembly, "base")
     link = add_body(assembly, "link")
-    mount = assembly.joint(
-        "mount",
-        body0=WORLD,
-        frame0=JointFrame(xyz=(1.0, 2.0, 3.0)),
-        body1=base,
-    )
-    hinge = assembly.joint("hinge", body0=base, body1=link, dofs=(JointDOF(JointAxis.ROT_Y),))
+    mount = assembly.joint("mount", WORLD.at(JointFrame(xyz=(1.0, 2.0, 3.0))), base.at())
+    hinge = assembly.joint("hinge", base.at(), link.at(), dofs=(JointDOF(JointAxis.ROT_Y),))
     assembly.articulation("fixed", root=mount, joints=(mount, hinge))
 
     resolved = assembly.resolve()
@@ -224,9 +209,9 @@ def test_multiple_articulations_do_not_share_bodies_and_cross_joints_are_exclude
     b = add_body(assembly, "b")
     c = add_body(assembly, "c")
     d = add_body(assembly, "d")
-    ab = assembly.joint("ab", body0=a, body1=b)
-    cd = assembly.joint("cd", body0=c, body1=d)
-    assembly.joint("bridge", body0=b, body1=c)
+    ab = assembly.joint("ab", a.at(), b.at())
+    cd = assembly.joint("cd", c.at(), d.at())
+    assembly.joint("bridge", b.at(), c.at())
     assembly.articulation("left", root=a, joints=(ab,))
     assembly.articulation("right", root=c, joints=(cd,))
 
@@ -242,7 +227,7 @@ def test_maximal_coordinate_assembly_needs_no_articulation() -> None:
     assembly = RigidBodyAssembly("maximal")
     a = add_body(assembly, "a")
     b = add_body(assembly, "b")
-    assembly.joint("constraint", body0=a, body1=b, dofs=(JointDOF(JointAxis.ROT_X),))
+    assembly.joint("constraint", a.at(), b.at(), dofs=(JointDOF(JointAxis.ROT_X),))
 
     resolved = assembly.resolve()
 
@@ -261,8 +246,8 @@ def test_invalid_graph_references_and_disconnected_bodies_fail() -> None:
     local = add_body(assembly, "local")
     foreign = RigidBody("foreign")
     foreign.add(Box(0.1, 0.1, 0.1), name="shape")
-    with pytest.raises(ValidationError, match="unknown body1"):
-        assembly.joint("bad", body0=local, body1=foreign)
+    with pytest.raises(ValidationError, match="unknown endpoint1"):
+        assembly.joint("bad", local.at(), foreign.at())
 
 
 def test_articulation_selection_must_be_a_rooted_tree() -> None:
@@ -275,7 +260,7 @@ def test_articulation_selection_must_be_a_rooted_tree() -> None:
 
     world_assembly = RigidBodyAssembly("wrong_root")
     body = add_body(world_assembly, "body")
-    mount = world_assembly.joint("mount", body0=WORLD, body1=body)
+    mount = world_assembly.joint("mount", WORLD.at(), body.at())
     world_assembly.articulation("bad", root=body, joints=(mount,))
     with pytest.raises(ValidationError, match="use that joint as the articulation root"):
         world_assembly.resolve()
@@ -298,10 +283,8 @@ def _ball(*axes: JointAxis) -> ResolvedRigidBodyAssembly:
     head = add_body(assembly, "head")
     assembly.joint(
         "socket",
-        body0=base,
-        frame0=JointFrame(),
-        body1=head,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        head.at(JointFrame()),
         dofs=tuple(JointDOF(axis, limits=(-math.pi, math.pi)) for axis in axes),
     )
     assembly.articulation("main", root=base, joints=["socket"])
@@ -340,8 +323,8 @@ def test_structural_names_must_be_identifiers() -> None:
     body = add_body(model, "part")
     other = add_body(model, "other")
     with pytest.raises(ValidationError, match="identifier"):
-        model.joint("hinge.rotZ", body0=body, body1=other)
-    hinge = model.joint("hinge", body0=body, body1=other)
+        model.joint("hinge.rotZ", body.at(), other.at())
+    hinge = model.joint("hinge", body.at(), other.at())
     with pytest.raises(ValidationError, match="identifier"):
         model.articulation("main tree", root=body, joints=[hinge])
 

--- a/tests/test_rigid_body_export.py
+++ b/tests/test_rigid_body_export.py
@@ -31,34 +31,30 @@ def four_bar(*, second_closure: bool = False) -> RigidBodyAssembly:
     coupler = body(assembly, "coupler")
     rocker = body(assembly, "rocker")
     dofs = (JointDOF(JointAxis.ROT_Z),)
-    a = assembly.joint("ground_crank", body0=ground, body1=crank, dofs=dofs)
+    a = assembly.joint("ground_crank", ground.at(), crank.at(), dofs=dofs)
     b = assembly.joint(
         "crank_coupler",
-        body0=crank,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=coupler,
+        crank.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        coupler.at(),
         dofs=dofs,
     )
     c = assembly.joint(
         "coupler_rocker",
-        body0=coupler,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=rocker,
+        coupler.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        rocker.at(),
         dofs=dofs,
     )
     assembly.joint(
         "rocker_ground",
-        body0=rocker,
-        body1=ground,
-        frame1=JointFrame(xyz=(2.0, 0.0, 0.0)),
+        rocker.at(),
+        ground.at(JointFrame(xyz=(2.0, 0.0, 0.0))),
         dofs=dofs,
     )
     if second_closure:
         assembly.joint(
             "crank_rocker",
-            body0=crank,
-            frame0=JointFrame(xyz=(2.0, 0.0, 0.0)),
-            body1=rocker,
+            crank.at(JointFrame(xyz=(2.0, 0.0, 0.0))),
+            rocker.at(),
             dofs=dofs,
         )
     assembly.articulation("main", root=ground, joints=(a, b, c))
@@ -150,11 +146,7 @@ def test_fixed_world_joint_is_the_articulation_root_and_has_one_body_target(
     assembly = RigidBodyAssembly("mounted")
     base = body(assembly, "base")
     mount = assembly.joint(
-        "mount",
-        body0=WORLD,
-        frame0=JointFrame(xyz=(1.0, 2.0, 3.0)),
-        body1=base,
-        frame1=JointFrame(rpy=(0.1, 0.2, 0.3)),
+        "mount", WORLD.at(JointFrame(xyz=(1.0, 2.0, 3.0))), base.at(JointFrame(rpy=(0.1, 0.2, 0.3)))
     )
     assembly.articulation("fixed", root=mount, joints=(mount,))
 
@@ -179,10 +171,8 @@ def test_simple_joints_use_specialized_native_schemas_and_radian_limits_become_d
     b = body(assembly, "b")
     joint = assembly.joint(
         "hinge",
-        body0=a,
-        frame0=JointFrame(xyz=(0.1, 0.2, 0.3), rpy=(0.2, 0.1, 0.0)),
-        body1=b,
-        frame1=JointFrame(xyz=(-0.1, 0.0, 0.2), rpy=(0.0, 0.3, 0.4)),
+        a.at(JointFrame(xyz=(0.1, 0.2, 0.3), rpy=(0.2, 0.1, 0.0))),
+        b.at(JointFrame(xyz=(-0.1, 0.0, 0.2), rpy=(0.0, 0.3, 0.4))),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(-math.pi / 2, math.pi / 4)),),
     )
     assembly.articulation("main", root=a, joints=(joint,))
@@ -206,8 +196,8 @@ def test_multi_dof_joint_uses_generic_usd_joint_and_per_axis_limit_apis(
     b = body(assembly, "b")
     assembly.joint(
         "planar",
-        body0=a,
-        body1=b,
+        a.at(),
+        b.at(),
         dofs=(
             JointDOF(JointAxis.TRANS_X, limits=(-0.2, 0.3)),
             JointDOF(JointAxis.ROT_Z),

--- a/tests/test_rigid_body_loop_solver.py
+++ b/tests/test_rigid_body_loop_solver.py
@@ -43,31 +43,26 @@ def four_bar() -> RigidBodyAssembly:
     hinge = (JointDOF(JointAxis.ROT_Y, limits=(-math.pi, math.pi)),)
     crank_pin = assembly.joint(
         "crank_pin",
-        body0=ground,
-        frame0=JointFrame(xyz=GROUND_A),
-        body1=crank,
+        ground.at(JointFrame(xyz=GROUND_A)),
+        crank.at(),
         dofs=hinge,
     )
     coupler_pin = assembly.joint(
         "coupler_pin",
-        body0=crank,
-        frame0=JointFrame(xyz=(CRANK, 0.0, 0.0), rpy=(0.0, COUPLER_TILT, 0.0)),
-        body1=coupler,
+        crank.at(JointFrame(xyz=(CRANK, 0.0, 0.0), rpy=(0.0, COUPLER_TILT, 0.0))),
+        coupler.at(),
         dofs=hinge,
     )
     rocker_pin = assembly.joint(
         "rocker_pin",
-        body0=ground,
-        frame0=JointFrame(xyz=GROUND_D, rpy=(0.0, -math.pi / 2.0, 0.0)),
-        body1=rocker,
+        ground.at(JointFrame(xyz=GROUND_D, rpy=(0.0, -math.pi / 2.0, 0.0))),
+        rocker.at(),
         dofs=hinge,
     )
     assembly.joint(
         "closing_pin",
-        body0=coupler,
-        frame0=JointFrame(xyz=(COUPLER, 0.0, 0.0)),
-        body1=rocker,
-        frame1=JointFrame(xyz=(ROCKER, 0.0, 0.0)),
+        coupler.at(JointFrame(xyz=(COUPLER, 0.0, 0.0))),
+        rocker.at(JointFrame(xyz=(ROCKER, 0.0, 0.0))),
         dofs=hinge,
     )
     assembly.articulation(
@@ -170,26 +165,23 @@ def _hydraulic_ram(slide_limits: tuple[float, float]) -> RigidBodyAssembly:
     ram_length = math.dist(barrel_pivot, (arm_length, 0.0, 0.0))
     ram_pitch = -math.atan2(0.4, 0.8)
     hinge = (JointDOF(JointAxis.ROT_Y, limits=(-1.0, 1.0)),)
-    arm_pin = assembly.joint("arm_pin", body0=ground, body1=arm, dofs=hinge)
+    arm_pin = assembly.joint("arm_pin", ground.at(), arm.at(), dofs=hinge)
     barrel_pin = assembly.joint(
         "barrel_pin",
-        body0=ground,
-        frame0=JointFrame(xyz=barrel_pivot, rpy=(0.0, ram_pitch, 0.0)),
-        body1=barrel,
+        ground.at(JointFrame(xyz=barrel_pivot, rpy=(0.0, ram_pitch, 0.0))),
+        barrel.at(),
         dofs=hinge,
     )
     slide = assembly.joint(
         "slide",
-        body0=barrel,
-        body1=rod,
+        barrel.at(),
+        rod.at(),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=slide_limits),),
     )
     assembly.joint(
         "rod_eye",
-        body0=rod,
-        frame0=JointFrame(xyz=(ram_length, 0.0, 0.0)),
-        body1=arm,
-        frame1=JointFrame(xyz=(arm_length, 0.0, 0.0)),
+        rod.at(JointFrame(xyz=(ram_length, 0.0, 0.0))),
+        arm.at(JointFrame(xyz=(arm_length, 0.0, 0.0))),
         dofs=hinge,
     )
     assembly.articulation("main", root=ground, joints=(arm_pin, barrel_pin, slide))

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -59,7 +59,7 @@ def test_part_accepts_multiple_named_shapes_and_preserves_local_placement() -> N
     assert body.add(shell, name="shell", color=(0.7, 0.1, 0.1)) is shell
     body.add(trim, name="trim", color=(0.8, 0.8, 0.8, 0.5))
 
-    stored_shell = body.get_shape("shell")
+    stored_shell = body.shape("shell")
     assert stored_shell is shell
     assert isinstance(stored_shell, Shape)
     assert pytest.approx(0.4) == stored_shell.bounding_box().min.X
@@ -76,7 +76,7 @@ def test_part_accepts_mesh_geometry() -> None:
 
     body.add(mesh, name="procedural")
 
-    assert body.get_shape("procedural") is mesh
+    assert body.shape("procedural") is mesh
     model.validate()
 
 
@@ -94,7 +94,7 @@ def test_shape_names_are_required_and_unique_within_each_part() -> None:
     with pytest.raises(ValidationError, match="duplicate shape name"):
         left.add(box(), name="body")
     with pytest.raises(ValidationError, match="unknown shape"):
-        left.get_shape("missing")
+        left.shape("missing")
 
 
 @pytest.mark.parametrize(
@@ -143,35 +143,23 @@ def test_public_joint_grammar_covers_fixed_hinge_free_and_slide() -> None:
     rotor = add_box(model, "rotor")
     slider = add_box(model, "slider")
 
-    model.joint(
-        "root_to_fixed",
-        body0=root,
-        frame0=JointFrame(),
-        body1=fixed,
-        frame1=JointFrame(),
-    )
+    model.joint("root_to_fixed", root.at(JointFrame()), fixed.at(JointFrame()))
     revolute = model.joint(
         "fixed_to_hinge",
-        body0=fixed,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.2)),
-        body1=hinge,
-        frame1=JointFrame(),
+        fixed.at(JointFrame(xyz=(0.0, 0.0, 0.2))),
+        hinge.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(-math.pi / 4.0, math.pi / 4.0)),),
     )
     model.joint(
         "hinge_to_rotor",
-        body0=hinge,
-        frame0=JointFrame(),
-        body1=rotor,
-        frame1=JointFrame(),
+        hinge.at(JointFrame()),
+        rotor.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Z),),
     )
     model.joint(
         "rotor_to_slider",
-        body0=rotor,
-        frame0=JointFrame(),
-        body1=slider,
-        frame1=JointFrame(),
+        rotor.at(JointFrame()),
+        slider.at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=(-0.02, 0.2)),),
     )
 
@@ -213,20 +201,12 @@ def test_the_graph_model_rules_are_validated() -> None:
     with pytest.raises(ValidationError, match="duplicate DOF axes"):
         model.joint(
             "twice",
-            body0=root,
-            frame0=JointFrame(),
-            body1=child,
-            frame1=JointFrame(),
+            root.at(JointFrame()),
+            child.at(JointFrame()),
             dofs=(JointDOF(JointAxis.ROT_Z), JointDOF(JointAxis.ROT_Z)),
         )
     with pytest.raises(ValidationError, match="endpoints cannot be the same"):
-        model.joint(
-            "itself",
-            body0=root,
-            frame0=JointFrame(),
-            body1=root,
-            frame1=JointFrame(),
-        )
+        model.joint("itself", root.at(JointFrame()), root.at(JointFrame()))
 
 
 def test_the_graph_must_be_one_connected_whole() -> None:
@@ -244,9 +224,9 @@ def test_a_second_joint_into_a_body_closes_a_loop() -> None:
     base = add_box(model, "base")
     upper = add_box(model, "upper")
     brace = add_box(model, "brace")
-    model.joint("base_upper", body0=base, frame0=JointFrame(), body1=upper, frame1=JointFrame())
-    model.joint("base_brace", body0=base, frame0=JointFrame(), body1=brace, frame1=JointFrame())
-    model.joint("upper_brace", body0=upper, frame0=JointFrame(), body1=brace, frame1=JointFrame())
+    model.joint("base_upper", base.at(JointFrame()), upper.at(JointFrame()))
+    model.joint("base_brace", base.at(JointFrame()), brace.at(JointFrame()))
+    model.joint("upper_brace", upper.at(JointFrame()), brace.at(JointFrame()))
     model.articulation("main", root=base, joints=["base_upper", "base_brace"])
 
     resolved = model.resolve()
@@ -261,9 +241,9 @@ def test_an_articulation_must_select_a_tree() -> None:
     base = add_box(model, "base")
     upper = add_box(model, "upper")
     brace = add_box(model, "brace")
-    model.joint("base_upper", body0=base, frame0=JointFrame(), body1=upper, frame1=JointFrame())
-    model.joint("base_brace", body0=base, frame0=JointFrame(), body1=brace, frame1=JointFrame())
-    model.joint("upper_brace", body0=upper, frame0=JointFrame(), body1=brace, frame1=JointFrame())
+    model.joint("base_upper", base.at(JointFrame()), upper.at(JointFrame()))
+    model.joint("base_brace", base.at(JointFrame()), brace.at(JointFrame()))
+    model.joint("upper_brace", upper.at(JointFrame()), brace.at(JointFrame()))
     # all three edges is the ring itself, not a spanning tree
     model.articulation("main", root=base, joints=["base_upper", "base_brace", "upper_brace"])
 
@@ -278,11 +258,13 @@ def test_duplicate_and_unknown_names_are_rejected() -> None:
 
     with pytest.raises(ValidationError, match="duplicate rigid body name"):
         model.rigid_body("root")
-    model.joint("connection", body0=root, frame0=JointFrame(), body1=child, frame1=JointFrame())
+    model.joint("connection", root.at(JointFrame()), child.at(JointFrame()))
     with pytest.raises(ValidationError, match="duplicate joint name"):
-        model.joint("connection", body0=root, frame0=JointFrame(), body1=child, frame1=JointFrame())
+        model.joint("connection", root.at(JointFrame()), child.at(JointFrame()))
     with pytest.raises(ValidationError, match="unknown"):
-        model.joint("missing", body0=root, frame0=JointFrame(), body1="absent", frame1=JointFrame())
+        model.joint(
+            "missing", root.at(JointFrame()), model.get_rigid_body("absent").at(JointFrame())
+        )
 
 
 def test_old_frame_and_joint_helpers_are_not_public() -> None:

--- a/tests/test_sdk_docs.py
+++ b/tests/test_sdk_docs.py
@@ -221,10 +221,14 @@ def test_sdk_docs_and_examples_are_package_data() -> None:
         assert pattern in package_data
 
 
-def test_all_new_sdk_examples_execute() -> None:
-    examples = package_dir / "sdk" / "docs" / "examples"
+def test_all_first_party_sdk_examples_execute() -> None:
+    repo_root = package_dir.parents[1]
+    paths = [
+        *(package_dir / "sdk" / "docs" / "examples").glob("*.py"),
+        *repo_root.glob("examples/*/main.py"),
+    ]
 
-    for path in sorted(examples.glob("*.py")):
+    for path in sorted(paths):
         values = runpy.run_path(str(path))
         model = values["object_model"]
         report = values["run_tests"]()

--- a/tests/test_sdk_export.py
+++ b/tests/test_sdk_export.py
@@ -129,36 +129,28 @@ def test_export_supports_every_articulation_type_and_matching_joint_frames(tmp_p
     slider.add(Box(0.1, 0.1, 0.1), name="body")
     model.joint(
         "fixed_mount",
-        body0=root,
-        frame0=JointFrame(),
-        body1=fixed_part,
-        frame1=JointFrame(),
+        root.at(JointFrame()),
+        fixed_part.at(JointFrame()),
         dofs=(),
     )
     model.joint(
         "hinge_joint",
-        body0=fixed_part,
-        frame0=JointFrame(),
-        body1=hinge,
-        frame1=JointFrame(),
+        fixed_part.at(JointFrame()),
+        hinge.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Z, limits=(-0.5, 0.75)),),
     )
     model.joint(
         "rotor_joint",
-        body0=hinge,
-        frame0=JointFrame(),
-        body1=rotor,
-        frame1=JointFrame(),
+        hinge.at(JointFrame()),
+        rotor.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Y),),
     )
     # A diagonal travel direction is carried by the frame's rotation: yaw 45
     # degrees so the joint's own X points along the old (1, 1, 0).
     model.joint(
         "slider_joint",
-        body0=rotor,
-        frame0=JointFrame(xyz=(0.1, 0.2, 0.3), rpy=(0.0, 0.1, math.pi / 4.0)),
-        body1=slider,
-        frame1=JointFrame(),
+        rotor.at(JointFrame(xyz=(0.1, 0.2, 0.3), rpy=(0.0, 0.1, math.pi / 4.0))),
+        slider.at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=(-0.1, 0.2)),),
     )
 
@@ -200,10 +192,8 @@ def test_reserved_and_shared_names_do_not_corrupt_the_stage(tmp_path) -> None:
     child.add(Box(0.1, 0.1, 0.1), name="body", material=slick)
     model.joint(
         "shapes",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.2)),
-        body1=child,
-        frame1=JointFrame(),
+        base.at(JointFrame(xyz=(0.0, 0.0, 0.2))),
+        child.at(),
         dofs=(JointDOF(JointAxis.ROT_Z),),
     )
     model.articulation("main", root=base, joints=["shapes"])
@@ -238,10 +228,8 @@ def _hinge() -> RigidBodyAssembly:
     # hinge turns about the frame's own Y.
     model.joint(
         "base_to_door",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.2), rpy=(math.pi / 4.0, 0.2, 0.3)),
-        body1=door,
-        frame1=JointFrame(),
+        base.at(JointFrame(xyz=(0.0, 0.0, 0.2), rpy=(math.pi / 4.0, 0.2, 0.3))),
+        door.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(0.0, 1.57)),),
     )
     model.articulation("main", root=base, joints=["base_to_door"])

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -43,10 +43,8 @@ def _hinged_box(
     )
     model.joint(
         "lid_hinge",
-        body0=base,
-        frame0=JointFrame(rpy=rpy),
-        body1=lid,
-        frame1=JointFrame(),
+        base.at(JointFrame(rpy=rpy)),
+        lid.at(JointFrame()),
         dofs=(JointDOF(axis, limits=(LOWER, UPPER)),),
     )
     model.articulation("main", root=base, joints=["lid_hinge"])
@@ -182,10 +180,8 @@ def test_a_rotated_rest_pose_survives_the_translation(tmp_path: Path) -> None:
     arm.add(BoxGeometry((0.02, 0.02, 0.20)), name="post", material=Material.STEEL)
     model.joint(
         "mount",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.025), rpy=(0.0, math.pi / 4.0, 0.0)),
-        body1=arm,
-        frame1=JointFrame(),
+        base.at(JointFrame(xyz=(0.0, 0.0, 0.025), rpy=(0.0, math.pi / 4.0, 0.0))),
+        arm.at(JointFrame()),
         dofs=(),
     )
     model.articulation("main", root=base, joints=["mount"])
@@ -257,10 +253,8 @@ def test_prismatic_travel_is_not_reported_as_part_separation(tmp_path: Path) -> 
     )
     model.joint(
         "slide",
-        body0=base,
-        frame0=JointFrame(),
-        body1=body,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        body.at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_Z, limits=(0.0, 0.10)),),
     )
 
@@ -298,10 +292,8 @@ def test_simulate_reads_a_rigid_body_graph_stage(tmp_path) -> None:
     )
     assembly.joint(
         "lid_hinge",
-        body0=base,
-        frame0=JointFrame(xyz=(0.0, -0.10, 0.10)),
-        body1=lid,
-        frame1=JointFrame(xyz=(0.0, -0.10, 0.0)),
+        base.at(JointFrame(xyz=(0.0, -0.10, 0.10))),
+        lid.at(JointFrame(xyz=(0.0, -0.10, 0.0))),
         dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.5)),),
     )
     assembly.articulation("main", root=base, joints=["lid_hinge"])
@@ -326,10 +318,8 @@ def test_a_multi_dof_joint_becomes_one_mjcf_joint_per_free_axis(tmp_path) -> Non
     head.add(BoxGeometry((0.06, 0.06, 0.06)), name="plate", material=Material.STEEL)
     assembly.joint(
         "socket",
-        body0=post,
-        frame0=JointFrame(xyz=(0.0, 0.0, 0.06)),
-        body1=head,
-        frame1=JointFrame(),
+        post.at(JointFrame(xyz=(0.0, 0.0, 0.06))),
+        head.at(JointFrame()),
         dofs=tuple(
             JointDOF(axis, limits=(-0.6, 0.6))
             for axis in (JointAxis.ROT_X, JointAxis.ROT_Y, JointAxis.ROT_Z)
@@ -361,10 +351,8 @@ def test_a_joint_authored_child_first_still_nests_under_the_root(tmp_path: Path)
     # Authored child first: the arm carries body0, the base body1.
     model.joint(
         "mount",
-        body0=arm,
-        frame0=JointFrame(),
-        body1=base,
-        frame1=JointFrame(xyz=(0.0, 0.0, 0.025)),
+        arm.at(JointFrame()),
+        base.at(JointFrame(xyz=(0.0, 0.0, 0.025))),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(-0.5, 0.5)),),
     )
     model.articulation("main", root=base, joints=["mount"])
@@ -385,14 +373,14 @@ def test_a_revolute_loop_is_preserved_as_a_mujoco_constraint(tmp_path: Path) -> 
     arm.add(BoxGeometry((0.02, 0.02, 0.2)), name="post", material=Material.STEEL)
     tree = model.joint(
         "tree_hinge",
-        body0=base,
-        body1=arm,
+        base.at(),
+        arm.at(),
         dofs=(JointDOF(JointAxis.ROT_Y),),
     )
     model.joint(
         "closing_hinge",
-        body0=base,
-        body1=arm,
+        base.at(),
+        arm.at(),
         dofs=(JointDOF(JointAxis.ROT_Y),),
     )
     model.articulation("main", root=base, joints=(tree,))
@@ -412,14 +400,14 @@ def test_an_unsupported_loop_fails_before_writing_partial_mjcf(tmp_path: Path) -
     carriage.add(BoxGeometry((0.05, 0.05, 0.05)), name="block", material=Material.STEEL)
     tree = model.joint(
         "tree_slide",
-        body0=base,
-        body1=carriage,
+        base.at(),
+        carriage.at(),
         dofs=(JointDOF(JointAxis.TRANS_X),),
     )
     model.joint(
         "closing_slide",
-        body0=base,
-        body1=carriage,
+        base.at(),
+        carriage.at(),
         dofs=(JointDOF(JointAxis.TRANS_X),),
     )
     model.articulation("main", root=base, joints=(tree,))

--- a/tests/test_simulation_viewer.py
+++ b/tests/test_simulation_viewer.py
@@ -40,10 +40,8 @@ def _run_dir(tmp_path: Path) -> tuple[Path, Path]:
     )
     model.joint(
         "lid_hinge",
-        body0=base,
-        frame0=JointFrame(),
-        body1=lid,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        lid.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.5)),),
     )
 

--- a/tests/test_testing_sdk.py
+++ b/tests/test_testing_sdk.py
@@ -28,13 +28,7 @@ def add_box(part, name: str, *, size: float = 1.0, x: float = 0.0) -> None:
 
 def fixed(model: RigidBodyAssembly, name: str, parent, child, xyz=(0.0, 0.0, 0.0)):
     """A joint with no free axes is a fixed joint."""
-    return model.joint(
-        name,
-        body0=parent,
-        frame0=JointFrame(xyz=xyz),
-        body1=child,
-        frame1=JointFrame(),
-    )
+    return model.joint(name, parent.at(JointFrame(xyz=xyz)), child.at(JointFrame()))
 
 
 def test_report_records_warnings_and_shape_scoped_allowances() -> None:
@@ -241,10 +235,8 @@ def test_pose_changes_prismatic_part_transform_and_restores() -> None:
     add_box(slider, "body", x=1.5)
     model.joint(
         "slide",
-        body0=base,
-        frame0=JointFrame(),
-        body1=slider,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        slider.at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=(-1.5, 0.0)),),
     )
     ctx = TestContext(model)
@@ -277,8 +269,8 @@ def test_pose_accepts_qualified_d6_coordinates() -> None:
     add_box(moving, "body")
     model.joint(
         "motion",
-        body0=base,
-        body1=moving,
+        base.at(),
+        moving.at(),
         dofs=(
             JointDOF(JointAxis.TRANS_X, limits=(-0.5, 0.5)),
             JointDOF(JointAxis.ROT_Z, limits=(-0.5, 0.5)),
@@ -516,8 +508,8 @@ def _swing_arm() -> RigidBodyAssembly:
     add_box(arm, "body", x=3.0)
     model.joint(
         "hinge",
-        body0=base,
-        body1=arm,
+        base.at(),
+        arm.at(),
         dofs=(JointDOF(JointAxis.ROT_Z, limits=(-1.0, 1.0)),),
     )
     model.articulation("main", root=base, joints=["hinge"])
@@ -567,10 +559,8 @@ def test_pose_sweeps_record_unreachable_loop_poses() -> None:
     arm = model.get_rigid_body("arm")
     model.joint(
         "second_pin",
-        body0=base,
-        frame0=JointFrame(xyz=(1.0, 0.0, 0.0)),
-        body1=arm,
-        frame1=JointFrame(xyz=(1.0, 0.0, 0.0)),
+        base.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
+        arm.at(JointFrame(xyz=(1.0, 0.0, 0.0))),
         dofs=(JointDOF(JointAxis.ROT_Z),),
     )
     context = TestContext(model)
@@ -590,8 +580,8 @@ def test_separation_check_handles_multi_dof_joints() -> None:
     add_box(moving, "body")
     model.joint(
         "wrist",
-        body0=base,
-        body1=moving,
+        base.at(),
+        moving.at(),
         dofs=(
             JointDOF(JointAxis.ROT_X, limits=(-0.4, 0.4)),
             JointDOF(JointAxis.ROT_Y, limits=(-0.4, 0.4)),

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -96,14 +96,14 @@ def test_viewer_disables_direct_posing_for_closed_loops(tmp_path) -> None:
     link.add(Box(0.1, 0.02, 0.2), name="body")
     tree = model.joint(
         "tree",
-        body0=base,
-        body1=link,
+        base.at(),
+        link.at(),
         dofs=(JointDOF(JointAxis.ROT_Y),),
     )
     model.joint(
         "closure",
-        body0=base,
-        body1=link,
+        base.at(),
+        link.at(),
         dofs=(JointDOF(JointAxis.ROT_Y),),
     )
     model.articulation("main", root=base, joints=(tree,))
@@ -123,10 +123,8 @@ def test_viewer_orients_symmetric_joint_from_the_articulation_root(tmp_path) -> 
     arm.add(Box(0.1, 0.02, 0.2), name="body")
     hinge = model.joint(
         "hinge",
-        body0=arm,
-        frame0=JointFrame(xyz=(0.2, 0.0, 0.0)),
-        body1=base,
-        frame1=JointFrame(xyz=(0.1, 0.0, 0.0)),
+        arm.at(JointFrame(xyz=(0.2, 0.0, 0.0))),
+        base.at(JointFrame(xyz=(0.1, 0.0, 0.0))),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(-0.5, 0.75)),),
     )
     model.articulation("main", root=base, joints=(hinge,))
@@ -196,10 +194,8 @@ def _revolute_model() -> RigidBodyAssembly:
     door.add(Box(0.1, 0.02, 0.2), name="panel")
     model.joint(
         "hinge_joint",
-        body0=base,
-        frame0=JointFrame(),
-        body1=door,
-        frame1=JointFrame(),
+        base.at(JointFrame()),
+        door.at(JointFrame()),
         dofs=(JointDOF(JointAxis.ROT_Y, limits=(-0.5, 0.75)),),
     )
     return model
@@ -214,10 +210,8 @@ def _prismatic_model() -> RigidBodyAssembly:
     # A diagonal travel direction rides in the frame's rotation.
     model.joint(
         "linear_travel",
-        body0=base,
-        frame0=JointFrame(xyz=(0.1, 0.2, 0.3), rpy=(0.0, 0.1, math.pi / 4.0)),
-        body1=carriage,
-        frame1=JointFrame(),
+        base.at(JointFrame(xyz=(0.1, 0.2, 0.3), rpy=(0.0, 0.1, math.pi / 4.0))),
+        carriage.at(JointFrame()),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=(-0.1, 0.2)),),
     )
     model.articulation("main", root=base, joints=["linear_travel"])


### PR DESCRIPTION
## Summary

- bind joint frames to `RigidBody` or `WORLD` before authoring a joint, preventing endpoint/frame mismatches by construction
- let `body.at(...)` consume points plus native build123d locations, planes, axes, faces, edges, vertices, and shapes without introducing a second selector language
- add `assembly.frame_in(...)` to derive exact reference-state frames across bodies, including loop-closing endpoints
- add `expect_coincident(...)` and `expect_coaxial(...)` intent checks while retaining mesh contact, gap, and containment checks for physical fit
- migrate the public API, prompts, docs, benchmarks, tests, and examples as a deliberate clean break
- make all first-party examples executable tests; the hinge and four-bar now anchor joints to actual geometry and check their axes while posed

## Why

Agents should express geometric intent, not manually copy transforms between bodies. This keeps build123d as the single topology-selection language, then lowers selected features to exact USD-local endpoint frames. The runtime also checks body identity, so a frame cannot silently bind to a same-named body from another assembly.

## Stack

3 of 3. Based on #125, which is based on #124.

## Validation

- `uv run --group sim pytest -q --replay` — 607 passed, 2 deselected
- `uv run basedpyright` — 0 errors
- `uv run ruff check .`
- `uv run ruff format --check .`
- all 9 first-party examples load, validate, pass their authored reports, and export validated USDZ packages
- CI is green, including Python 3.11 and 3.12 distribution smoke tests

Closes #119