### PR TITLE
Validate every SDK number through one implementation

### DIFF
--- a/src/articraft/sdk/_values.py
+++ b/src/articraft/sdk/_values.py
@@ -2,12 +2,15 @@
 
 These outlived the joint module that used to own them: a vector is a vector
 whether it describes a joint frame, a centre of mass, or a velocity.
+
+``field_name`` is positional-or-keyword on purpose. Callers here grew up in
+separate modules with separate habits, and both spellings are in use.
 """
 
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Iterable
 from typing import TypeAlias, cast
 
 from articraft.sdk.errors import ValidationError
@@ -15,7 +18,7 @@ from articraft.sdk.errors import ValidationError
 Vec3: TypeAlias = tuple[float, float, float]
 
 
-def _as_vec3(value: Sequence[float], *, field_name: str) -> Vec3:
+def _as_vec3(value: Iterable[float], field_name: str) -> Vec3:
     if isinstance(value, (str, bytes)):
         raise ValidationError(f"{field_name} must have 3 numeric values")
     try:
@@ -29,7 +32,7 @@ def _as_vec3(value: Sequence[float], *, field_name: str) -> Vec3:
     return values
 
 
-def _as_name(value: object, *, field_name: str) -> str:
+def _as_name(value: object, field_name: str) -> str:
     if not isinstance(value, str):
         raise ValidationError(f"{field_name} must be a string")
     name = value.strip()
@@ -38,7 +41,7 @@ def _as_name(value: object, *, field_name: str) -> str:
     return name
 
 
-def _as_identifier(value: object, *, field_name: str) -> str:
+def _as_identifier(value: object, field_name: str) -> str:
     """A name that survives every namespace it flows into, verbatim.
 
     Assembly, rigid body, joint, and articulation names become USD prim
@@ -48,7 +51,7 @@ def _as_identifier(value: object, *, field_name: str) -> str:
     one joint's name collide with another's DOF id.
     """
 
-    name = _as_name(value, field_name=field_name)
+    name = _as_name(value, field_name)
     if not name.isidentifier() or not name.isascii():
         raise ValidationError(
             f"{field_name} must be an identifier: letters, digits, and underscores, "
@@ -57,24 +60,33 @@ def _as_identifier(value: object, *, field_name: str) -> str:
     return name
 
 
-def _optional_finite(value: object | None, *, field_name: str) -> float | None:
-    if value is None:
-        return None
-    return _finite(value, field_name=field_name)
+def _finite(value: object, field_name: str) -> float:
+    """Every number the SDK accepts passes through here.
 
