### PR TITLE
Evaluate splines and rotations through scipy instead of by hand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "pydantic-settings>=2.14.2",
     "python-fcl>=0.7.0.11",
     "rich>=13.0.0",
-    "scipy>=1.11.0",
+    # Rotation.as_quat(scalar_first=) arrived in 1.14.
+    "scipy>=1.14",
     "trimesh>=4.11.3",
     "typer>=0.12.0",
     # 26.8 fails to publish the temporary USDZ on macOS arm64.

--- a/src/articraft/sdk/_mesh/core.py
+++ b/src/articraft/sdk/_mesh/core.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, SupportsIndex, TypeAlias, cast
 
 import numpy as np
 import trimesh
+from scipy.interpolate import CubicHermiteSpline  # pyright: ignore[reportMissingTypeStubs]
 
 from articraft.sdk.errors import ValidationError
 
@@ -963,47 +964,39 @@ class LatheGeometry(MeshGeometry):
         super().__init__(converted.vertices, converted.faces)
 
 
-def _interpolate_loft_point(
-    p0: Vec3,
-    p1: Vec3,
-    p2: Vec3,
-    p3: Vec3,
-    amount: float,
+def _interpolate_loft_span(
+    p0: Sequence[Vec3],
+    p1: Sequence[Vec3],
+    p2: Sequence[Vec3],
+    p3: Sequence[Vec3],
+    amounts: np.ndarray,
     *,
     interpolation: str,
     parameters: tuple[float, float, float, float],
     tension: float,
-) -> Vec3:
-    if interpolation == "linear":
-        return _v_lerp(p1, p2, amount)
+) -> list[list[Vec3]]:
+    """Rings between ``p1`` and ``p2``, one per sample amount.
+
+    The smooth mode is a cardinal (tension-scaled Catmull-Rom) segment; scipy
+    evaluates the same Hermite cubic from the ring values and end derivatives.
+    """
+
+    start = np.asarray(p1, dtype=np.float64)
+    end = np.asarray(p2, dtype=np.float64)
     t0, t1, t2, t3 = parameters
-    first_span = t2 - t0
-    second_span = t3 - t1
-    span = t2 - t1
-    if min(first_span, second_span, span) <= _EPS:
-        return _v_lerp(p1, p2, amount)
-    slope_scale = 1.0 - tension
-    first_derivative = _v_scale(_v_sub(p2, p0), slope_scale / first_span)
-    second_derivative = _v_scale(_v_sub(p3, p1), slope_scale / second_span)
-    amount2, amount3 = amount * amount, amount * amount * amount
-    h00 = 2.0 * amount3 - 3.0 * amount2 + 1.0
-    h10 = amount3 - 2.0 * amount2 + amount
-    h01 = -2.0 * amount3 + 3.0 * amount2
-    h11 = amount3 - amount2
-    return (
-        h00 * p1[0]
-        + h10 * span * first_derivative[0]
-        + h01 * p2[0]
-        + h11 * span * second_derivative[0],
-        h00 * p1[1]
-        + h10 * span * first_derivative[1]
-        + h01 * p2[1]
-        + h11 * span * second_derivative[1],
-        h00 * p1[2]
-        + h10 * span * first_derivative[2]
-        + h01 * p2[2]
-        + h11 * span * second_derivative[2],
-    )
+    if interpolation == "linear" or min(t2 - t0, t3 - t1, t2 - t1) <= _EPS:
+        rings = start + (end - start) * amounts[:, None, None]
+    else:
+        slope_scale = 1.0 - tension
+        first_derivative = slope_scale * (end - np.asarray(p0, dtype=np.float64)) / (t2 - t0)
+        second_derivative = slope_scale * (np.asarray(p3, dtype=np.float64) - start) / (t3 - t1)
+        spline = CubicHermiteSpline(
+            np.asarray((t1, t2)),
+            np.stack((start, end)),
+            np.stack((first_derivative, second_derivative)),
+        )
+        rings = spline(t1 + (t2 - t1) * amounts)
+    return [[(float(x), float(y), float(z)) for x, y, z in ring] for ring in rings]
 
 
 def _loft_parameter_step(start: Vec3, end: Vec3, parameterization: str) -> float:
@@ -1077,23 +1070,18 @@ def _interpolate_loft_rings(
                 ]
             )
             t3 = parameters[span + 2] if span + 2 < len(rings) else 2.0 * t2 - t1
