### PR TITLE
Ask the installed geometry libraries the geometry questions

### DIFF
--- a/src/articraft/sdk/_collision.py
+++ b/src/articraft/sdk/_collision.py
@@ -6,9 +6,12 @@ from dataclasses import dataclass
 from typing import TypeAlias
 
 import fcl
+import igl
 import manifold3d
 import numpy as np
 import trimesh
+from scipy import sparse
+from scipy.sparse.csgraph import connected_components
 
 from articraft.sdk._mesh.core import MeshGeometry, geometry_to_trimesh
 from articraft.sdk.assembly import PhysicsState, RigidBodyAssembly
@@ -404,7 +407,7 @@ def _component_connectivity(
     *,
     contact_tol: float,
 ) -> tuple[list[set[int]], dict[int, tuple[int, float]]]:
-    adjacency: dict[int, set[int]] = {index: set() for index in range(len(components))}
+    touching: list[tuple[int, int]] = []
     nearest: dict[int, tuple[int, float]] = {}
     for index, component in enumerate(components):
         for other_index in range(index + 1, len(components)):
@@ -415,26 +418,17 @@ def _component_connectivity(
                 if solid_intersection is not None and solid_intersection > 0.0:
                     collided, distance = True, 0.0
             if collided or distance <= contact_tol:
-                adjacency[index].add(other_index)
-                adjacency[other_index].add(index)
+                touching.append((index, other_index))
             _remember_nearest(nearest, index, other_index, distance)
             _remember_nearest(nearest, other_index, index, distance)
 
-    remaining = set(range(len(components)))
-    groups: list[set[int]] = []
-    while remaining:
-        start = min(remaining)
-        group: set[int] = set()
-        stack = [start]
-        remaining.remove(start)
-        while stack:
-            current = stack.pop()
-            group.add(current)
-            for neighbor in sorted(adjacency[current]):
-                if neighbor in remaining:
-                    remaining.remove(neighbor)
-                    stack.append(neighbor)
-        groups.append(group)
+    count = len(components)
+    graph = sparse.coo_matrix(
+        (np.ones(len(touching)), tuple(np.asarray(touching, dtype=np.int64).reshape(-1, 2).T)),
+        shape=(count, count),
+    )
+    group_count, labels = connected_components(graph, directed=False)
+    groups = [set(map(int, np.flatnonzero(labels == label))) for label in range(group_count)]
     return groups, nearest
 
 
@@ -552,39 +546,18 @@ def _open_mesh_buried(mesh_a: trimesh.Trimesh, mesh_b: trimesh.Trimesh) -> bool:
             continue
         vertices = np.asarray(contents.vertices, dtype=np.float64)
         probes = vertices[:: max(1, len(vertices) // 8)][:8]
-        inside = _ray_parity_inside(container, probes)
+        # Winding numbers are immune to the edge-grazing rays that break
+        # crossing-parity tests; the majority vote stays as cheap insurance
+        # against probes that land exactly on the container's surface.
+        winding = igl.fast_winding_number(
+            np.ascontiguousarray(container.vertices, dtype=np.float64),
+            np.ascontiguousarray(container.faces, dtype=np.int64),
+            np.ascontiguousarray(probes),
+        )
+        inside = np.asarray(winding) > 0.5
         if len(inside) and int(np.count_nonzero(inside)) * 2 > len(inside):
             return True
     return False
-
-
-def _ray_parity_inside(mesh: trimesh.Trimesh, points: np.ndarray) -> np.ndarray:
-    """Point-in-watertight-mesh by ray crossing parity (Moller-Trumbore).
-
-    Self-contained on purpose: trimesh's own containment queries require the
-    optional rtree package. A handful of probe points against every triangle
-    is cheap, and the caller takes a majority vote so one edge-grazing ray
-    cannot decide the answer alone.
-    """
-
-    triangles = np.asarray(mesh.triangles, dtype=np.float64)
-    origin_edge = triangles[:, 1] - triangles[:, 0]
-    far_edge = triangles[:, 2] - triangles[:, 0]
-    direction = np.asarray((0.2743, 0.6712, 0.6886), dtype=np.float64)
-    perpendicular = np.cross(direction, far_edge)
-    determinant = np.einsum("ij,ij->i", origin_edge, perpendicular)
-    valid = np.abs(determinant) > 1e-12
-    safe_det = np.where(valid, determinant, 1.0)
-    inside = np.zeros(len(points), dtype=bool)
-    for index, point in enumerate(points):
-        offset = point - triangles[:, 0]
-        u = np.einsum("ij,ij->i", offset, perpendicular) / safe_det
-        cross = np.cross(offset, origin_edge)
-        v = (cross @ direction) / safe_det
-        t = np.einsum("ij,ij->i", far_edge, cross) / safe_det
-        hits = valid & (u >= 0.0) & (v >= 0.0) & (u + v <= 1.0) & (t > 1e-9)
-        inside[index] = bool(np.count_nonzero(hits) % 2)
-    return inside
 
 
 def _meshes_have_overlapping_bounds(a: trimesh.Trimesh, b: trimesh.Trimesh) -> bool:

--- a/src/articraft/sdk/_mesh/health.py
+++ b/src/articraft/sdk/_mesh/health.py
@@ -8,6 +8,8 @@ from typing import TypeAlias
 import igl
 import numpy as np
 import trimesh
+from scipy import sparse
+from scipy.sparse.csgraph import connected_components
 
 from articraft.sdk._mesh.core import MeshGeometry, geometry_to_trimesh
 from articraft.sdk.errors import ValidationError
@@ -360,36 +362,27 @@ def _topology(faces: np.ndarray) -> _Topology:
 
 
 def _face_components(face_count: int, edge_face_indices: np.ndarray) -> np.ndarray:
+    """Label each face with its connected component, joining faces across shared edges.
+
+    Sorting by edge id makes rows of one edge adjacent, so linking each row to
+    the next row of the same edge chains every face on that edge together --
+    including all faces of a non-manifold edge -- without visiting Python-level
+    edges one by one.
+    """
+
     if face_count == 0:
         return np.empty(0, dtype=np.int64)
-    parents = np.arange(face_count)
-
-    def find(index: int) -> int:
-        while parents[index] != index:
-            parents[index] = parents[parents[index]]
-            index = int(parents[index])
-        return index
-
-    def union(first: int, second: int) -> None:
-        first_root = find(first)
-        second_root = find(second)
-        if first_root != second_root:
-            parents[second_root] = first_root
-
-    order = np.argsort(edge_face_indices[:, 0], kind="stable")
-    ordered = edge_face_indices[order]
-    start = 0
-    while start < len(ordered):
-        end = start + 1
-        while end < len(ordered) and ordered[end, 0] == ordered[start, 0]:
-            end += 1
-        first_face = int(ordered[start, 1])
-        for row in ordered[start + 1 : end]:
-            union(first_face, int(row[1]))
-        start = end
-    roots = np.asarray([find(index) for index in range(face_count)])
-    _, component_ids = np.unique(roots, return_inverse=True)
-    return component_ids
+    ordered = edge_face_indices[np.argsort(edge_face_indices[:, 0], kind="stable")]
+    same_edge = ordered[:-1, 0] == ordered[1:, 0]
+    graph = sparse.coo_matrix(
+        (
+            np.ones(int(np.count_nonzero(same_edge))),
+            (ordered[:-1, 1][same_edge], ordered[1:, 1][same_edge]),
+        ),
+        shape=(face_count, face_count),
+    )
+    _count, component_ids = connected_components(graph, directed=False)
+    return component_ids.astype(np.int64)
 
 
 def _faces_outside_largest_positive_component(

--- a/src/articraft/sdk/_mesh/weld.py
+++ b/src/articraft/sdk/_mesh/weld.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import math
 
+import fcl
 import igl
 import manifold3d
 import numpy as np
+from scipy import sparse
+from scipy.sparse.csgraph import connected_components
 from trimesh import Trimesh
 
 from articraft.sdk._mesh.boolean import (
@@ -29,37 +32,43 @@ class SnapRefused(ValueError):
     """Raised when snapping a piece to touch would move it further than allowed."""
 
 
-def _closest_points(mesh: Trimesh, points: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    squared, _faces, closest = igl.point_mesh_squared_distance(
-        np.ascontiguousarray(points, dtype=np.float64),
-        np.ascontiguousarray(mesh.vertices, dtype=np.float64),
-        np.ascontiguousarray(mesh.faces, dtype=np.int64),
-    )
-    distances = np.sqrt(np.maximum(np.asarray(squared, dtype=np.float64), 0.0))
-    return np.asarray(closest, dtype=np.float64), distances
-
-
 def _require_mesh(geometry: object, label: str) -> MeshGeometry:
     if not isinstance(geometry, MeshGeometry):
         raise TypeError(f"{label} must be MeshGeometry")
     return geometry
 
 
+def _collision_object(mesh: Trimesh) -> fcl.CollisionObject:
+    model = fcl.BVHModel()
+    model.beginModel(len(mesh.vertices), len(mesh.faces))
+    model.addSubModel(
+        np.ascontiguousarray(mesh.vertices, dtype=np.float64),
+        np.ascontiguousarray(mesh.faces, dtype=np.int32),
+    )
+    model.endModel()
+    return fcl.CollisionObject(model, fcl.Transform())
+
+
 def _nearest_gap(anchor: MeshGeometry, piece: MeshGeometry) -> tuple[float, np.ndarray]:
-    """Smallest surface gap between two solids and the unit direction piece -> anchor."""
-    a_mesh = anchor.to_trimesh()
-    b_mesh = piece.to_trimesh()
-    points_on_a, dist_b = _closest_points(a_mesh, b_mesh.vertices)
-    i = int(np.argmin(dist_b))
-    point_a, point_b, dist = points_on_a[i], b_mesh.vertices[i], float(dist_b[i])
-    points_on_b, dist_a = _closest_points(b_mesh, a_mesh.vertices)
-    j = int(np.argmin(dist_a))
-    if dist_a[j] < dist:
-        point_a, point_b, dist = a_mesh.vertices[j], points_on_b[j], float(dist_a[j])
-    direction = np.asarray(point_a, dtype=np.float64) - np.asarray(point_b, dtype=np.float64)
+    """Smallest surface gap between two solids and the unit direction piece -> anchor.
+
+    FCL measures the true surface-to-surface minimum, so a gap whose closest
+    approach is edge-to-edge or face-to-face reads exactly; sampling one mesh's
+    vertices against the other's surface would under-report it.
+    """
+
+    anchor_obj = _collision_object(anchor.to_trimesh())
+    piece_obj = _collision_object(piece.to_trimesh())
+    if int(fcl.collide(anchor_obj, piece_obj, fcl.CollisionRequest(), fcl.CollisionResult())) > 0:
+        return 0.0, np.zeros(3)
+    request = fcl.DistanceRequest(enable_nearest_points=True)
+    result = fcl.DistanceResult()
+    dist = float(fcl.distance(anchor_obj, piece_obj, request, result))
+    point_a, point_b = (np.asarray(point, dtype=np.float64) for point in result.nearest_points)
+    direction = point_a - point_b
     norm = float(np.linalg.norm(direction))
     unit = direction / norm if norm > 1e-12 else np.zeros(3)
-    return dist, unit
+    return max(dist, 0.0), unit
 
 
 def _smooth_max(first: np.ndarray, second: np.ndarray, radius: float, profile: str) -> np.ndarray:
@@ -95,13 +104,8 @@ def _grid_points(
     lower: np.ndarray,
     spacing: np.ndarray,
 ) -> np.ndarray:
-    flat = np.arange(start, stop, dtype=np.int64)
-    yz = int(dimensions[1] * dimensions[2])
-    x = flat // yz
-    remainder = flat - x * yz
-    y = remainder // dimensions[2]
-    z = remainder - y * dimensions[2]
-    return lower + np.column_stack((x, y, z)) * spacing
+    coordinates = np.unravel_index(np.arange(start, stop, dtype=np.int64), tuple(dimensions))
+    return lower + np.column_stack(coordinates) * spacing
 
 
 def _extract_level_set(
@@ -109,11 +113,8 @@ def _extract_level_set(
 ) -> MeshGeometry:
     nx, ny, nz = (int(value) for value in dimensions)
     point_count = len(field)
-    flat = np.arange(point_count, dtype=np.int64)
-    x = flat % nx
-    y = (flat // nx) % ny
-    z = flat // (nx * ny)
-    grid_vertices = lower + np.column_stack((x, y, z)) * spacing
+    coordinates = np.unravel_index(np.arange(point_count, dtype=np.int64), (nx, ny, nz), order="F")
+    grid_vertices = lower + np.column_stack(coordinates) * spacing
     samples = np.ascontiguousarray(field.reshape((nx, ny, nz)).ravel(order="F"))
     vertices, faces, _edges = igl.marching_cubes(
         samples,
@@ -178,25 +179,20 @@ def _connection_gaps(
 
 
 def _require_connected_inputs(geometries: tuple[MeshGeometry, ...], *, max_gap: float) -> None:
-    connected = {0}
     gaps = _connection_gaps(geometries)
-    while True:
-        additions = {
-            second if first in connected else first
-            for first, second, gap in gaps
-            if gap <= max_gap and ((first in connected) != (second in connected))
-        }
-        if not additions:
-            break
-        connected.update(additions)
-    if len(connected) != len(geometries):
-        nearest = min(
-            gap for first, second, gap in gaps if (first in connected) != (second in connected)
-        )
-        raise ValueError(
-            f"weld inputs are separated by {nearest * 1000.0:.2f} mm; overlap them or "
-            "increase max_gap"
-        )
+    close = [(first, second) for first, second, gap in gaps if gap <= max_gap]
+    graph = sparse.coo_matrix(
+        (np.ones(len(close)), tuple(np.asarray(close, dtype=np.int64).reshape(-1, 2).T)),
+        shape=(len(geometries), len(geometries)),
+    )
+    _count, labels = connected_components(graph, directed=False)
+    if np.all(labels == labels[0]):
+        return
+    connected = labels == labels[0]
+    nearest = min(gap for first, second, gap in gaps if connected[first] != connected[second])
+    raise ValueError(
+        f"weld inputs are separated by {nearest * 1000.0:.2f} mm; overlap them or increase max_gap"
+    )
 
 
 def _surface_controls(

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -9,9 +9,9 @@ from enum import StrEnum
 from pathlib import Path
 from typing import ClassVar, cast
 
+import igl
 import numpy as np
 import trimesh
-from scipy.spatial import cKDTree  # pyright: ignore[reportAttributeAccessIssue]
 
 from articraft.sdk._collision import (
     Bounds,
@@ -741,12 +741,23 @@ class TestContext:
             raise ValidationError("plane_normal must be non-zero")
         normal /= length
         tolerance = _non_negative(tolerance, "tolerance")
-        vertices = self._selected_world_vertices(part, shape)
-        if len(vertices) > 20_000:
-            vertices = vertices[np.linspace(0, len(vertices) - 1, 20_000, dtype=int)]
-        reflected = vertices - 2.0 * np.outer((vertices - origin) @ normal, normal)
-        distances, _indices = cKDTree(vertices).query(reflected, workers=1)
-        deviation = float(np.max(distances, initial=0.0))
+        meshes = self._selected_world_meshes(part, shape)
+        combined = meshes[0] if len(meshes) == 1 else trimesh.util.concatenate(meshes)
+        surface = np.asarray(combined.vertices, dtype=np.float64)
+        samples = surface
+        if len(samples) > 20_000:
+            samples = samples[np.linspace(0, len(samples) - 1, 20_000, dtype=int)]
+        reflected = samples - 2.0 * np.outer((samples - origin) @ normal, normal)
+        # Measure the reflection against the surface, not the vertex set: a
+        # symmetric surface whose two halves are tessellated differently has
+        # no matching vertices, and the nearest-vertex distance would report
+        # that meshing accident as an asymmetry of the part.
+        squared, _faces, _closest = igl.point_mesh_squared_distance(
+            np.ascontiguousarray(reflected),
+            surface,
+            np.ascontiguousarray(combined.faces, dtype=np.int64),
+        )
+        deviation = float(math.sqrt(max(float(np.max(squared, initial=0.0)), 0.0)))
         selector = _geometry_selector(part, shape)
         return self.expect_metric(
             name or f"symmetry_deviation({selector})",

--- a/tests/test_evidence_sdk.py
+++ b/tests/test_evidence_sdk.py
@@ -30,6 +30,7 @@ from articraft.sdk import (
     render_view,
 )
 from articraft.sdk.export import export_assembly
+from articraft.sdk.mesh import subdivide_mesh
 
 
 def test_partial_lathe_is_capped_watertight_and_axis_aware() -> None:
@@ -94,6 +95,19 @@ def test_geometry_metrics_cover_components_orientation_and_symmetry() -> None:
     symmetric = RigidBodyAssembly("symmetric")
     symmetric.rigid_body("body").add(BoxGeometry((2.0, 1.0, 1.0)), name="box")
     assert TestContext(symmetric).expect_symmetry(tolerance=1e-9)
+
+    # The two halves mirror each other in shape but not in vertex layout: the
+    # subdivided half's reflected vertices land mid-face on the coarse half,
+    # far from any of its vertices. Only a point-to-surface reading sees the
+    # symmetry.
+    uneven = RigidBodyAssembly("uneven_tessellation")
+    halves = uneven.rigid_body("body")
+    halves.add(BoxGeometry((0.02, 0.02, 0.02)).translate(-0.02, 0.0, 0.0), name="coarse")
+    halves.add(
+        subdivide_mesh(BoxGeometry((0.02, 0.02, 0.02)), levels=2).translate(0.02, 0.0, 0.0),
+        name="fine",
+    )
+    assert TestContext(uneven).expect_symmetry(plane_normal=(1.0, 0.0, 0.0), tolerance=1e-6)
 
     reversed_model = RigidBodyAssembly("reversed")
     reversed_mesh = BoxGeometry((1.0, 1.0, 1.0))

--- a/tests/test_mesh_weld.py
+++ b/tests/test_mesh_weld.py
@@ -141,6 +141,20 @@ def test_snap_to_closes_a_small_gap() -> None:
     assert fused.to_trimesh().body_count == 1
 
 
+def test_snap_to_measures_edge_to_edge_gaps_exactly() -> None:
+    # Rotated about perpendicular axes, the boxes' closest approach is between
+    # two skew mid-edges, far from every vertex. Sampling one mesh's vertices
+    # against the other's surface overstates this gap six-fold and would
+    # refuse the snap.
+    lower = BoxGeometry((0.04, 0.04, 0.04)).rotate_x(np.pi / 4)
+    upper = BoxGeometry((0.04, 0.04, 0.04)).rotate_y(np.pi / 4).translate(0.0, 0.0, 0.06)
+    gap = 0.06 - 0.04 * float(np.sqrt(2.0))
+    before = np.asarray(upper.to_trimesh().vertices.mean(axis=0))
+    moved = snap_to(lower, upper, overlap=0.0, max_move=gap * 1.2)
+    after = np.asarray(moved.to_trimesh().vertices.mean(axis=0))
+    assert float(np.linalg.norm(after - before)) == pytest.approx(gap, abs=1e-6)
+
+
 def test_snap_to_refuses_a_move_beyond_max() -> None:
     barrel = CylinderGeometry(0.008, 0.02, radial_segments=16).rotate_y(np.pi / 2)
     cap = SphereGeometry(0.02, width_segments=16, height_segments=8).translate(0.0, 0.03, 0.0)


### PR DESCRIPTION
## Change

- Buried-mesh containment in the collision kernel reads libigl fast winding numbers instead of a hand-written Moller-Trumbore crossing-parity loop. The majority vote over probe vertices stays as cheap insurance.
- `snap_to` and the weld `max_gap` check measure the true surface-to-surface minimum through FCL's BVH distance query instead of sampling each mesh's vertices against the other's surface.
- `expect_symmetry` measures the reflected vertices against the mirrored *surface* (`igl.point_mesh_squared_distance`) instead of the nearest vertex, and testing.py drops its cKDTree import.
- Mesh-health face-component labelling and weld-input connectivity run through `scipy.sparse.csgraph.connected_components`, replacing a pure-Python union-find over every mesh edge and an iterative growth loop. Weld grid coordinates come from `np.unravel_index` instead of hand-rolled index arithmetic.

## Why

All four algorithms duplicated queries that libigl, FCL, and scipy — existing hard dependencies — answer with better numerics, and two of them were measurably wrong:

- A gap whose closest approach is edge-to-edge has no vertex near the minimum, so the vertex-sampled reading overstates it (six-fold in the regression test) and `snap_to` refuses snaps the geometry allows.
- A symmetric surface whose two halves are tessellated differently has no matching vertices, so the nearest-vertex reading reports the meshing accident as an asymmetry of the part.

The parity hand-roll existed to avoid trimesh's optional rtree dependency; libigl sidesteps that without a new dependency and is immune to edge-grazing rays. The union-find ran on the hot path behind every boolean (`_require_healthy_mesh`).

## Impact

No API changes. Two behavior changes, both in the direction of the documented semantics: `snap_to`/`weld` gaps read exactly where they previously read too large, and `expect_symmetry` no longer fails symmetric parts over tessellation. Two regression tests pin these; both fail on the previous implementations.

## Checks

- `uv run --group sim pytest -q --replay` — 621 passed, 2 deselected
- `uv run basedpyright` — 0 errors
- `uv run ruff format --check .`
- `uv run ruff check .`

## Stack

Independent of the other library-consolidation PRs (scipy numerics, MjSpec translation, loop-solver swap); merges in any order.