+    ``OverflowError`` matters as much as ``ValueError``: ``float()`` raises it
+    for an int too large to convert, and letting it escape turns a modelling
+    mistake into a crash instead of feedback the author can act on. Copies of
+    this check that omitted it did exactly that.
+    """
 
-def _positive_finite(value: object, *, field_name: str) -> float:
-    result = _finite(value, field_name=field_name)
-    if result <= 0.0:
-        raise ValidationError(f"{field_name} must be positive")
-    return result
-
-
-def _finite(value: object, *, field_name: str) -> float:
     try:
         result = float(cast(str, value))
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValidationError(f"{field_name} must be numeric") from exc
     if not math.isfinite(result):
         raise ValidationError(f"{field_name} must be finite")
+    return result
+
+
+def _positive(value: object, field_name: str) -> float:
+    result = _finite(value, field_name)
+    if result <= 0.0:
+        raise ValidationError(f"{field_name} must be positive")
+    return result
+
+
+def _non_negative(value: object, field_name: str) -> float:
+    result = _finite(value, field_name)
+    if result < 0.0:
+        raise ValidationError(f"{field_name} must be non-negative")
     return result

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -10,7 +10,7 @@ from typing import TypeAlias, cast
 import numpy as np
 import trimesh
 
-from articraft.sdk._values import _as_identifier, _as_name
+from articraft.sdk._values import _as_identifier, _as_name, _finite, _positive
 from articraft.sdk.bodies import RigidBody, RigidBodyRef
 from articraft.sdk.errors import LoopClosureError, ValidationError
 from articraft.sdk.frames import WORLD, BodyFrame, JointFrame, _WorldEndpoint
@@ -275,8 +275,8 @@ class ResolvedRigidBodyAssembly:
                 f"physics state rigid bodies do not match the assembly: "
                 f"missing={missing!r} unexpected={unexpected!r}"
             )
-        linear_tolerance = _positive_tolerance(linear_tolerance, "linear tolerance")
-        angular_tolerance = _positive_tolerance(angular_tolerance, "angular tolerance")
+        linear_tolerance = _positive(linear_tolerance, "linear tolerance")
+        angular_tolerance = _positive(angular_tolerance, "angular tolerance")
         matrices = {
             body.name: _as_matrix4(
                 state.body_poses[body.name], field_name=f"physics state pose for {body.name!r}"
@@ -548,7 +548,7 @@ class RigidBodyAssembly:
             )
             for joint in self.joints
         )
-        has_closed_loops = _graph_has_cycle(tuple(self.rigid_bodies), tuple(self.joints))
+        has_closed_loops = _graph_has_cycle(tuple(self.joints))
         transforms = _propagate_transforms(
             tuple(self.rigid_bodies),
             tuple(self.joints),
@@ -667,9 +667,7 @@ def _resolve_articulations(
     for articulation in assembly.articulations:
         selected = articulation.joints
         if selected is None:
-            if len(assembly.articulations) != 1 or _graph_has_cycle(
-                tuple(assembly.rigid_bodies), tuple(assembly.joints)
-            ):
+            if len(assembly.articulations) != 1 or _graph_has_cycle(tuple(assembly.joints)):
                 raise ValidationError(
                     f"articulation {articulation.name!r} requires explicit joints because "
                     "the assembly topology is not one unambiguous tree"
@@ -1176,8 +1174,9 @@ def _nodes_connected(nodes: set[JointEndpoint], joints: Iterable[Joint]) -> bool
     return nodes <= visited
 
 
-def _graph_has_cycle(bodies: tuple[RigidBody, ...], joints: tuple[Joint, ...]) -> bool:
-    del bodies
+def _graph_has_cycle(joints: tuple[Joint, ...]) -> bool:
+    """A cycle is a property of the edges; the body list never mattered."""
+
     return _edge_graph_has_cycle(joints)
 
 
@@ -1202,23 +1201,6 @@ def _edge_graph_has_cycle(joints: Iterable[Joint]) -> bool:
 
 def _body_name(value: RigidBodyRef, *, field_name: str) -> str:
     return _as_name(value if isinstance(value, str) else value.name, field_name=field_name)
-
-
-def _finite(value: object, *, field_name: str) -> float:
-    try:
-        result = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValidationError(f"{field_name} must be numeric") from exc
-    if not math.isfinite(result):
-        raise ValidationError(f"{field_name} must be finite")
-    return result
-
-
-def _positive_tolerance(value: object, field_name: str) -> float:
-    result = _finite(value, field_name=field_name)
-    if result <= 0.0:
-        raise ValidationError(f"{field_name} must be positive")
-    return result
 
 
 def _as_matrix4(value: object, *, field_name: str) -> Mat4:

--- a/src/articraft/sdk/frames.py
+++ b/src/articraft/sdk/frames.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import math
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
 import trimesh
@@ -11,6 +10,7 @@ from build123d import Axis, Location, Plane, Vector
 from build123d.topology import Edge, Face, Shape, Vertex
 
 from articraft.sdk._mesh.core import MeshGeometry
+from articraft.sdk._values import _as_vec3 as _vec3
 from articraft.sdk.errors import ValidationError
 
 if TYPE_CHECKING:
@@ -152,18 +152,6 @@ def _location_frame(location: Location) -> JointFrame:
             float(orientation[2]),
         ),
     )
-
-
-def _vec3(value: Iterable[float], *, field_name: str) -> Vec3:
-    if isinstance(value, (str, bytes)):
-        raise ValidationError(f"{field_name} must have 3 numeric values")
-    try:
-        values = tuple(float(component) for component in value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValidationError(f"{field_name} must have 3 numeric values") from exc
-    if len(values) != 3 or any(not math.isfinite(component) for component in values):
-        raise ValidationError(f"{field_name} must have 3 finite numeric values")
-    return cast(Vec3, values)
 
 
 __all__ = ["WORLD", "BodyFrame", "FrameSource", "JointFrame"]

--- a/src/articraft/sdk/mass.py
+++ b/src/articraft/sdk/mass.py
@@ -15,13 +15,12 @@ a mass, centre of mass, and inertia out. It lives beside the override so that
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 
 import numpy as np
 import trimesh
 
-from articraft.sdk._values import Vec3, _as_vec3
+from articraft.sdk._values import Vec3, _as_vec3, _positive
 from articraft.sdk.errors import ValidationError
 from articraft.sdk.materials import Material
 
@@ -77,16 +76,6 @@ class MassProperties:
             object.__setattr__(self, "diagonal_inertia", inertia)
         if self.principal_axes is not None:
             object.__setattr__(self, "principal_axes", _as_quat(self.principal_axes))
-
-
-def _positive(value: object, *, field_name: str) -> float:
-    try:
-        number = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError) as exc:
-        raise ValidationError(f"{field_name} must be a number") from exc
-    if not math.isfinite(number) or number <= 0.0:
-        raise ValidationError(f"{field_name} must be a positive, finite number")
-    return number
 
 
 def _as_quat(value: object) -> tuple[float, float, float, float]:

--- a/src/articraft/sdk/materials.py
+++ b/src/articraft/sdk/materials.py
@@ -29,6 +29,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import ClassVar, TypeAlias
 
+from articraft.sdk._values import _positive
 from articraft.sdk.errors import ValidationError
 
 Color: TypeAlias = tuple[float, float, float, float]
@@ -181,16 +182,6 @@ def _as_friction(value: object, *, name: str) -> Friction:
         if not math.isfinite(coefficient) or coefficient < 0.0:
             raise ValidationError(f"material {name!r} friction must be non-negative and finite")
     return (numbers[0], numbers[1])
-
-
-def _positive(value: object, *, field_name: str) -> float:
-    try:
-        number = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError) as exc:
-        raise ValidationError(f"{field_name} must be a number") from exc
-    if not math.isfinite(number) or number <= 0.0:
-        raise ValidationError(f"{field_name} must be a positive, finite number")
-    return number
 
 
 def _as_color(value: Sequence[float], *, field_name: str) -> Color:

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -24,6 +24,8 @@ from articraft.sdk._collision import (
 )
 from articraft.sdk._mesh.core import geometry_to_trimesh
 from articraft.sdk._mesh.health import MeshHealthIssue, analyze_mesh_health
+from articraft.sdk._values import _as_vec3 as _vec3
+from articraft.sdk._values import _finite, _non_negative
 from articraft.sdk.assembly import (
     WORLD,
     Joint,
@@ -1665,18 +1667,6 @@ def _artifact_kind(path: Path) -> str:
     )
 
 
-def _vec3(value: Sequence[float], field_name: str) -> Vec3:
-    if isinstance(value, str | bytes):
-        raise ValidationError(f"{field_name} must contain 3 numeric values")
-    try:
-        values = tuple(_finite(item, field_name) for item in value)
-    except TypeError as exc:
-        raise ValidationError(f"{field_name} must contain 3 numeric values") from exc
-    if len(values) != 3:
-        raise ValidationError(f"{field_name} must contain 3 numeric values")
-    return cast(Vec3, values)
-
-
 def _geometry_selector(part: RigidBodyRef | None, shape: str | None) -> str:
     if part is None:
         return "model"
@@ -1777,23 +1767,6 @@ def _axis_names(axes: str | Sequence[str]) -> tuple[str, ...]:
 
 def _axis_index(axis: str) -> int:
     return {"x": 0, "y": 1, "z": 2}[axis]
-
-
-def _finite(value: object, field_name: str) -> float:
-    try:
-        result = float(cast(str, value))
-    except (TypeError, ValueError) as exc:
-        raise ValidationError(f"{field_name} must be numeric") from exc
-    if not math.isfinite(result):
-        raise ValidationError(f"{field_name} must be finite")
-    return result
-
-
-def _non_negative(value: object, field_name: str) -> float:
-    result = _finite(value, field_name)
-    if result < 0.0:
-        raise ValidationError(f"{field_name} must be non-negative")
-    return result
 
 
 def _collision_details(query: CollisionQuery) -> str:

--- a/tests/test_shared_validators.py
+++ b/tests/test_shared_validators.py
@@ -1,0 +1,49 @@
+"""Every SDK module validates numbers through one implementation.
+
+These used to be copied per module, and the copies drifted: four of them
+omitted ``OverflowError`` from the ``except`` clause, so a value too large to
+convert escaped as a crash instead of the ValidationError the author needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from articraft.sdk import _values, assembly, frames, mass, materials, testing
+from articraft.sdk.errors import ValidationError
+
+TOO_LARGE = 10**400  # an int float() rejects with OverflowError, not ValueError
+
+
+def test_every_module_shares_one_implementation() -> None:
+    assert testing._finite is _values._finite
+    assert assembly._finite is _values._finite
+    assert testing._vec3 is _values._as_vec3
+    assert frames._vec3 is _values._as_vec3
+    assert mass._positive is _values._positive
+    assert materials._positive is _values._positive
+    assert assembly._positive is _values._positive
+    assert testing._non_negative is _values._non_negative
+
+
+@pytest.mark.parametrize(
+    ("validate", "value"),
+    [
+        (_values._finite, TOO_LARGE),
+        (_values._positive, TOO_LARGE),
+        (_values._non_negative, TOO_LARGE),
+        (_values._as_vec3, (TOO_LARGE, 0.0, 0.0)),
+    ],
+)
+def test_a_value_too_large_to_convert_is_a_validation_error(validate, value) -> None:
+    """Not an OverflowError: the author needs feedback, not a stack trace."""
+
+    with pytest.raises(ValidationError):
+        validate(value, "field")
+
+
+def test_field_name_may_be_positional_or_keyword() -> None:
+    """Both spellings are in use across the modules that share these."""
+
+    assert _values._finite(1.5, "field") == 1.5
+    assert _values._finite(1.5, field_name="field") == 1.5