-        for sample in range(samples):
-            amount = sample / samples
-            result.append(
-                [
-                    _interpolate_loft_point(
-                        a,
-                        b,
-                        c,
-                        d,
-                        amount,
-                        interpolation=interpolation,
-                        parameters=(t0, t1, t2, t3),
-                        tension=tension,
-                    )
-                    for a, b, c, d in zip(p0, p1, p2, p3, strict=True)
-                ]
+        result.extend(
+            _interpolate_loft_span(
+                p0,
+                p1,
+                p2,
+                p3,
+                np.arange(samples, dtype=np.float64) / samples,
+                interpolation=interpolation,
+                parameters=(t0, t1, t2, t3),
+                tension=tension,
             )
+        )
     if not close_path:
         result.append(list(rings[-1]))
     return result

--- a/src/articraft/sdk/_mesh/profiles.py
+++ b/src/articraft/sdk/_mesh/profiles.py
@@ -5,6 +5,10 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import TypedDict, Unpack
 
+import numpy as np
+from scipy.interpolate import BPoly, CubicHermiteSpline  # pyright: ignore[reportMissingTypeStubs]
+from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
+
 from articraft.sdk._mesh.core import (
     _EPS,
     LoftGeometry,
@@ -12,10 +16,7 @@ from articraft.sdk._mesh.core import (
     Vec2,
     Vec3,
     _v_add,
-    _v_dot,
     _v_norm,
-    _v_normalize,
-    _v_scale,
     _v_sub,
     _vec3,
 )
@@ -30,21 +31,16 @@ def _sample_cubic_bezier(
     if len(points) < 4 or (len(points) - 1) % 3:
         raise ValueError("Bezier control points must contain 3n + 1 points")
     steps = max(2, int(samples_per_segment))
-    result: list[tuple[float, ...]] = []
-    for segment in range((len(points) - 1) // 3):
-        p0, p1, p2, p3 = points[segment * 3 : segment * 3 + 4]
-        for index in range(steps):
-            amount = index / steps
-            inverse = 1.0 - amount
-            result.append(
-                tuple(
-                    inverse**3 * p0[axis]
-                    + 3.0 * inverse**2 * amount * p1[axis]
-                    + 3.0 * inverse * amount**2 * p2[axis]
-                    + amount**3 * p3[axis]
-                    for axis in range(dimensions)
-                )
-            )
+    segments = (len(points) - 1) // 3
+    array = np.asarray(points, dtype=np.float64)
+    # Bezier control points are Bernstein coefficients, which is BPoly's
+    # native representation: coefficient k of segment s is control point 3s+k.
+    spline = BPoly(
+        np.stack([array[k : k + 3 * segments : 3] for k in range(4)]),
+        np.arange(segments + 1, dtype=np.float64),
+    )
+    samples = np.arange(segments * steps, dtype=np.float64) / steps
+    result = [tuple(float(value) for value in row) for row in spline(samples)]
     result.append(points[-1])
     return result
 
@@ -75,43 +71,6 @@ def _tuple_distance(a: Sequence[float], b: Sequence[float]) -> float:
     return math.sqrt(sum((left - right) ** 2 for left, right in zip(a, b, strict=True)))
 
 
-def _catmull_interpolate(
-    a: Sequence[float], b: Sequence[float], ta: float, tb: float, value: float
-) -> tuple[float, ...]:
-    if abs(tb - ta) <= _EPS:
-        return tuple(a)
-    amount = (value - ta) / (tb - ta)
-    return tuple(left + (right - left) * amount for left, right in zip(a, b, strict=True))
-
-
-def _catmull_segment(
-    p0: Sequence[float],
-    p1: Sequence[float],
-    p2: Sequence[float],
-    p3: Sequence[float],
-    *,
-    steps: int,
-    alpha: float,
-) -> list[tuple[float, ...]]:
-    def advance(value: float, a: Sequence[float], b: Sequence[float]) -> float:
-        return value + max(_tuple_distance(a, b), _EPS) ** alpha
-
-    t0 = 0.0
-    t1 = advance(t0, p0, p1)
-    t2 = advance(t1, p1, p2)
-    t3 = advance(t2, p2, p3)
-    result: list[tuple[float, ...]] = []
-    for index in range(steps):
-        value = t1 + (t2 - t1) * index / steps
-        a1 = _catmull_interpolate(p0, p1, t0, t1, value)
-        a2 = _catmull_interpolate(p1, p2, t1, t2, value)
-        a3 = _catmull_interpolate(p2, p3, t2, t3, value)
-        b1 = _catmull_interpolate(a1, a2, t0, t2, value)
-        b2 = _catmull_interpolate(a2, a3, t1, t3, value)
-        result.append(_catmull_interpolate(b1, b2, t1, t2, value))
-    return result
-
-
 def _sample_catmull_rom(
     points: Sequence[Sequence[float]],
     *,
@@ -137,44 +96,35 @@ def _sample_catmull_rom(
             deduplicated.pop()
         if len(deduplicated) < 3:
             raise ValueError("closed Catmull-Rom spline requires at least three points")
-        result: list[tuple[float, ...]] = []
-        for index in range(len(deduplicated)):
-            result.extend(
-                _catmull_segment(
-                    deduplicated[(index - 1) % len(deduplicated)],
-                    deduplicated[index],
-                    deduplicated[(index + 1) % len(deduplicated)],
-                    deduplicated[(index + 2) % len(deduplicated)],
-                    steps=steps,
-                    alpha=alpha,
-                )
-            )
-        result.append(result[0])
-        return result
-    if len(deduplicated) == 2:
-        return [
-            tuple(
-                start + (end - start) * index / steps
-                for start, end in zip(deduplicated[0], deduplicated[1], strict=True)
-            )
-            for index in range(steps + 1)
-        ]
-    first = tuple(2.0 * a - b for a, b in zip(deduplicated[0], deduplicated[1], strict=True))
-    last = tuple(2.0 * a - b for a, b in zip(deduplicated[-1], deduplicated[-2], strict=True))
-    extended = [first, *deduplicated, last]
-    result = []
-    for index in range(len(deduplicated) - 1):
-        result.extend(
-            _catmull_segment(
-                extended[index],
-                extended[index + 1],
-                extended[index + 2],
-                extended[index + 3],
-                steps=steps,
-                alpha=alpha,
-            )
-        )
-    result.append(deduplicated[-1])
+        core = np.asarray(deduplicated, dtype=np.float64)
+        # Wrap-around context: one phantom point behind, two ahead, so every
+        # real segment has the neighbors the tangent formula reads.
+        extended = np.vstack([core[-1], core, core[:2]])
+        segment_count = len(core)
+    else:
+        core = np.asarray(deduplicated, dtype=np.float64)
+        if len(core) == 2:
+            amounts = np.arange(steps + 1, dtype=np.float64)[:, None] / steps
+            values = core[0] + (core[1] - core[0]) * amounts
+            return [tuple(float(value) for value in row) for row in values]
+        # Reflected phantom endpoints keep the authored end tangents.
+        extended = np.vstack([2.0 * core[0] - core[1], core, 2.0 * core[-1] - core[-2]])
+        segment_count = len(core) - 1
+
+    gaps = np.maximum(np.linalg.norm(np.diff(extended, axis=0), axis=1), _EPS) ** alpha
+    knots = np.concatenate([[0.0], np.cumsum(gaps)])
+    # The Barry-Goldman pyramid on knots (t0..t3) is the unique cubic through
+    # P1 and P2 with these endpoint derivatives, so a Hermite spline with the
+    # non-uniform Catmull-Rom tangents reproduces it exactly.
+    spans = np.diff(extended, axis=0) / np.diff(knots)[:, None]
+    central = (extended[2:] - extended[:-2]) / (knots[2:] - knots[:-2])[:, None]
+    tangents = spans[:-1] + spans[1:] - central
+    spline = CubicHermiteSpline(knots[1:-1], extended[1:-1], tangents)
+    starts = knots[1 : 1 + segment_count, None]
+    ends = knots[2 : 2 + segment_count, None]
+    samples = (starts + (ends - starts) * np.arange(steps) / steps).reshape(-1)
+    result = [tuple(float(value) for value in row) for row in spline(samples)]
+    result.append(result[0] if closed else deduplicated[-1])
     return result
 
 
@@ -224,33 +174,22 @@ def sample_arc_3d(
     angle: float,
     segments: int = 16,
 ) -> list[Vec3]:
-    start: Vec3 = (float(start_point[0]), float(start_point[1]), float(start_point[2]))
-    center = (float(center[0]), float(center[1]), float(center[2]))
-    axis = _v_normalize((float(normal[0]), float(normal[1]), float(normal[2])))
-    relative = _v_sub(start, center)
-    if _v_norm(relative) <= _EPS:
+    origin = np.asarray(center, dtype=np.float64)
+    axis = np.asarray(normal, dtype=np.float64)
+    length = float(np.linalg.norm(axis))
+    if length <= _EPS:
+        raise ValueError("arc normal must be non-zero")
+    axis /= length
+    relative = np.asarray(start_point, dtype=np.float64) - origin
+    radius = float(np.linalg.norm(relative))
+    if radius <= _EPS:
         raise ValueError("arc start_point must differ from center")
-    if abs(_v_dot(_v_normalize(relative), axis)) > 1.0 - 1e-6:
+    if abs(float(relative @ axis)) / radius > 1.0 - 1e-6:
         raise ValueError("arc radius must not be collinear with its normal")
-    result: list[Vec3] = []
-    for index in range(max(2, int(segments)) + 1):
-        local_angle = float(angle) * index / max(2, int(segments))
-        rotated = _v_add(
-            _v_add(
-                _v_scale(relative, math.cos(local_angle)),
-                _v_scale(
-                    (
-                        axis[1] * relative[2] - axis[2] * relative[1],
-                        axis[2] * relative[0] - axis[0] * relative[2],
-                        axis[0] * relative[1] - axis[1] * relative[0],
-                    ),
-                    math.sin(local_angle),
-                ),
-            ),
-            _v_scale(axis, _v_dot(axis, relative) * (1.0 - math.cos(local_angle))),
-        )
-        result.append(_v_add(center, rotated))
-    return result
+    count = max(2, int(segments))
+    angles = float(angle) * np.arange(count + 1, dtype=np.float64) / count
+    points = origin + Rotation.from_rotvec(np.outer(angles, axis)).apply(relative)
+    return [(float(x), float(y), float(z)) for x, y, z in points]
 
 
 @dataclass

--- a/src/articraft/sdk/_mesh/section_loft.py
+++ b/src/articraft/sdk/_mesh/section_loft.py
@@ -155,37 +155,21 @@ def _coerce_spec(
 def _resample_loop(points: Sequence[Vec3], count: int) -> list[Vec3]:
     if len(points) == count:
         return list(points)
-    closed = [*points, points[0]]
-    lengths = [0.0]
-    for start, end in pairwise(closed):
-        lengths.append(lengths[-1] + float(np.linalg.norm(np.subtract(end, start))))
-    total = lengths[-1]
+    array = np.asarray(points, dtype=np.float64)
+    ring = np.vstack((array, array[:1]))
+    lengths = np.concatenate([[0.0], np.cumsum(np.linalg.norm(np.diff(ring, axis=0), axis=1))])
+    total = float(lengths[-1])
     if total <= 1e-12:
         raise ValidationError("loft section perimeter must be non-zero")
-    result: list[Vec3] = []
-    edge = 0
-    for index in range(count):
-        target = total * index / count
-        while edge + 1 < len(lengths) and lengths[edge + 1] < target:
-            edge += 1
-        span = lengths[edge + 1] - lengths[edge]
-        amount = 0.0 if span <= 1e-12 else (target - lengths[edge]) / span
-        start, end = closed[edge], closed[edge + 1]
-        result.append(
-            (
-                start[0] + (end[0] - start[0]) * amount,
-                start[1] + (end[1] - start[1]) * amount,
-                start[2] + (end[2] - start[2]) * amount,
-            )
-        )
-    return result
+    targets = total * np.arange(count, dtype=np.float64) / count
+    columns = [np.interp(targets, lengths, ring[:, axis]) for axis in range(3)]
+    return [(float(x), float(y), float(z)) for x, y, z in zip(*columns, strict=True)]
 
 
 def _loop_normal(points: Sequence[Vec3]) -> np.ndarray:
-    center = np.mean(np.asarray(points, dtype=np.float64), axis=0)
-    normal = np.zeros(3, dtype=np.float64)
-    for start, end in pairwise([*points, points[0]]):
-        normal += np.cross(np.subtract(start, center), np.subtract(end, center))
+    centered = np.asarray(points, dtype=np.float64)
+    centered = centered - centered.mean(axis=0)
+    normal = np.cross(centered, np.roll(centered, -1, axis=0)).sum(axis=0)
     length = float(np.linalg.norm(normal))
     if length <= 1e-12:
         raise ValidationError("loft section must enclose a non-zero planar area")
@@ -208,20 +192,13 @@ def _align_loop(reference: Sequence[Vec3], candidate: Sequence[Vec3]) -> list[Ve
 
 
 def _sample_polyline(points: Sequence[Vec3], amount: float) -> Vec3:
-    lengths = [0.0]
-    for start, end in pairwise(points):
-        lengths.append(lengths[-1] + float(np.linalg.norm(np.subtract(end, start))))
-    target = lengths[-1] * amount
-    index = 0
-    while index + 1 < len(lengths) and lengths[index + 1] < target:
-        index += 1
-    span = lengths[index + 1] - lengths[index]
-    local = 0.0 if span <= 1e-12 else (target - lengths[index]) / span
-    start, end = points[index], points[index + 1]
+    array = np.asarray(points, dtype=np.float64)
+    lengths = np.concatenate([[0.0], np.cumsum(np.linalg.norm(np.diff(array, axis=0), axis=1))])
+    target = float(lengths[-1]) * amount
     return (
-        start[0] + (end[0] - start[0]) * local,
-        start[1] + (end[1] - start[1]) * local,
-        start[2] + (end[2] - start[2]) * local,
+        float(np.interp(target, lengths, array[:, 0])),
+        float(np.interp(target, lengths, array[:, 1])),
+        float(np.interp(target, lengths, array[:, 2])),
     )
 
 

--- a/src/articraft/sdk/_mesh/sweeps.py
+++ b/src/articraft/sdk/_mesh/sweeps.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from itertools import pairwise
 from typing import cast
 
+import numpy as np
+from scipy.interpolate import CubicHermiteSpline  # pyright: ignore[reportMissingTypeStubs]
+
 from articraft.sdk._mesh.core import (
     _EPS,
     MeshGeometry,
@@ -347,34 +350,22 @@ def _path_frames(
 def _resample_profile(points: Sequence[Vec2], count: int, *, closed: bool) -> list[Vec2]:
     if len(points) == count:
         return list(points)
-    edge_count = len(points) if closed else len(points) - 1
-    lengths = [0.0]
-    for index in range(edge_count):
-        start, end = points[index], points[(index + 1) % len(points)]
-        lengths.append(lengths[-1] + math.dist(start, end))
-    total = lengths[-1]
+    array = np.asarray(points, dtype=np.float64)
+    ring = np.vstack((array, array[:1])) if closed else array
+    lengths = np.concatenate([[0.0], np.cumsum(np.linalg.norm(np.diff(ring, axis=0), axis=1))])
+    total = float(lengths[-1])
     if total <= _EPS:
         raise ValueError("sweep profile perimeter must be positive")
-    targets = (
-        [total * index / count for index in range(count)]
-        if closed
-        else [total * index / (count - 1) for index in range(count)]
-    )
-    result: list[Vec2] = []
-    edge = 0
-    for target in targets:
-        while edge + 1 < len(lengths) - 1 and lengths[edge + 1] < target:
-            edge += 1
-        span = lengths[edge + 1] - lengths[edge]
-        amount = 0.0 if span <= _EPS else (target - lengths[edge]) / span
-        start, end = points[edge], points[(edge + 1) % len(points)]
-        result.append(
-            (
-                start[0] + (end[0] - start[0]) * amount,
-                start[1] + (end[1] - start[1]) * amount,
-            )
+    divisor = count if closed else count - 1
+    targets = total * np.arange(count, dtype=np.float64) / divisor
+    return [
+        (float(x), float(y))
+        for x, y in zip(
+            np.interp(targets, lengths, ring[:, 0]),
+            np.interp(targets, lengths, ring[:, 1]),
+            strict=True,
         )
-    return result
+    ]
 
 
 def _profile_distance(a: Sequence[Vec2], b: Sequence[Vec2]) -> float:
@@ -482,15 +473,15 @@ def _profile_derivative(
     previous_position: float,
     following_position: float,
     tension: float,
-) -> list[Vec2]:
+) -> np.ndarray:
     span = following_position - previous_position
     if span <= _EPS:
-        return [(0.0, 0.0) for _ in previous.points]
+        return np.zeros((len(previous.points), 2))
     scale = (1.0 - tension) / span
-    return [
-        ((end[0] - start[0]) * scale, (end[1] - start[1]) * scale)
-        for start, end in zip(previous.points, following.points, strict=True)
-    ]
+    return scale * (
+        np.asarray(following.points, dtype=np.float64)
+        - np.asarray(previous.points, dtype=np.float64)
+    )
 
 
 def _smooth_profile_span(
@@ -536,31 +527,20 @@ def _smooth_profile_span(
         following_position=following_position,
         tension=start.tension,
     )
-    amount2, amount3 = amount * amount, amount * amount * amount
-    h00 = 2.0 * amount3 - 3.0 * amount2 + 1.0
-    h10 = amount3 - 2.0 * amount2 + amount
-    h01 = -2.0 * amount3 + 3.0 * amount2
-    h11 = amount3 - amount2
-    span = end.position - start.position
-    return [
-        (
-            h00 * first[0]
-            + h10 * span * first_derivative[0]
-            + h01 * second[0]
-            + h11 * span * second_derivative[0],
-            h00 * first[1]
-            + h10 * span * first_derivative[1]
-            + h01 * second[1]
-            + h11 * span * second_derivative[1],
-        )
-        for first, second, first_derivative, second_derivative in zip(
-            start.points,
-            end.points,
-            start_derivative,
-            end_derivative,
-            strict=True,
-        )
-    ]
+    # The section blend is a cardinal segment; scipy evaluates the same
+    # Hermite cubic from the section profiles and their end derivatives.
+    spline = CubicHermiteSpline(
+        np.asarray((start.position, end.position)),
+        np.stack(
+            (
+                np.asarray(start.points, dtype=np.float64),
+                np.asarray(end.points, dtype=np.float64),
+            )
+        ),
+        np.stack((start_derivative, end_derivative)),
+    )
+    values = spline(start.position + (end.position - start.position) * amount)
+    return [(float(x), float(y)) for x, y in values]
 
 
 def _profile_at(

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -8,12 +8,12 @@ from types import MappingProxyType
 from typing import TypeAlias, cast
 
 import numpy as np
-import trimesh
+from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
 
 from articraft.sdk._values import _as_identifier, _as_name
 from articraft.sdk.bodies import RigidBody, RigidBodyRef
 from articraft.sdk.errors import LoopClosureError, ValidationError
-from articraft.sdk.frames import WORLD, BodyFrame, JointFrame, _WorldEndpoint
+from articraft.sdk.frames import WORLD, BodyFrame, JointFrame, _matrix_rpy, _WorldEndpoint
 from articraft.sdk.mass import MassProperties
 from articraft.sdk.physics import BodyState, PhysicsScene
 
@@ -1077,7 +1077,7 @@ def _rotation_values(joint: Joint, relative: Mat4) -> dict[JointAxis, float]:
     ]
     rotation = np.asarray(relative[:3, :3], dtype=np.float64)
     if len(free) > 1:
-        angles = trimesh.transformations.euler_from_matrix(relative, axes="sxyz")
+        angles = _matrix_rpy(rotation)
         return {
             JointAxis.ROT_X: float(angles[0]),
             JointAxis.ROT_Y: float(angles[1]),
@@ -1094,13 +1094,7 @@ def _rotation_values(joint: Joint, relative: Mat4) -> dict[JointAxis, float]:
         cosine = float(np.trace(rotation) - direction @ rotation @ direction) * 0.5
         angle = math.atan2(sine, cosine)
         values[free[0]] = angle
-        rotation = (
-            np.asarray(
-                trimesh.transformations.rotation_matrix(-angle, direction),
-                dtype=np.float64,
-            )[:3, :3]
-            @ rotation
-        )
+        rotation = Rotation.from_rotvec(-angle * direction).as_matrix() @ rotation
     leftover = _rotation_vector(rotation)
     for axis in (JointAxis.ROT_X, JointAxis.ROT_Y, JointAxis.ROT_Z):
         if axis not in free:
@@ -1111,17 +1105,7 @@ def _rotation_values(joint: Joint, relative: Mat4) -> dict[JointAxis, float]:
 def _rotation_vector(rotation: np.ndarray) -> np.ndarray:
     """The axis-angle vector of a rotation matrix; zero for the identity."""
 
-    embedded = np.identity(4, dtype=np.float64)
-    embedded[:3, :3] = rotation
-    quaternion = trimesh.transformations.quaternion_from_matrix(embedded)
-    vector = np.asarray(quaternion[1:], dtype=np.float64)
-    length = float(np.linalg.norm(vector))
-    if length < 1e-12:
-        return np.zeros(3, dtype=np.float64)
-    angle = 2.0 * math.atan2(length, float(quaternion[0]))
-    if angle > math.pi:
-        angle -= 2.0 * math.pi
-    return vector * (angle / length)
+    return Rotation.from_matrix(rotation).as_rotvec()
 
 
 def _motion_matrix(joint: Joint, positions: Mapping[str, float]) -> Mat4:
@@ -1135,16 +1119,15 @@ def _motion_matrix(joint: Joint, positions: Mapping[str, float]) -> Mat4:
         else:
             translation[axis.component] = value
     matrix = np.identity(4, dtype=np.float64)
-    matrix[:3, 3] = translation
-    return matrix @ np.asarray(
-        trimesh.transformations.euler_matrix(*rotation, axes="sxyz"), dtype=np.float64
-    )
+    matrix[:3, :3] = Rotation.from_euler("xyz", rotation).as_matrix()
+    motion = np.identity(4, dtype=np.float64)
+    motion[:3, 3] = translation
+    return motion @ matrix
 
 
 def _frame_matrix(frame: JointFrame) -> Mat4:
-    matrix = np.asarray(
-        trimesh.transformations.euler_matrix(*frame.rpy, axes="sxyz"), dtype=np.float64
-    )
+    matrix = np.identity(4, dtype=np.float64)
+    matrix[:3, :3] = Rotation.from_euler("xyz", frame.rpy).as_matrix()
     matrix[:3, 3] = np.asarray(frame.xyz, dtype=np.float64)
     return matrix
 
@@ -1245,7 +1228,7 @@ def _matrix_tuple(matrix: Mat4) -> Matrix4:
 
 
 def _matrix_frame(matrix: Mat4) -> JointFrame:
-    rpy = trimesh.transformations.euler_from_matrix(matrix, axes="sxyz")
+    rpy = _matrix_rpy(np.asarray(matrix)[:3, :3])
     return JointFrame(
         xyz=(float(matrix[0, 3]), float(matrix[1, 3]), float(matrix[2, 3])),
         rpy=(float(rpy[0]), float(rpy[1]), float(rpy[2])),

--- a/src/articraft/sdk/export.py
+++ b/src/articraft/sdk/export.py
@@ -866,18 +866,23 @@ def _normal_data(mesh, crease_angle: float) -> tuple[np.ndarray, str]:
     vertex_faces = np.asarray(mesh.vertex_faces, dtype=np.int64)
     face_areas = np.asarray(mesh.area_faces, dtype=np.float64)
     cosine = math.cos(crease_angle)
-    corner_normals = np.empty((len(faces), 3, 3), dtype=np.float64)
-    for face_index, face in enumerate(faces):
-        reference = face_normals[face_index]
-        for corner_index, vertex_index in enumerate(face):
-            adjacent = vertex_faces[vertex_index]
-            adjacent = adjacent[adjacent >= 0]
-            aligned = adjacent[(face_normals[adjacent] @ reference) >= cosine]
-            weighted = (face_normals[aligned] * face_areas[aligned, None]).sum(axis=0)
-            length = float(np.linalg.norm(weighted))
-            corner_normals[face_index, corner_index] = (
-                reference if length <= 1e-14 else weighted / length
-            )
+    # Every corner's candidate faces at once: (face, corner, neighbor), with
+    # trimesh's -1 padding masked out. A corner averages the area-weighted
+    # normals of the neighbors within the crease angle of its own face.
+    adjacent = vertex_faces[faces]
+    valid = adjacent >= 0
+    safe = np.where(valid, adjacent, 0)
+    neighbor_normals = face_normals[safe]
+    aligned = valid & (np.einsum("fcnj,fj->fcn", neighbor_normals, face_normals) >= cosine)
+    weights = np.where(aligned, face_areas[safe], 0.0)
+    corner_normals = np.einsum("fcnj,fcn->fcj", neighbor_normals, weights)
+    lengths = np.linalg.norm(corner_normals, axis=2)
+    flat = lengths <= 1e-14
+    corner_normals = np.where(
+        flat[..., None],
+        np.broadcast_to(face_normals[:, None, :], corner_normals.shape),
+        corner_normals / np.where(flat, 1.0, lengths)[..., None],
+    )
     return corner_normals.reshape((-1, 3)).astype(np.float32), UsdGeom.Tokens.faceVarying
 
 
@@ -1007,8 +1012,8 @@ def _quat(matrix: Gf.Matrix4d) -> Gf.Quatf:
 
 
 def _gf_matrix(matrix) -> Gf.Matrix4d:
-    rows = tuple(tuple(float(matrix[column, row]) for column in range(4)) for row in range(4))
-    return Gf.Matrix4d(rows)
+    # Transposed because Gf matrices act on row vectors.
+    return Gf.Matrix4d(np.asarray(matrix, dtype=np.float64).T.tolist())
 
 
 def _safe_name_map(names: Iterable[str]) -> dict[str, str]:
@@ -1122,20 +1127,10 @@ def _audit_assembly_usdz(
         if points is None or faces is None:
             raise RuntimeError(f"USDZ audit found an empty mesh at {prim.GetPath()}")
         triangle_count += len(faces) // 3
-        matrix = cache.GetLocalToWorldTransform(prim)
-        exported_points.append(
-            np.asarray(
-                [
-                    tuple(
-                        matrix.Transform(
-                            Gf.Vec3d(float(point[0]), float(point[1]), float(point[2]))
-                        )
-                    )
-                    for point in points
-                ],
-                dtype=np.float64,
-            )
-        )
+        # Gf matrices act on row vectors, so points transform as p @ M.
+        matrix = np.asarray(cache.GetLocalToWorldTransform(prim), dtype=np.float64)
+        local_points = np.asarray(points, dtype=np.float64)
+        exported_points.append(local_points @ matrix[:3, :3] + matrix[3, :3])
         normals = mesh.GetNormalsAttr().Get()
         if normals is None or len(normals) == 0:
             raise RuntimeError(f"USDZ audit found a mesh without normals at {prim.GetPath()}")

--- a/src/articraft/sdk/frames.py
+++ b/src/articraft/sdk/frames.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import math
+import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 import numpy as np
-import trimesh
 from build123d import Axis, Location, Plane, Vector
 from build123d.topology import Edge, Face, Shape, Vertex
+from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
 
 from articraft.sdk._mesh.core import MeshGeometry
 from articraft.sdk.errors import ValidationError
@@ -137,13 +138,27 @@ def _edge_location(edge: Edge) -> Location:
     return Axis(edge.center(), edge.tangent_at()).location
 
 
+def _matrix_rpy(rotation: np.ndarray) -> np.ndarray:
+    """Extrinsic XYZ Euler angles of a rotation matrix.
+
+    At gimbal lock scipy warns that it zeroes the third angle. That is simply
+    one of the equivalent decompositions of an ambiguous reading, so the
+    warning is suppressed; callers that must tell the splits apart already
+    reconcile against the recomposed rotation.
+    """
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return Rotation.from_matrix(rotation).as_euler("xyz")
+
+
 def _location_frame(location: Location) -> JointFrame:
     transform = location.wrapped.Transformation()
-    matrix = np.identity(4, dtype=np.float64)
-    for row in range(3):
-        for column in range(4):
-            matrix[row, column] = transform.Value(row + 1, column + 1)
-    orientation = trimesh.transformations.euler_from_matrix(matrix, axes="sxyz")
+    matrix = np.asarray(
+        [[transform.Value(row + 1, column + 1) for column in range(4)] for row in range(3)],
+        dtype=np.float64,
+    )
+    orientation = _matrix_rpy(matrix[:, :3])
     return JointFrame(
         xyz=(float(matrix[0, 3]), float(matrix[1, 3]), float(matrix[2, 3])),
         rpy=(

--- a/src/articraft/sdk/mass.py
+++ b/src/articraft/sdk/mass.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import trimesh
+from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
 
 from articraft.sdk._values import Vec3, _as_vec3
 from articraft.sdk.errors import ValidationError
@@ -305,30 +306,5 @@ def _combine(meshes: list[trimesh.Trimesh], *, part_name: str) -> trimesh.Trimes
 def _quaternion(rotation: np.ndarray) -> tuple[float, float, float, float]:
     """A (w, x, y, z) quaternion for a right-handed rotation matrix."""
 
-    trace = float(rotation[0, 0] + rotation[1, 1] + rotation[2, 2])
-    if trace > 0.0:
-        scale = 0.5 / ((trace + 1.0) ** 0.5)
-        w = 0.25 / scale
-        x = float(rotation[2, 1] - rotation[1, 2]) * scale
-        y = float(rotation[0, 2] - rotation[2, 0]) * scale
-        z = float(rotation[1, 0] - rotation[0, 1]) * scale
-    elif rotation[0, 0] > rotation[1, 1] and rotation[0, 0] > rotation[2, 2]:
-        scale = 2.0 * ((1.0 + rotation[0, 0] - rotation[1, 1] - rotation[2, 2]) ** 0.5)
-        w = float(rotation[2, 1] - rotation[1, 2]) / scale
-        x = 0.25 * scale
-        y = float(rotation[0, 1] + rotation[1, 0]) / scale
-        z = float(rotation[0, 2] + rotation[2, 0]) / scale
-    elif rotation[1, 1] > rotation[2, 2]:
-        scale = 2.0 * ((1.0 + rotation[1, 1] - rotation[0, 0] - rotation[2, 2]) ** 0.5)
-        w = float(rotation[0, 2] - rotation[2, 0]) / scale
-        x = float(rotation[0, 1] + rotation[1, 0]) / scale
-        y = 0.25 * scale
-        z = float(rotation[1, 2] + rotation[2, 1]) / scale
-    else:
-        scale = 2.0 * ((1.0 + rotation[2, 2] - rotation[0, 0] - rotation[1, 1]) ** 0.5)
-        w = float(rotation[1, 0] - rotation[0, 1]) / scale
-        x = float(rotation[0, 2] + rotation[2, 0]) / scale
-        y = float(rotation[1, 2] + rotation[2, 1]) / scale
-        z = 0.25 * scale
-    norm = (w * w + x * x + y * y + z * z) ** 0.5
-    return (w / norm, x / norm, y / norm, z / norm)
+    w, x, y, z = Rotation.from_matrix(rotation).as_quat(canonical=True, scalar_first=True)
+    return (float(w), float(x), float(y), float(z))

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1685,17 +1685,9 @@ def _geometry_selector(part: RigidBodyRef | None, shape: str | None) -> str:
 
 
 def _signed_mesh_volume(mesh: trimesh.Trimesh) -> float:
-    vertices = np.asarray(mesh.vertices, dtype=np.float64)
-    faces = np.asarray(mesh.faces, dtype=np.int64)
-    triangles = vertices[faces]
-    return float(
-        np.einsum(
-            "ij,ij->i",
-            triangles[:, 0],
-            np.cross(triangles[:, 1], triangles[:, 2]),
-        ).sum()
-        / 6.0
-    )
+    # trimesh's surface integral keeps the winding sign, which is the signal
+    # the orientation checks read.
+    return float(mesh.volume)
 
 
 def _pose_dicts(
@@ -1735,11 +1727,9 @@ def _articulation_sweep_values(
         return [0.0]
     if high <= low:
         return [low]
-    # Clamp against float overshoot: the last step can land a hair past the
-    # upper limit and a strict limit check would reject the joint's own range.
-    return [
-        min(max(low + (high - low) * index / (samples - 1), low), high) for index in range(samples)
-    ]
+    # linspace hits both limits exactly, so the strict limit check never sees
+    # a last step that lands a hair past the joint's own range.
+    return [float(value) for value in np.linspace(low, high, samples)]
 
 
 def _articulation_name(value: object) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-fcl", specifier = ">=0.7.0.11" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "scipy", specifier = ">=1.11.0" },
+    { name = "scipy", specifier = ">=1.14" },
     { name = "trimesh", specifier = ">=4.11.3" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "usd-core", specifier = ">=26.5,<26.8" },


### PR DESCRIPTION
## Change

- **Splines.** Bezier sampling builds a `scipy.interpolate.BPoly` — Bernstein coefficients are exactly what cubic Bezier control points are. Catmull-Rom sampling becomes a `CubicHermiteSpline` with the standard non-uniform tangents, which reproduces the hand-written Barry-Goldman pyramid exactly. Loft and sweep section blends evaluate the same cardinal Hermite through scipy over whole rings at once instead of per point, per axis.
- **Rotations.** Arc sampling (`Rotation.from_rotvec`), joint-frame Euler↔matrix conversions, axis-angle vectors (`as_rotvec`), and the mass principal-axes quaternion all go through `scipy.spatial.transform.Rotation`, retiring the hand-rolled Rodrigues expansion, Shepperd quaternion branch, and per-element OCCT matrix copies.
- **Misc numerics.** Arc-length resampling of profiles/loops/polylines is `np.interp` on cumulative lengths (three near-duplicate hand-rolled resamplers reduced to the same idiom); sweep values come from `np.linspace`, whose exact endpoints retire a documented clamp against float overshoot; signed mesh volume is trimesh's; the export audit transforms mesh points as one matrix product instead of per-point `Gf.Vec3d` calls; crease-angle corner normals compute in one vectorized gather instead of a Python loop over every corner of every face.

## Why

`profiles.py` was 547 lines of numerics using no library at all — not even numpy — and the same Hermite basis was expanded by hand in three files. These are textbook routines with canonical implementations in dependencies the SDK already ships. Delegating them removes ~160 net lines, kills the two per-mesh Python hot loops (corner normals at export, loft ring interpolation), and names the math: a reader sees `CubicHermiteSpline` and the Catmull-Rom tangent formula instead of reverse-engineering an unrolled basis.

## Impact

No behavior change by construction, and verified: every replaced routine was compared against its predecessor on randomized inputs (Bezier 2D/3D, open/closed Catmull-Rom at α ∈ {0, 0.5, 1}, arcs, lofts across all parameterizations and tensions, sectioned sweeps, crease normals, `trimesh sxyz` vs scipy extrinsic `xyz` over random rotations) — worst deviation 4.4e-15. One user-visible difference: scipy warns at gimbal lock where trimesh chose a split silently; a shared helper (`_matrix_rpy`) suppresses the warning since equivalent decompositions are already reconciled downstream.

Deliberately *not* converted, with reasons in place: the tuple-based parallel-transport frame code in `sweeps.py` (a piecemeal scipy swap just hides the same formula behind array conversions — that's the numpy-backed `MeshGeometry` follow-up), the identity-keyed 17-line graph walks in `assembly.py` (an index-map for csgraph would net more code), the 4-line parallel-axis theorem in `mass.py`, and the manifold3d extrude/revolve swap (tessellation-changing, doesn't belong in a no-output-change PR).

## Checks

- `uv run --group sim pytest -q --replay` — 620 passed, 2 deselected
- `uv run basedpyright` — 0 errors
- `uv run ruff format --check .`
- `uv run ruff check .`

## Stack

Independent of the other library-consolidation PRs (#130 geometry queries, MjSpec translation, loop-solver swap); merges in any order.