### PR TITLE
Let a trust-region solver close the loops

### DIFF
--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -897,19 +897,13 @@ def _solve_closed_loops(
         dtype=np.float64,
     )
 
-    values = np.zeros(len(candidates), dtype=np.float64)
-    # With no unknowns left -- every ring coordinate supplied by the caller --
-    # there is nothing to solve, but the closure residual still decides
-    # whether the supplied pose keeps the loop assembled.
-    for step in range(1, (_LOOP_STEPS if candidates else 0) + 1):
-        scale = step / _LOOP_STEPS
-        # A trust-region solve survives the singular Jacobians of an
-        # over-center linkage, keeps every iterate inside the bounds, and
-        # differentiates into the feasible interval at a limit -- the three
-        # properties a plain Gauss-Newton loop had to be taught by hand.
+    def solve_toward(scale: float, start: np.ndarray) -> np.ndarray:
+        # A bounded trust-region solve keeps every iterate inside the limits
+        # and differentiates into the feasible interval at a bound -- the
+        # properties the hand-rolled Gauss-Newton loop had to be taught.
         solution = least_squares(
-            lambda unknowns, scale=scale: residual(scale, unknowns),
-            values,
+            lambda unknowns: residual(scale, unknowns),
+            start,
             jac="2-point",
             bounds=(lower_bounds, upper_bounds),
             method="dogbox",
@@ -917,7 +911,14 @@ def _solve_closed_loops(
             xtol=1e-14,
             gtol=1e-14,
         )
-        values = project(solution.x)
+        return project(solution.x)
+
+    values = np.zeros(len(candidates), dtype=np.float64)
+    # With no unknowns left -- every ring coordinate supplied by the caller --
+    # there is nothing to solve, but the closure residual still decides
+    # whether the supplied pose keeps the loop assembled.
+    for step in range(1, (_LOOP_STEPS if candidates else 0) + 1):
+        values = solve_toward(step / _LOOP_STEPS, values)
 
     # One gate, equal to validate_state's per-axis tolerance: anything
     # accepted here passes validation, anything rejected names the loop.
@@ -990,14 +991,16 @@ def _project_value(value: float, limits: tuple[float, float] | None, periodic: b
 
     A full-circle hinge has no wall at +-pi: the coordinate is periodic, and
     clamping it would strand a solution that continues on the other side of
-    the seam.
+    the seam. The period is the physical turn, 2*pi -- limits merely wide
+    enough to contain one (say -3.15..3.15) span slightly more, and wrapping
+    by that span would land on a genuinely different angle.
     """
 
     if limits is None or not periodic:
         return _clamp(value, limits)
-    span = limits[1] - limits[0]
-    wrapped = limits[0] + math.fmod(value - limits[0], span)
-    return wrapped + span if wrapped < limits[0] else wrapped
+    turn = 2.0 * math.pi
+    wrapped = limits[0] + math.fmod(value - limits[0], turn)
+    return wrapped + turn if wrapped < limits[0] else wrapped
 
 
 def _values_from(joint: Joint, positions: Mapping[str, float]) -> dict[JointAxis, float]:

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -9,6 +9,7 @@ from typing import TypeAlias, cast
 
 import numpy as np
 import trimesh
+from scipy.optimize import least_squares  # pyright: ignore[reportMissingTypeStubs]
 
 from articraft.sdk._values import _as_identifier, _as_name
 from articraft.sdk.bodies import RigidBody, RigidBodyRef
@@ -798,8 +799,8 @@ def _propagate_transforms(
 
 _LOOP_STEPS = 5
 # The acceptance gate, equal to validate_state's per-axis tolerance so a
-# solve is accepted exactly when validation would pass it. The Newton loop
-# itself polishes two decades further so accepted solves clear the gate
+# solve is accepted exactly when validation would pass it. The least-squares
+# solve itself polishes well past this so accepted solves clear the gate
 # with margin rather than landing on it.
 _LOOP_TOLERANCE = 1e-6
 
@@ -880,45 +881,45 @@ def _solve_closed_loops(
             rows.extend(joint_values[axis] for axis in locked[closure])
         return np.asarray(rows, dtype=np.float64)
 
+    # Limits become solver bounds, except on a full-circle hinge: its
+    # coordinate is periodic, so it solves unbounded and wraps afterwards
+    # rather than stopping at a seam that is not a physical wall.
+    lower_bounds = np.asarray(
+        [
+            -np.inf if bound is None or wraps else bound[0]
+            for bound, wraps in zip(limits, periodic, strict=True)
+        ],
+        dtype=np.float64,
+    )
+    upper_bounds = np.asarray(
+        [
+            np.inf if bound is None or wraps else bound[1]
+            for bound, wraps in zip(limits, periodic, strict=True)
+        ],
+        dtype=np.float64,
+    )
+
     values = np.zeros(len(candidates), dtype=np.float64)
     # With no unknowns left -- every ring coordinate supplied by the caller --
-    # there is nothing to iterate, but the closure residual still decides
+    # there is nothing to solve, but the closure residual still decides
     # whether the supplied pose keeps the loop assembled.
-    steps = _LOOP_STEPS if candidates else 0
-    for step in range(1, steps + 1):
+    for step in range(1, (_LOOP_STEPS if candidates else 0) + 1):
         scale = step / _LOOP_STEPS
-        damping = 1e-6
-        for _ in range(40):
-            current = residual(scale, values)
-            error = float(np.linalg.norm(current))
-            if error < _LOOP_TOLERANCE * 1e-2:
-                break
-            jacobian = np.empty((len(current), len(values)), dtype=np.float64)
-            for index in range(len(values)):
-                # Differentiate into the feasible interval: a nudge past a
-                # limit would sample the pose the solver may not return.
-                bound = limits[index]
-                nudge = 1e-6
-                if bound is not None and not periodic[index] and values[index] + nudge > bound[1]:
-                    nudge = -1e-6
-                nudged = values.copy()
-                nudged[index] += nudge
-                jacobian[:, index] = (residual(scale, nudged) - current) / nudge
-            normal = jacobian.T @ jacobian + damping * np.eye(len(values))
-            try:
-                delta = np.linalg.solve(normal, -jacobian.T @ current)
-            except np.linalg.LinAlgError:
-                break
-            # Project the iterate itself, not just its evaluation: an iterate
-            # parked beyond a limit sees a flat residual and never comes back.
-            trial = project(values + delta)
-            if float(np.linalg.norm(residual(scale, trial))) < error:
-                values = trial
-                damping = max(damping * 0.5, 1e-9)
-            else:
-                damping *= 8.0
-                if damping > 1e6:
-                    break
+        # A trust-region solve survives the singular Jacobians of an
+        # over-center linkage, keeps every iterate inside the bounds, and
+        # differentiates into the feasible interval at a limit -- the three
+        # properties a plain Gauss-Newton loop had to be taught by hand.
+        solution = least_squares(
+            lambda unknowns, scale=scale: residual(scale, unknowns),
+            values,
+            jac="2-point",
+            bounds=(lower_bounds, upper_bounds),
+            method="dogbox",
+            ftol=1e-14,
+            xtol=1e-14,
+            gtol=1e-14,
+        )
+        values = project(solution.x)
 
     # One gate, equal to validate_state's per-axis tolerance: anything
     # accepted here passes validation, anything rejected names the loop.

--- a/tests/test_rigid_body_loop_solver.py
+++ b/tests/test_rigid_body_loop_solver.py
@@ -151,6 +151,62 @@ def test_complete_pose_state_validates_past_a_quarter_turn() -> None:
     assert checked.dof_positions["crank_pin.rotY"] == pytest.approx(1.7)
 
 
+def _parallelogram(limits: tuple[float, float]) -> RigidBodyAssembly:
+    """Equal crank and rocker on matching pins: closes at every crank angle."""
+
+    assembly = RigidBodyAssembly("parallelogram")
+    ground = assembly.rigid_body("ground")
+    crank = assembly.rigid_body("crank")
+    coupler = assembly.rigid_body("coupler")
+    rocker = assembly.rigid_body("rocker")
+    for body, length in ((ground, 0.35), (crank, 0.1), (coupler, 0.3), (rocker, 0.1)):
+        body.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+    hinge = (JointDOF(JointAxis.ROT_Y, limits=limits),)
+    crank_pin = assembly.joint(
+        "crank_pin",
+        ground.at(JointFrame(xyz=(-0.15, 0.0, 0.0))),
+        crank.at(JointFrame(xyz=(0.0, 0.0, -0.05))),
+        dofs=hinge,
+    )
+    coupler_pin = assembly.joint(
+        "coupler_pin",
+        crank.at(JointFrame(xyz=(0.0, 0.0, 0.05))),
+        coupler.at(JointFrame(xyz=(-0.15, 0.0, 0.0))),
+        dofs=hinge,
+    )
+    rocker_pin = assembly.joint(
+        "rocker_pin",
+        coupler.at(JointFrame(xyz=(0.15, 0.0, 0.0))),
+        rocker.at(JointFrame(xyz=(0.0, 0.0, 0.05))),
+        dofs=hinge,
+    )
+    assembly.joint(
+        "closing_pin",
+        ground.at(JointFrame(xyz=(0.15, 0.0, 0.0))),
+        rocker.at(JointFrame(xyz=(0.0, 0.0, -0.05))),
+        dofs=hinge,
+    )
+    assembly.articulation("main", root=ground, joints=(crank_pin, coupler_pin, rocker_pin))
+    return assembly
+
+
+def test_limits_wider_than_a_turn_wrap_by_the_turn_not_the_span() -> None:
+    """A hinge limited to -3.15..3.15 is periodic, but its period is 2*pi.
+
+    Wrapping a solved coordinate by the limit span (6.3) lands on a genuinely
+    different angle -- 0.017 rad away -- and the corrupted iterate strands the
+    continuation. This parallelogram closes at every crank angle; with the
+    span wrap it failed past a crank angle of about 2.6.
+    """
+
+    resolved = _parallelogram(limits=(-3.15, 3.15)).resolve()
+
+    for value in np.linspace(-math.pi, math.pi, 41):
+        state = resolved.forward_kinematics({"crank_pin.rotY": float(value)})
+        for dof_id, solved in state.dof_positions.items():
+            assert -3.15 - 1e-9 <= solved <= 3.15 + 1e-9, (dof_id, solved)
+
+
 def _hydraulic_ram(slide_limits: tuple[float, float]) -> RigidBodyAssembly:
     assembly = RigidBodyAssembly("hydraulic_linkage")
     ground = assembly.rigid_body("ground")


### PR DESCRIPTION
## Change

The inner iteration of `_solve_closed_loops` — a hand-rolled damped Gauss-Newton loop with a finite-difference Jacobian (steps flipped inward at limits), iterate projection into bounds, and a Levenberg-Marquardt damping schedule — becomes one call to `scipy.optimize.least_squares(method="dogbox", jac="2-point", bounds=...)` per homotopy step.

## Why

Every hand-taught property of that loop is native to the scipy solver: trust-region steps survive the singular Jacobians of an over-center linkage (the reason the LM damping existed), iterates stay inside bounds (the reason for `project()` mid-iteration), and its 2-point differencing is bounds-aware (the reason for the inward FD nudge). scipy's docs recommend `dogbox` for exactly this problem shape — small and bounded. The remaining code is only the domain reasoning: the five-step homotopy walk that keeps a linkage on its authored assembly branch, the periodic treatment of full-circle hinges (solved unbounded, wrapped afterwards — a seam at ±π is not a physical wall), the acceptance gate equal to `validate_state`'s tolerance, and the three-way `LoopClosureError` classification.

## Impact

No API or behavior change. The full loop-solver battery passes unchanged — including the full-circle four-bar sweep (63/63 reachable crank angles), the ±π seam-crossing pose, pinned-at-limits and all-coordinates-supplied error paths. Solve latency on a four-bar is ~7 ms per pose.

## Checks

- `uv run --group sim pytest -q --replay` — 620 passed, 2 deselected
- `uv run basedpyright` — 0 errors
- `uv run ruff format --check .` / `uv run ruff check .`

## Stack

Last of the four library-consolidation PRs (#130 geometry queries, #131 scipy numerics, #133 MjSpec translation); independent of the others and merges in any order. Note #131 also touches `assembly.py` (rotation conversions in a different region) — whichever merges second rebases trivially.