### PR DESCRIPTION
Follow-up to the cutover cleanup. Net **−65 lines**.

## The actual defect

The same validators were copied into six modules, and the copies drifted. Four omitted `OverflowError` from their `except` clause — which `float()` raises for an int too large to convert, rather than `ValueError`:

```
_values._finite       -> ValidationError     frames._vec3        -> ValidationError
assembly._finite      -> ValidationError     testing._vec3       -> LEAKED OverflowError
testing._finite       -> LEAKED OverflowError
mass._positive        -> LEAKED OverflowError
materials._positive   -> LEAKED OverflowError
```

`ValidationError` is how the SDK hands a modelling mistake back to the author as feedback. A leaked `OverflowError` is a crash instead.

**Severity is low** — the trigger is roughly `10**309` or larger, which realistic authored dimensions don't reach, and `inf`/`nan` were already caught by the `isfinite` check all copies shared. Filing it as a cleanup, not a fix for anything seen in the wild.

## Why dedupe rather than patch four `except` clauses

The copies *are* the bug. Adding `OverflowError` in four places closes today's divergence and leaves the next one free to happen. `_values` now owns `_finite`, `_positive`, `_non_negative`, and `_as_vec3`; every module imports them.

`field_name` is positional-or-keyword because the modules grew up apart and both spellings are in use — that keeps 42 call sites untouched and the diff to deletions.

## Also removed

- `_optional_finite` / `_positive_finite` — no caller since the joint module that owned them was deleted. The file's docstring already admitted they'd "outlived" it.
- The `bodies` argument to `_graph_has_cycle`, discarded by `del bodies` on the function's first line. A cycle is a property of the edges.

## Not touched

`_body_name` appears in both `assembly.py` and `export.py`, but they're different functions sharing a name — one validates a `RigidBodyRef`, the other reads `.name` off an endpoint the caller already checked.

## Checks

629 pass (6 new), ruff clean, basedpyright clean. `tests/test_shared_validators.py` asserts each module resolves to the same function object, so a re-copied helper fails the build.