### PR TITLE
Show the quickstart's hinge being selected, not measured

### DIFF
--- a/src/articraft/sdk/docs/common/00_quickstart.md
+++ b/src/articraft/sdk/docs/common/00_quickstart.md
@@ -14,7 +14,7 @@ from articraft.sdk import RigidBodyAssembly, TestContext, TestReport
 
 model = RigidBodyAssembly("small_table")
 body = model.rigid_body("body")
-body.add(Box(0.8, 0.5, 0.04), name="top", color=(0.45, 0.24, 0.10))
+top = body.add(Box(0.8, 0.5, 0.04), name="top", color=(0.45, 0.24, 0.10))
 body.add(Pos(X=0.36, Y=0.21, Z=-0.36) * Box(0.04, 0.04, 0.7), name="leg_1")
 
 object_model = model
@@ -29,16 +29,14 @@ Every shape needs a unique name within its body. A color can contain RGB or RGBA
 zero through one.
 
 Within one rigid body, overlapping shapes count as connected -- `leg_1` overlaps up into `top`
-above. To attach a handle or spout, extend its end a few millimeters into the form it meets; it
-then reads as one molded piece.
+above. To attach a handle or spout, extend its end a few millimeters into the form it meets.
 
 Prefer build123d for exact solids, wall thickness, openings, bores, rims and local fillets. Use
 mesh helpers when the form is better described by freeform sections or paths. One body can hold
 both.
 
 Motion is two steps. `model.joint(...)` connects two bodies at a frame on each, and its `dofs`
-say which axes are free: none is fixed, one rotational is a hinge, one linear is a slide, three
-rotational is a ball. `model.articulation(...)` then names the tree the simulator solves.
+say which axes are free. `model.articulation(...)` names the tree the simulator solves.
 
 ```python
 from articraft.sdk import JointAxis, JointDOF
@@ -46,19 +44,21 @@ from articraft.sdk import JointAxis, JointDOF
 
 lid = model.rigid_body("lid")
 lid.add(Box(0.8, 0.5, 0.02), name="panel")
+# The edge's direction becomes the frame's own Z.
+hinge = top.edges().filter_by(Axis.X).sort_by(Axis.Z)[-1]
 model.joint(
     "lid_hinge",
-    body.at((0.0, 0.25, 0.02)),
-    lid.at((0.0, 0.25, -0.01)),
-    # The hinge edge runs along X, so ROT_X; negative angles open the lid.
-    dofs=(JointDOF(JointAxis.ROT_X, limits=(-1.9, 0.0)),),
+    body.at(hinge),
+    lid.at(hinge),
+    dofs=(JointDOF(JointAxis.ROT_Z, limits=(-1.9, 0.0)),),
 )
 model.articulation("main", root=body, joints=["lid_hinge"])
 ```
 
 `body.at(...)` accepts a point or build123d location, plane, axis, face, edge,
-or vertex. Prefer a feature over a copied coordinate. Endpoint frames coincide
-at rest. Limits use radians or meters and must contain zero.
+or vertex. Prefer a feature over a copied coordinate, and pass one feature to
+both endpoints so the frames cannot disagree. Endpoint frames coincide at rest.
+Limits use radians or meters and must contain zero.
 
 **Count the pivots.** A body pinned in two places takes two joints, making the mechanism a
 ring -- linkages, four-bars, grippers, scissors. Author every joint it has, then leave


### PR DESCRIPTION
## The problem

`body.at(...)` accepts build123d features, and the quickstart's prose says to prefer one over a copied coordinate. Its example did the opposite:

```python
model.joint(
    "lid_hinge",
    body.at((0.0, 0.25, 0.02)),
    lid.at((0.0, 0.25, -0.01)),
    dofs=(JointDOF(JointAxis.ROT_X, limits=(-1.9, 0.0)),),
)
```

Two hand-written tuples for one physical hinge — the arithmetic `at()` exists to remove. This is the first thing every run reads, and runs copy its shape.

## The change

```python
top = body.add(Box(0.8, 0.5, 0.04), name="top", ...)
...
# The edge's direction becomes the frame's own Z.
hinge = top.edges().filter_by(Axis.X).sort_by(Axis.Z)[-1]
model.joint("lid_hinge", body.at(hinge), lid.at(hinge),
            dofs=(JointDOF(JointAxis.ROT_Z, limits=(-1.9, 0.0)),))
```

`ROT_X` becomes `ROT_Z` because the edge's direction *is* the frame's Z, so the axis falls out of the geometry. Passing one feature to both endpoints means the two frames cannot disagree. Verified the example runs and the lid swings.

Fits the 5000-character quickstart budget at 4940.

## Evidence

Two runs on this SDK before the change, same model, same prompts:

| | `.at()` calls | `.at()` with a literal | edits | outcome |
| --- | --- | --- | --- | --- |
| anglepoise lamp | 15 | — | 20 | success @ 44 turns, both four-bars closed |
| excavator | 2 | 2 | 63 | error @ 100 turns |

The lamp leaned on the feature form and finished. The excavator called `at()` twice with literals, then spent its whole budget nudging coordinates.

Re-running the excavator after this change:

| | before | after |
| --- | --- | --- |
| outcome | error @ 100 turns | success @ 61 |
| `edit` | 63 | 16 |
| `.at()` calls | 2 | 11 |
| `.at()` with a literal tuple | 2 | **0** |
| closed loops | 6 | 4 |

Every anchor now comes from a helper rather than a typed coordinate.

## What this does not show

n=1 per side, and this prompt is high variance: two excavator runs on identical code earlier gave 18 joints / 5 loops against 11 joints / 0 loops. The pass/fail flip is weak on its own. The 63 to 16 edit drop and the 2 to 11 anchor shift are the more meaningful numbers, since they measure the behaviour the change targets directly.

The result is also not clean. Driving the bucket pivot still leaves two cylinder closures open, so the coupled-loop difficulty is reduced, not gone.

Worth two or three more runs each side before treating the improvement as established.