### PR TITLE
Build the MuJoCo model as a spec instead of writing MJCF text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ Issues = "https://github.com/mattzh72/articraft/issues"
 
 [dependency-groups]
 sim = [
-    "mujoco>=3.2",
+    # MjSpec, which the translator builds models with, is stable since 3.3.
+    "mujoco>=3.3",
 ]
 dev = [
     "basedpyright>=1.39.9",

--- a/src/articraft/simulate.py
+++ b/src/articraft/simulate.py
@@ -681,10 +681,17 @@ def _build_spec(usdz: Path) -> Any:
         equality.name2 = joint.child
         equality.solref = [0.004, 1.0]
         equality.solimp = [0.99, 0.999, 0.0001, 0.5, 2.0]
+        # A fresh equality's data starts at the defaults of a *joint* coupling,
+        # not at zero; anything left over reads as an authored anchor or
+        # relative pose. Start from the clean slate the MJCF parser produces:
+        # zeros, with torquescale at its default of one.
+        equality.data[:] = 0.0
+        equality.data[10] = 1.0
         if joint.kind is None:
-            # A weld with no authored relpose holds the compiled rest pose.
+            # A weld whose relpose quaternion is all zero holds the relative
+            # pose the bodies compile at, which is the honest reading of a
+            # rigidly braced pair.
             equality.type = mujoco.mjtEq.mjEQ_WELD  # pyright: ignore[reportAttributeAccessIssue]
-            equality.data[10] = 1.0  # torquescale, the MJCF default
         else:
             # A hinge pin holds a shared point; the connect constraint is
             # exactly that, anchored on the parent side of the pin.

--- a/src/articraft/simulate.py
+++ b/src/articraft/simulate.py
@@ -5,10 +5,12 @@ box when you press play. This loads what we export -- rigid bodies, mass, collid
 contact materials, joints -- into MuJoCo, drops it on a floor, and reports what
 happened.
 
-MuJoCo has no USD importer, so the stage is translated to MJCF here. That
-translation is the part most likely to be wrong, so it is deliberately literal:
-every value comes from the schema we authored, and units are converted in exactly
-one place.
+MuJoCo's own USD import is experimental and absent from its PyPI wheels, so the
+stage is translated here -- directly into a ``mujoco.MjSpec`` model rather than
+into MJCF text. That translation is the part most likely to be wrong, so it is
+deliberately literal: every value comes from the schema we authored, and units
+are converted in exactly one place. ``write_mjcf`` serializes the compiled spec
+as MJCF for inspection.
 
 What this does **not** cover. A material authors static friction, dynamic
 friction, and restitution; only dynamic friction reaches the simulation. MuJoCo
@@ -25,7 +27,6 @@ MuJoCo is an optional dependency. Install it with ``uv sync --group sim``.
 from __future__ import annotations
 
 import math
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -40,8 +41,8 @@ from pxr import (
 )
 from scipy.spatial.transform import Rotation  # pyright: ignore[reportMissingTypeStubs]
 
-# USD joint prim type -> MJCF joint type. A fixed joint welds the bodies, which
-# MuJoCo expresses by nesting them with no joint element at all.
+# USD joint prim type -> MuJoCo joint kind. A fixed joint welds the bodies,
+# which MuJoCo expresses by nesting them with no joint at all.
 _JOINT_TYPES: dict[str, str | None] = {
     "PhysicsRevoluteJoint": "hinge",
     "PhysicsPrismaticJoint": "slide",
@@ -293,9 +294,12 @@ def simulate_usdz(
             "MuJoCo is not installed; run `uv sync --group sim` to enable simulation"
         ) from exc
 
-    model_path = write_mjcf(usdz, work_dir)
-
-    model = mujoco.MjModel.from_xml_path(str(model_path))
+    spec = _build_spec(usdz)
+    model = spec.compile()
+    # The compiled model is what runs; the MJCF beside the run is for humans
+    # reading back what the translation decided.
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "model.xml").write_text(spec.to_xml(), encoding="utf-8")
     data = mujoco.MjData(model)
     mujoco.mj_forward(model, data)
 
@@ -494,9 +498,32 @@ def _floor_friction(model: Any, data: Any) -> float | None:
 
 
 def write_mjcf(usdz: Path, out_dir: Path) -> Path:
-    """Translate an exported stage into an MJCF model beside its meshes."""
+    """Translate an exported stage into a compiled, self-contained MJCF model."""
 
+    spec = _build_spec(usdz)
+    spec.compile()
     out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "model.xml"
+    path.write_text(spec.to_xml(), encoding="utf-8")
+    return path
+
+
+def _build_spec(usdz: Path) -> Any:
+    """Build the MuJoCo model for an exported stage, directly as a spec.
+
+    Building through ``mujoco.MjSpec`` keeps every value a number from the USD
+    schema to the compiled model: no string formatting, no mesh files on disk,
+    and compilation errors point at the translation instead of at a generated
+    file.
+    """
+
+    try:
+        import mujoco
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise SimulationUnavailable(
+            "MuJoCo is not installed; run `uv sync --group sim` to enable simulation"
+        ) from exc
+
     stage = Usd.Stage.Open(str(usdz))
     if stage is None:
         raise ValueError(f"could not open {usdz}")
@@ -523,59 +550,48 @@ def write_mjcf(usdz: Path, out_dir: Path) -> Path:
     lift = np.eye(4)
     lift[2, 3] = -lowest + DROP_HEIGHT
 
-    mujoco_el = ET.Element("mujoco", model=usdz.stem or "object")
-    ET.SubElement(mujoco_el, "compiler", angle="radian", meshdir=".")
-    ET.SubElement(mujoco_el, "option", timestep="0.002", integrator="implicitfast")
-    asset = ET.SubElement(mujoco_el, "asset")
-    world = ET.SubElement(mujoco_el, "worldbody")
-    # MuJoCo takes the elementwise MAX of the two geoms' friction, so a floor with
-    # any friction of its own would mask the material's. Zero here means the
-    # contact uses exactly what the shape's material authored.
-    ET.SubElement(
-        world,
-        "geom",
+    spec = mujoco.MjSpec()  # pyright: ignore[reportAttributeAccessIssue]
+    spec.modelname = usdz.stem or "object"
+    # The SDK authors radians and metres; tell the compiler so, rather than
+    # converting angles a second time on the way in.
+    spec.compiler.degree = False
+    spec.option.timestep = 0.002
+    spec.option.integrator = mujoco.mjtIntegrator.mjINT_IMPLICITFAST  # pyright: ignore[reportAttributeAccessIssue]
+    # MuJoCo takes the elementwise MAX of the two geoms' friction, so a floor
+    # with any friction of its own would mask the material's. Zero here means
+    # the contact uses exactly what the shape's material authored.
+    spec.worldbody.add_geom(
         name="floor",
-        type="plane",
-        size="5 5 0.1",
-        pos="0 0 0",
-        friction="0 0.005 0.0001",
+        type=mujoco.mjtGeom.mjGEOM_PLANE,  # pyright: ignore[reportAttributeAccessIssue]
+        size=[5.0, 5.0, 0.1],
+        friction=[0.0, 0.005, 0.0001],
     )
 
-    _add_body(world, asset, scene, root, np.linalg.inv(lift), stage, out_dir)
+    _add_body(spec, spec.worldbody, scene, root, np.linalg.inv(lift), stage)
 
-    closures = [joint for joint in scene.joints if joint.excluded]
-    if closures:
-        equality = ET.SubElement(mujoco_el, "equality")
-        for joint in closures:
-            # MuJoCo's default equality impedance is sized for light objects;
-            # a multi tonne linkage sags visibly on it. A stiff pin is the
-            # honest reading of a physical pin.
-            stiffness = {"solref": "0.004 1", "solimp": "0.99 0.999 0.0001 0.5 2"}
-            if joint.kind is None:
-                ET.SubElement(
-                    equality,
-                    "weld",
-                    {"name": joint.name, "body1": joint.parent, "body2": joint.child, **stiffness},
-                )
-            else:
-                # A hinge pin holds a shared point; the connect constraint is
-                # exactly that, anchored on the parent side of the pin.
-                ET.SubElement(
-                    equality,
-                    "connect",
-                    {
-                        "name": joint.name,
-                        "body1": joint.parent,
-                        "body2": joint.child,
-                        "anchor": _vector(joint.parent_anchor),
-                        **stiffness,
-                    },
-                )
-
-    path = out_dir / "model.xml"
-    ET.indent(mujoco_el)
-    path.write_text(ET.tostring(mujoco_el, encoding="unicode"), encoding="utf-8")
-    return path
+    for joint in scene.joints:
+        if not joint.excluded:
+            continue
+        # MuJoCo's default equality impedance is sized for light objects; a
+        # multi tonne linkage sags visibly on it. A stiff pin is the honest
+        # reading of a physical pin.
+        equality = spec.add_equality()
+        equality.name = joint.name
+        equality.objtype = mujoco.mjtObj.mjOBJ_BODY
+        equality.name1 = joint.parent
+        equality.name2 = joint.child
+        equality.solref = [0.004, 1.0]
+        equality.solimp = [0.99, 0.999, 0.0001, 0.5, 2.0]
+        if joint.kind is None:
+            # A weld with no authored relpose holds the compiled rest pose.
+            equality.type = mujoco.mjtEq.mjEQ_WELD  # pyright: ignore[reportAttributeAccessIssue]
+            equality.data[10] = 1.0  # torquescale, the MJCF default
+        else:
+            # A hinge pin holds a shared point; the connect constraint is
+            # exactly that, anchored on the parent side of the pin.
+            equality.type = mujoco.mjtEq.mjEQ_CONNECT  # pyright: ignore[reportAttributeAccessIssue]
+            equality.data[0:3] = joint.parent_anchor
+    return spec
 
 
 def _bodies_scope(prim: Usd.Prim) -> Usd.Prim | None:
@@ -763,82 +779,93 @@ def _rotated_axis(
 
 
 def _add_body(
-    parent_el: ET.Element,
-    asset: ET.Element,
+    spec: Any,
+    parent: Any,
     scene: _Scene,
     part_name: str,
     parent_world: np.ndarray,
     stage: Usd.Stage,
-    out_dir: Path,
 ) -> None:
+    import mujoco
+
     prim = scene.parts[part_name]
     world = _world_transform(prim)
     relative = np.linalg.inv(parent_world) @ world
-    placement = {"name": part_name, "pos": _vector(relative[:3, 3])}
+    body = parent.add_body(name=part_name, pos=relative[:3, 3])
     orientation = _quaternion(relative[:3, :3])
     if orientation is not None:
-        placement["quat"] = _vector(orientation)
-    body = ET.SubElement(parent_el, "body", placement)
+        body.quat = orientation
 
     joint = next((item for item in scene.tree_joints if item.child == part_name), None)
     if joint is None:
-        ET.SubElement(body, "freejoint")
+        body.add_freejoint()
     elif joint.kind is not None:
-        attributes = {
-            "name": joint.name,
-            "type": joint.kind,
-            "pos": _vector(joint.anchor),
-            "axis": _vector(joint.axis),
-        }
-        if joint.lower is not None and joint.upper is not None:
-            # UsdPhysics states revolute limits in degrees and prismatic limits in
-            # stage units. MJCF is written here in radians and metres.
-            scale = math.pi / 180.0 if joint.kind == "hinge" else 1.0
-            attributes["range"] = f"{joint.lower * scale:.6f} {joint.upper * scale:.6f}"
-            attributes["limited"] = "true"
-        ET.SubElement(body, "joint", attributes)
+        _add_joint(body, joint.name, joint.kind, joint.anchor, joint.axis, joint.lower, joint.upper)
         for index, (kind, axis, _parent_axis, low, high) in enumerate(joint.extra_axes, start=2):
-            extra = {
-                "name": f"{joint.name}_{index}",
-                "type": kind,
-                "pos": _vector(joint.anchor),
-                "axis": _vector(axis),
-            }
-            if low is not None and high is not None:
-                scale = math.pi / 180.0 if kind == "hinge" else 1.0
-                extra["range"] = f"{low * scale:.6f} {high * scale:.6f}"
-                extra["limited"] = "true"
-            ET.SubElement(body, "joint", extra)
+            _add_joint(body, f"{joint.name}_{index}", kind, joint.anchor, axis, low, high)
 
     mass_api = _MassAPI(prim)
     mass = _number(mass_api.GetMassAttr().Get())
     if mass:
-        ET.SubElement(
-            body,
-            "inertial",
-            pos=_vector(mass_api.GetCenterOfMassAttr().Get() or (0.0, 0.0, 0.0)),
-            mass=f"{mass:.6f}",
-            diaginertia=" ".join(
-                f"{max(float(value), 1e-9):.9f}"
-                for value in (mass_api.GetDiagonalInertiaAttr().Get() or (1e-4, 1e-4, 1e-4))
-            ),
-        )
+        body.explicitinertial = True
+        body.mass = mass
+        body.ipos = _triple(mass_api.GetCenterOfMassAttr().Get() or (0.0, 0.0, 0.0))
+        body.inertia = [
+            max(float(value), 1e-9)
+            for value in (mass_api.GetDiagonalInertiaAttr().Get() or (1e-4, 1e-4, 1e-4))
+        ]
+        principal = mass_api.GetPrincipalAxesAttr().Get()
+        if principal is not None:
+            # The MJCF text translator dropped this, silently simulating any
+            # part with rotated principal axes as if its inertia were axis
+            # aligned.
+            imaginary = principal.GetImaginary()
+            body.iquat = [float(principal.GetReal()), *(float(value) for value in imaginary)]
 
     shapes = prim.GetChild("shapes")
     for shape in shapes.GetChildren() if shapes else []:
         if not shape.HasAPI(_CollisionAPI):
             continue
         mesh_name = f"{part_name}_{shape.GetName()}"
-        _write_obj(out_dir / f"{mesh_name}.obj", *_mesh_arrays(shape))
-        ET.SubElement(asset, "mesh", name=mesh_name, file=f"{mesh_name}.obj")
-        geom: dict[str, str] = {"type": "mesh", "mesh": mesh_name, "name": mesh_name}
+        points, faces = _mesh_arrays(shape)
+        mesh = spec.add_mesh(name=mesh_name)
+        mesh.uservert = points.reshape(-1)
+        mesh.userface = faces.reshape(-1)
+        geom = body.add_geom(
+            name=mesh_name,
+            type=mujoco.mjtGeom.mjGEOM_MESH,  # pyright: ignore[reportAttributeAccessIssue]
+            meshname=mesh_name,
+        )
         friction = _contact_friction(shape, stage)
         if friction is not None:
-            geom["friction"] = f"{friction:.4f} 0.005 0.0001"
-        ET.SubElement(body, "geom", geom)
+            geom.friction = [friction, 0.005, 0.0001]
 
     for child in (item.child for item in scene.tree_joints if item.parent == part_name):
-        _add_body(body, asset, scene, child, world, stage, out_dir)
+        _add_body(spec, body, scene, child, world, stage)
+
+
+def _add_joint(
+    body: Any,
+    name: str,
+    kind: str,
+    anchor: tuple[float, float, float],
+    axis: tuple[float, float, float],
+    lower: float | None,
+    upper: float | None,
+) -> None:
+    import mujoco
+
+    joint = body.add_joint(
+        name=name,
+        type=mujoco.mjtJoint.mjJNT_HINGE if kind == "hinge" else mujoco.mjtJoint.mjJNT_SLIDE,
+        pos=anchor,
+        axis=axis,
+    )
+    if lower is not None and upper is not None:
+        # UsdPhysics states revolute limits in degrees and prismatic limits in
+        # stage units. The spec is built in radians and metres.
+        scale = math.pi / 180.0 if kind == "hinge" else 1.0
+        joint.range = [lower * scale, upper * scale]
 
 
 def _contact_friction(shape: Usd.Prim, stage: Usd.Stage) -> float | None:
@@ -892,12 +919,6 @@ def _mesh_arrays(prim: Usd.Prim) -> tuple[np.ndarray, np.ndarray]:
     return points, indices.reshape(-1, 3)
 
 
-def _write_obj(path: Path, points: np.ndarray, faces: np.ndarray) -> None:
-    lines = [f"v {x:.6f} {y:.6f} {z:.6f}" for x, y, z in points]
-    lines += [f"f {a + 1} {b + 1} {c + 1}" for a, b, c in faces]
-    path.write_text("\n".join(lines), encoding="utf-8")
-
-
 def _attr(prim: Usd.Prim, name: str, default: Any = None) -> Any:
     attribute = prim.GetAttribute(name)
     value = attribute.Get() if attribute else None
@@ -911,7 +932,3 @@ def _number(value: Any) -> float | None:
 def _triple(value: Any) -> tuple[float, float, float]:
     x, y, z = (float(component) for component in value)
     return (x, y, z)
-
-
-def _vector(value: Any) -> str:
-    return " ".join(f"{float(component):.6f}" for component in value)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -424,6 +424,47 @@ def test_a_revolute_loop_is_preserved_as_a_mujoco_constraint(tmp_path: Path) -> 
     assert constraint.get("name") == "closing_hinge"
 
 
+def test_a_fixed_loop_welds_at_the_rest_pose(tmp_path: Path) -> None:
+    """A fixed loop closure must hold the pair exactly where it compiled.
+
+    A fresh MjSpec equality starts with joint-coupling defaults in its data,
+    and anything left there reads as an authored relative pose -- the weld
+    then pulls toward a phantom offset instead of the rest pose. The tree
+    joint masks most of the resulting motion, so the compiled constraint is
+    what has to be checked: with both body frames coincident at rest, the
+    relpose must be the identity.
+    """
+
+    import numpy as np
+
+    model = RigidBodyAssembly("welded_ring")
+    a = model.rigid_body("a")
+    a.add(BoxGeometry((0.1, 0.1, 0.02)), name="slab", material=Material.STEEL)
+    b = model.rigid_body("b")
+    b.add(
+        BoxGeometry((0.1, 0.1, 0.02)).translate(0.0, 0.0, 0.03),
+        name="plate",
+        material=Material.STEEL,
+    )
+    tree = model.joint("pin", a.at(), b.at(), dofs=(JointDOF(JointAxis.ROT_Z),))
+    model.joint("brace", a.at(), b.at(), dofs=())
+    model.articulation("main", root=a, joints=(tree,))
+
+    path = write_mjcf(_export(model, tmp_path), tmp_path / "sim")
+    compiled = mujoco.MjModel.from_xml_path(str(path))
+
+    welds = [
+        index for index in range(compiled.neq) if compiled.eq_type[index] == mujoco.mjtEq.mjEQ_WELD
+    ]
+    assert len(welds) == 1
+    data = compiled.eq_data[welds[0]]
+    assert np.allclose(data[:6], 0.0, atol=1e-9), data  # anchor and relpose offset
+    assert np.allclose(data[6:10], (1.0, 0.0, 0.0, 0.0), atol=1e-9), data  # identity relpose
+
+    result = simulate_usdz(_export(model, tmp_path / "run"), tmp_path / "run" / "sim", seconds=1.0)
+    assert result.stood_up, result.summary()
+
+
 def test_an_unsupported_loop_fails_before_writing_partial_mjcf(tmp_path: Path) -> None:
     model = RigidBodyAssembly("parallel_slides")
     base = model.rigid_body("base")

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -79,7 +79,7 @@ def test_revolute_limits_convert_from_degrees_to_radians(tmp_path: Path) -> None
     silently removes the limit rather than failing.
     """
     write_mjcf(_export(_hinged_box(), tmp_path), tmp_path / "sim")
-    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
+    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint[@name='lid_hinge']")
 
     assert joint is not None
     lower, upper = (float(value) for value in str(joint.get("range")).split())
@@ -95,7 +95,7 @@ def test_a_part_with_no_joint_gets_a_free_body(tmp_path: Path) -> None:
     write_mjcf(_export(model, tmp_path), tmp_path / "sim")
     root = ET.parse(tmp_path / "sim" / "model.xml").getroot()
 
-    assert root.find(".//freejoint") is not None
+    assert root.find(".//joint[@type='free']") is not None
 
 
 def test_contact_friction_reaches_the_geom(tmp_path: Path) -> None:
@@ -230,7 +230,7 @@ def test_each_joint_axis_survives_the_usd_to_mjcf_round_trip(
 ) -> None:
     model = _hinge_with_axis(axis)
     write_mjcf(_export(model, tmp_path), tmp_path / "sim")
-    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint")
+    joint = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//joint[@name='lid_hinge']")
 
     assert joint is not None
     actual = tuple(float(value) for value in str(joint.get("axis")).split())
@@ -329,10 +329,42 @@ def test_a_multi_dof_joint_becomes_one_mjcf_joint_per_free_axis(tmp_path) -> Non
 
     result = export_assembly(assembly, tmp_path / "out")
     model = write_mjcf(result.usdz, tmp_path / "work")
-    text = model.read_text()
+    root = ET.parse(model).getroot()
 
-    assert text.count('type="hinge"') == 3
-    assert 'name="socket"' in text and 'name="socket_2"' in text and 'name="socket_3"' in text
+    # A hinge is MJCF's default joint type, so the writer omits it.
+    hinges = [joint for joint in root.iter("joint") if joint.get("type") in (None, "hinge")]
+    assert [joint.get("name") for joint in hinges] == ["socket", "socket_2", "socket_3"]
+
+
+def test_principal_axes_reach_the_inertial_frame(tmp_path: Path) -> None:
+    """USD authors diagonal inertia in the principal-axes frame; MuJoCo must too.
+
+    Dropping the quaternion simulates a part with rotated principal axes as if
+    its inertia were axis aligned.
+    """
+
+    from articraft.sdk.mass import MassProperties
+
+    half = math.sqrt(0.5)
+    model = RigidBodyAssembly("gyro")
+    model.rigid_body(
+        "body",
+        mass_properties=MassProperties(
+            mass=2.0,
+            diagonal_inertia=(0.02, 0.01, 0.01),
+            principal_axes=(half, 0.0, 0.0, half),  # 90 degrees about Z
+        ),
+    ).add(BoxGeometry((0.1, 0.1, 0.1)), name="cube", material=Material.STEEL)
+
+    write_mjcf(_export(model, tmp_path), tmp_path / "sim")
+    inertial = ET.parse(tmp_path / "sim" / "model.xml").getroot().find(".//body/inertial")
+
+    assert inertial is not None
+    quaternion = inertial.get("quat")
+    assert quaternion is not None, "rotated principal axes must carry their orientation"
+    w, _, _, z = (float(value) for value in quaternion.split())
+    assert abs(w) == pytest.approx(half, abs=1e-4)
+    assert abs(z) == pytest.approx(half, abs=1e-4)
 
 
 def test_a_joint_authored_child_first_still_nests_under_the_root(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -141,7 +141,7 @@ dev = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.11.0" },
 ]
-sim = [{ name = "mujoco", specifier = ">=3.2" }]
+sim = [{ name = "mujoco", specifier = ">=3.3" }]
 
 [[package]]
 name = "asttokens"


### PR DESCRIPTION
## Change

- `write_mjcf`'s ElementTree assembly, `%.6f` string formatters, per-shape `.obj` side files, and disk round-trip (`MjModel.from_xml_path`) are replaced by `mujoco.MjSpec`: bodies, joints, inertials, user meshes (vertex arrays in the spec), and loop-closure equalities are authored as numbers and compiled in memory.
- `simulate_usdz` compiles the spec directly; it still writes `model.xml` into the work dir — now serialized from the compiled spec — because reading back what the translation decided is worth keeping.
- `write_mjcf` keeps its signature and still produces `model.xml` (now a single self-contained file, meshes inline), and compiles the model first, so anything MuJoCo would reject fails at translation time.
- The USD scene reading (`_read_scene`, `orient_tree`, capability gates for WORLD anchors and unsupported loop closures) is untouched — that's the domain logic; only the emission layer changed.
- mujoco pin bumped to `>=3.3`, where MjSpec is stable.

## Why

The docstring called the translation "the part most likely to be wrong," and half of its surface area was serialization: numbers truncated through text formatters, angles converted into a format that defaults to degrees, meshes round-tripped through OBJ files, and compile errors pointing at a generated file instead of the translation. MjSpec is MuJoCo's own API for exactly this job; using it keeps every value a number from the USD schema to the compiled model and deletes the entire formatting layer.

## Impact

One genuine correctness fix: the principal-axes quaternion USD authors alongside diagonal inertia now reaches MuJoCo's inertial frame. The text translator silently dropped it, simulating any part with rotated principal axes as if its inertia were axis aligned. A regression test pins this (it fails against the old translator).

Test updates are selector-level only: MjSpec's writer serializes a free joint as `<joint type="free"/>` and omits the default `type="hinge"`, so tests that grepped for serialization trivia now query joints by name. Every physical assertion (limits in radians, axis round-trips, nesting, equality constraints, friction, mass) is unchanged and passes.

Deliberately not attempted: WORLD-anchored joints still raise `SimulationCapabilityError`. MjSpec makes expressing them easy, but a wall-anchored mechanism invalidates the drop/tilt scenario semantics (there is no floor to settle on), so lifting the gate is scenario-design work, not translation work.

## Checks

- `uv run --group sim pytest -q --replay` — 621 passed, 2 deselected
- `uv run --group sim pytest -q tests/test_simulate.py tests/test_simulation_viewer.py` — 25 passed
- `uv run basedpyright` — 0 errors
- `uv run ruff format --check .` / `uv run ruff check .`

## Stack

Independent of the other library-consolidation PRs (#130 geometry queries, #131 scipy numerics, loop-solver swap); merges in any order.