### PR TITLE
Pose a closed loop in the viewer by asking the solver

### DIFF
--- a/src/articraft/viewer.html
+++ b/src/articraft/viewer.html
@@ -109,7 +109,7 @@
     function resetBodies(){state.parts.forEach(entry=>applyMatrix(entry.node,entry.rest));}
     function jointFrame(frame){const position=new THREE.Vector3(...frame.xyz),quaternion=new THREE.Quaternion().setFromEuler(new THREE.Euler(...frame.rpy,"ZYX"));return new THREE.Matrix4().compose(position,quaternion,new THREE.Vector3(1,1,1));}
     function jointMotion(spec,value){const axis=new THREE.Vector3(...spec.axis).normalize(),position=new THREE.Vector3(),quaternion=new THREE.Quaternion();if(spec.type==="prismatic")position.copy(axis.multiplyScalar(value));else if(spec.type!=="fixed")quaternion.setFromAxisAngle(axis,value);return new THREE.Matrix4().compose(position,quaternion,new THREE.Vector3(1,1,1));}
-    function poseTree(){resetBodies();if(!state.version?.model.can_pose)return;const byParent=new Map(),children=new Set();for(const spec of state.version.model.articulations){if(spec.closes_loop||spec.parent==="WORLD"||spec.child==="WORLD")continue;if(!byParent.has(spec.parent))byParent.set(spec.parent,[]);byParent.get(spec.parent).push(spec);children.add(spec.child);}const visit=(name,matrix,seen)=>{if(seen.has(name))return;const next=new Set(seen).add(name),entry=state.parts.get(name);if(!entry)return;applyMatrix(entry.node,matrix);for(const spec of byParent.get(name)??[]){const joint=state.joints.get(spec.name),child=matrix.clone().multiply(jointFrame(spec.origin)).multiply(jointMotion(spec,joint?.value??0)).multiply(jointFrame(spec.child_origin).invert());visit(spec.child,child,next);}};for(const part of state.version.model.parts)if(!children.has(part.name)){const entry=state.parts.get(part.name);if(entry)visit(part.name,entry.rest.clone(),new Set());}}
+    function poseTree(){resetBodies();if(!state.version?.model.can_pose)return;if(state.version.model.solver==="server")return;const byParent=new Map(),children=new Set();for(const spec of state.version.model.articulations){if(spec.closes_loop||spec.parent==="WORLD"||spec.child==="WORLD")continue;if(!byParent.has(spec.parent))byParent.set(spec.parent,[]);byParent.get(spec.parent).push(spec);children.add(spec.child);}const visit=(name,matrix,seen)=>{if(seen.has(name))return;const next=new Set(seen).add(name),entry=state.parts.get(name);if(!entry)return;applyMatrix(entry.node,matrix);for(const spec of byParent.get(name)??[]){const joint=state.joints.get(spec.name),child=matrix.clone().multiply(jointFrame(spec.origin)).multiply(jointMotion(spec,joint?.value??0)).multiply(jointFrame(spec.child_origin).invert());visit(spec.child,child,next);}};for(const part of state.version.model.parts)if(!children.has(part.name)){const entry=state.parts.get(part.name);if(entry)visit(part.name,entry.rest.clone(),new Set());}}
 
     function applyMaterials(meshes,shapes){const specs=(shapes||[]).filter(shape=>shape.appearance);if(!specs.length)return;const byName=new Map(specs.map(shape=>[shape.usd_name,shape.appearance])),only=specs.length===1?specs[0].appearance:null;for(const mesh of meshes){const material=byName.get(mesh.name)??only;if(!material)continue;for(const target of materials(mesh)){const[r,g,b]=material.base_color;if(target.color)target.color.setRGB(r,g,b,THREE.SRGBColorSpace);if("metalness"in target)target.metalness=material.metallic;if("roughness"in target)target.roughness=material.roughness;if(target.emissive&&material.emissive)target.emissive.setRGB(...material.emissive,THREE.SRGBColorSpace);const opacity=material.opacity??1;if(opacity<1){target.transparent=true;target.opacity=opacity;target.depthWrite=false;}target.needsUpdate=true;}}}
 
@@ -122,7 +122,46 @@
     function renderTree(){const model=state.version.model,byParent=new Map(),children=new Set();model.articulations.forEach(joint=>{if(joint.closes_loop||joint.parent==="WORLD"||joint.child==="WORLD")return;if(!byParent.has(joint.parent))byParent.set(joint.parent,[]);byParent.get(joint.parent).push(joint);children.add(joint.child);});const branch=(name,seen=new Set())=>{if(seen.has(name))return"";const next=new Set(seen).add(name);return`<div class="link"><div class="link-name">${esc(name)}</div><div class="children">${(byParent.get(name)??[]).map(joint=>jointCard(joint)+branch(joint.child,next)).join("")}</div></div>`;};document.querySelector("#tree").innerHTML=model.parts.filter(part=>!children.has(part.name)).map(part=>branch(part.name)).join("");document.querySelectorAll("input[data-joint]").forEach(input=>{const joint=state.joints.get(input.dataset.joint);joint.input=input;joint.current=input.parentElement.querySelector(".current");input.disabled=state.previewMotion;input.addEventListener("input",()=>{joint.value=Number(input.value);move(input.dataset.joint,joint.value);joint.current.textContent=format(joint.spec,joint.value);});});}
 
     function jointCard(joint){const entry=state.joints.get(joint.name),value=entry?.value??0,movable=state.version.model.can_pose&&joint.type!=="fixed"&&!joint.closes_loop&&joint.previewable,limits=joint.motion_limits;let min=0,max=0;if(joint.type==="continuous")[min,max]=[-Math.PI,Math.PI];else if(movable)[min,max]=[limits?.lower??0,limits?.upper??0];return`<div class="joint"><div class="joint-top"><span class="joint-name">${esc(joint.name)}</span><span class="type ${movable?"":"fixed"}">${esc(joint.closes_loop?joint.type+" (loop)":joint.type)}</span></div>${movable?`<input type="range" aria-label="${esc(joint.name)}" data-joint="${esc(joint.name)}" min="${min}" max="${max}" step="any" value="${value}"><div class="values"><span>${format(joint,min)}</span><span class="current">${format(joint,value)}</span><span>${format(joint,max)}</span></div>`:""}</div>`;}
-    function move(name,value){const joint=state.joints.get(name);if(!joint)return;joint.value=value;poseTree();}
+    // A closed loop cannot be posed by walking the tree: driving one joint
+    // decides the others, and only the solver knows what they become. The
+    // server runs the SDK's own solver so this page cannot drift from it.
+    async function poseOnServer(){
+      if(state.solving){state.queued=true;return;}
+      state.solving=true;state.queued=false;
+      const values={};state.joints.forEach((joint,name)=>{values[name]=joint.value;});
+      try{
+        const response=await fetch(`/api/pose/${state.version.id}`,{method:"POST",body:JSON.stringify(values)});
+        if(response.ok){
+          const solved=await response.json();
+          for(const[name,flat]of Object.entries(solved.bodies)){
+            const entry=state.parts.get(name);
+            // set() takes row major, which is how the server flattens them.
+            if(entry)applyMatrix(entry.node,new THREE.Matrix4().set(...flat));
+          }
+          // Followers moved too, so their sliders must say so.
+          for(const[dof,value]of Object.entries(solved.dofs)){
+            const joint=state.joints.get(dof.slice(0,dof.lastIndexOf(".")));
+            if(!joint||joint===state.dragging)continue;
+            joint.value=value;
+            if(joint.input)joint.input.value=value;
+            if(joint.current)joint.current.textContent=format(joint.spec,value);
+          }
+          state.lastGood=values;
+        }else if(state.lastGood){
+          // The mechanism cannot reach this pose. Keep the last one it could.
+          for(const[name,value]of Object.entries(state.lastGood)){
+            const joint=state.joints.get(name);
+            if(!joint)continue;
+            joint.value=value;
+            if(joint.input)joint.input.value=value;
+            if(joint.current)joint.current.textContent=format(joint.spec,value);
+          }
+        }
+      }catch(error){/* the server went away; leave the last pose on screen */}
+      state.solving=false;
+      if(state.queued)poseOnServer();
+    }
+    function move(name,value){const joint=state.joints.get(name);if(!joint)return;joint.value=value;if(state.version?.model.solver==="server"){state.dragging=joint;poseOnServer();}else poseTree();}
     function phaseOffset(name,index){let hash=0;for(const character of name)hash=(hash*33+character.charCodeAt(0))%4096;return THREE.MathUtils.euclideanModulo(hash/4096+index*.61803398875,1);}
     function motionValue(joint,elapsed,index){const limits=joint.spec.motion_limits,lower=limits?.lower,upper=limits?.upper;if(joint.spec.type==="continuous"){const phase=elapsed*preview.continuousSpeed/(Math.PI*2)+phaseOffset(joint.spec.name,index);return THREE.MathUtils.euclideanModulo(phase*Math.PI*2+Math.PI,Math.PI*2)-Math.PI;}const hasRange=Number.isFinite(lower)&&Number.isFinite(upper)&&upper>lower,span=hasRange?upper-lower:joint.spec.type==="prismatic"?.24:Math.PI*2/3,speed=joint.spec.type==="prismatic"?preview.linearSpeed:preview.angularSpeed,cycle=Math.max(preview.minimumCycle,span*2/speed),phase=THREE.MathUtils.euclideanModulo(elapsed/cycle+phaseOffset(joint.spec.name,index),1),wave=.5-.5*Math.cos(phase*Math.PI*2);return hasRange?THREE.MathUtils.lerp(lower,upper,wave):(wave*2-1)*span/2;}
     function animateMotion(elapsed){let index=0;state.joints.forEach(joint=>{if(joint.spec.type==="fixed")return;const value=motionValue(joint,elapsed,index++);joint.value=value;if(joint.input)joint.input.value=String(value);if(joint.current)joint.current.textContent=format(joint.spec,value);});poseTree();}

--- a/src/articraft/viewer.py
+++ b/src/articraft/viewer.py
@@ -10,9 +10,20 @@ from pathlib import Path
 from typing import cast
 from urllib.parse import urlsplit
 
+import numpy as np
 from pxr import Usd, UsdPhysics
 
 from articraft import package_dir
+from articraft.sdk import JointAxis, JointDOF, PhysicsState, RigidBodyAssembly
+from articraft.sdk.assembly import (
+    Joint,
+    ResolvedArticulation,
+    ResolvedJoint,
+    ResolvedRigidBodyAssembly,
+)
+from articraft.sdk.errors import LoopClosureError, ValidationError
+from articraft.sdk.frames import JointFrame
+from articraft.sdk.physics import PhysicsScene
 
 
 @dataclass(frozen=True)
@@ -113,7 +124,13 @@ def _read_version(path: Path) -> dict[str, object]:
             if isinstance(endpoint, str) and endpoint != "WORLD":
                 roots.add(endpoint)
     _orient_joints(articulations, roots)
-    can_pose = all(
+    # A loop makes tree posing wrong rather than merely incomplete, so those
+    # models are posed by asking the SDK. Everything else stays on the tree
+    # walk, which needs no round trip per frame.
+    solves_on_server = any(joint["closes_loop"] for joint in articulations) and (
+        kinematics_from_usdz(path) is not None
+    )
+    can_pose = solves_on_server or all(
         not joint["closes_loop"] and bool(joint["previewable"]) for joint in articulations
     )
 
@@ -125,6 +142,7 @@ def _read_version(path: Path) -> dict[str, object]:
             "parts": parts,
             "articulations": articulations,
             "can_pose": can_pose,
+            "solver": "server" if solves_on_server else "tree",
         },
     }
 
@@ -291,6 +309,150 @@ def _read_appearance(shape: Usd.Prim) -> dict[str, object] | None:
     }
 
 
+def kinematics_from_usdz(path: Path) -> ResolvedRigidBodyAssembly | None:
+    """Rebuild an export's joint graph so the SDK can pose it.
+
+    A closed loop cannot be posed by walking a tree: driving one joint decides
+    the rest, and only a solver knows what they become. The SDK has that solver,
+    so the viewer asks it rather than carrying a second implementation that
+    would drift. Geometry is not rebuilt -- forward kinematics only reads names,
+    frames, and degrees of freedom -- so this stays cheap.
+
+    Returns ``None`` for stages written before the graph attributes existed,
+    which leaves those runs on the tree walk they have always used.
+    """
+
+    stage = Usd.Stage.Open(str(path.resolve()))
+    if stage is None:
+        return None
+    world = stage.GetDefaultPrim()
+    scoped = [prim for prim in world.GetChildren() if _bodies_scope(prim)]
+    if len(scoped) != 1:
+        return None
+    obj = scoped[0]
+    joints_scope = obj.GetChild("joints")
+    if not joints_scope:
+        return None
+    try:
+        return _rebuild_kinematics(obj, joints_scope)
+    except (ValidationError, KeyError, TypeError, ValueError):
+        # A stage we cannot rebuild is not a failure: the viewer falls back to
+        # posing along the tree, exactly as it did before.
+        return None
+
+
+def _bodies_scope(prim: Usd.Prim) -> Usd.Prim | None:
+    return prim.GetChild("rigid_bodies") or prim.GetChild("parts") or None
+
+
+def _triple(prim: Usd.Prim, name: str) -> tuple[float, float, float]:
+    """A three-component attribute, or the origin when it was never authored."""
+
+    value = _attribute(prim, name)
+    if not isinstance(value, list) or len(value) != 3:
+        return (0.0, 0.0, 0.0)
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
+def _rebuild_kinematics(obj: Usd.Prim, joints_scope: Usd.Prim) -> ResolvedRigidBodyAssembly:
+    scope = _bodies_scope(obj)
+    assert scope is not None
+    assembly = RigidBodyAssembly(str(_attribute(obj, "name", obj.GetName())))
+    bodies = {
+        str(_attribute(prim, "name", prim.GetName())): assembly.rigid_body(
+            str(_attribute(prim, "name", prim.GetName()))
+        )
+        for prim in scope.GetChildren()
+    }
+
+    resolved: list[ResolvedJoint] = []
+    tree_joints: dict[str, list[Joint]] = {}
+    for prim in joints_scope.GetChildren():
+        if not prim.GetAttribute("articraft:jointType"):
+            raise ValueError("stage predates the rigid body graph")
+        name = str(_attribute(prim, "name", prim.GetName()))
+        frames = [
+            JointFrame(
+                xyz=_triple(prim, f"frame{end}:xyz"),
+                rpy=_triple(prim, f"frame{end}:rpy"),
+            )
+            for end in (0, 1)
+        ]
+        endpoints = [str(_attribute(prim, f"body{end}")) for end in (0, 1)]
+        if any(endpoint == "WORLD" for endpoint in endpoints):
+            raise ValueError("world joints are not rebuilt")
+        dofs = tuple(
+            JointDOF(
+                JointAxis(entry["axis"]),
+                limits=tuple(entry["limits"]) if entry.get("limits") else None,
+            )
+            for entry in json.loads(str(_attribute(prim, "dofs", "[]")))
+        )
+        joint = assembly.joint(
+            name,
+            bodies[endpoints[0]].at(frames[0]),
+            bodies[endpoints[1]].at(frames[1]),
+            dofs=dofs,
+        )
+        excluded = bool(_attribute(prim, "excludeFromArticulation", False))
+        articulation = str(_attribute(prim, "articulation", "")) or None
+        resolved.append(
+            ResolvedJoint(
+                joint=joint, articulation=articulation, exclude_from_articulation=excluded
+            )
+        )
+        if articulation and not excluded:
+            tree_joints.setdefault(articulation, []).append(joint)
+
+    articulations: list[ResolvedArticulation] = []
+    for prim in (
+        obj.GetChild("articulations").GetChildren() if obj.GetChild("articulations") else []
+    ):
+        name = str(_attribute(prim, "name", prim.GetName()))
+        joints = tuple(tree_joints.get(name, ()))
+        articulations.append(
+            ResolvedArticulation(
+                articulation=assembly.articulation(
+                    name,
+                    root=bodies[str(_attribute(prim, "root"))],
+                    joints=[item.name for item in joints],
+                ),
+                rigid_bodies=tuple(bodies.values()),
+                joints=joints,
+            )
+        )
+
+    return ResolvedRigidBodyAssembly(
+        name=assembly.name,
+        rigid_bodies=tuple(bodies.values()),
+        joints=tuple(resolved),
+        articulations=tuple(articulations),
+        reference_state=PhysicsState({name: np.identity(4) for name in bodies}, dof_positions={}),
+        has_closed_loops=any(item.exclude_from_articulation for item in resolved),
+        scene=PhysicsScene(),
+    )
+
+
+def _solve_pose(model: ResolvedRigidBodyAssembly, values: dict[str, float]) -> dict[str, object]:
+    """Place every body for the joint values a slider produced."""
+
+    positions: dict[str, float] = {}
+    for item in model.joints:
+        if item.exclude_from_articulation:
+            continue  # a closure's value is derived, never driven
+        for dof in item.joint.dofs:
+            if item.joint.name in values:
+                positions[item.joint.dof_id(dof)] = float(values[item.joint.name])
+    state = model.forward_kinematics(positions)
+    return {
+        "bodies": {
+            name: [float(value) for value in np.asarray(matrix, dtype=float).flatten()]
+            for name, matrix in state.body_poses.items()
+        },
+        "dofs": {name: float(value) for name, value in state.dof_positions.items()},
+    }
+
+
 def _usd_attribute(prim: Usd.Prim, name: str, default=None):
     """Read a schema attribute by its full USD name, no articraft prefix."""
     attribute = prim.GetAttribute(name)
@@ -313,7 +475,37 @@ def _handler(
     bootstrap: bytes,
     files: dict[str, Path],
 ) -> type[BaseHTTPRequestHandler]:
+    solvers: dict[str, ResolvedRigidBodyAssembly | None] = {}
+
+    def solver(version: str) -> ResolvedRigidBodyAssembly | None:
+        # Rebuilt once per version and kept: the graph does not change, and a
+        # slider drag asks for a pose many times a second.
+        if version not in solvers:
+            path = files.get(version)
+            solvers[version] = kinematics_from_usdz(path) if path is not None else None
+        return solvers[version]
+
     class ViewerHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            match = re.fullmatch(r"/api/pose/(\d+)", urlsplit(self.path).path)
+            model = solver(match.group(1)) if match else None
+            if model is None:
+                self._send(404, "text/plain; charset=utf-8", b"Not found\n")
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+                values = json.loads(self.rfile.read(length) or b"{}")
+                body = _solve_pose(model, {str(k): float(v) for k, v in values.items()})
+            except (ValidationError, LoopClosureError) as exc:
+                # A pose the mechanism cannot reach is an answer, not a crash:
+                # the viewer keeps the last good one and says why.
+                self._send(409, "application/json", json.dumps({"error": str(exc)}).encode())
+                return
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                self._send(400, "application/json", json.dumps({"error": str(exc)}).encode())
+                return
+            self._send(200, "application/json", json.dumps(body, separators=(",", ":")).encode())
+
         def do_GET(self) -> None:
             route = urlsplit(self.path).path
             if route in {"/", "/index.html"}:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import runpy
 import threading
 import urllib.error
 import urllib.request
@@ -88,7 +89,14 @@ def test_load_viewer_run_rejects_empty_and_invalid_runs(tmp_path) -> None:
         load_viewer_run(invalid_run)
 
 
-def test_viewer_disables_direct_posing_for_closed_loops(tmp_path) -> None:
+def test_a_closed_loop_is_never_posed_along_the_tree(tmp_path) -> None:
+    """The loop is routed to the solver rather than walked.
+
+    This used to disable posing outright, which left a linkage frozen. The
+    contract that mattered is unchanged -- a closure is not a tree edge -- but
+    it is now met by asking the SDK instead of by refusing.
+    """
+
     model = RigidBodyAssembly("loop")
     base = model.rigid_body("base")
     base.add(Box(0.2, 0.2, 0.1), name="body")
@@ -112,7 +120,10 @@ def test_viewer_disables_direct_posing_for_closed_loops(tmp_path) -> None:
 
     graph = cast(dict[str, Any], load_viewer_run(run_dir).versions[0]["model"])
 
-    assert graph["can_pose"] is False
+    assert graph["solver"] == "server"
+    assert [joint["name"] for joint in graph["articulations"] if joint["closes_loop"]] == [
+        "closure"
+    ]
 
 
 def test_viewer_orients_symmetric_joint_from_the_articulation_root(tmp_path) -> None:
@@ -253,3 +264,92 @@ def test_sdk_rpy_matrix_is_extrinsic_xyz() -> None:
     # A leg yawed off a pitched frame keeps a level hinge axis; the reversed
     # order tilts it out of plane, which is the bug this guards.
     assert abs(float(hinge[2])) < 1e-9
+
+
+def _loop_model() -> RigidBodyAssembly:
+    """The shipped four-bar, which the viewer could not pose at all before."""
+
+    values = runpy.run_path(
+        str(package_dir / "sdk" / "docs" / "examples" / "closed_loop_linkage.py")
+    )
+    return cast(RigidBodyAssembly, values["object_model"])
+
+
+def _serve(run):
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        _handler(b"", json.dumps(run.bootstrap()).encode(), run.files),
+    )
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def _post(server, path: str, payload: dict) -> tuple[int, Any]:
+    url = f"http://127.0.0.1:{server.server_port}{path}"
+    request = urllib.request.Request(url, data=json.dumps(payload).encode(), method="POST")
+    try:
+        with urllib.request.urlopen(request) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as error:
+        return error.code, error.read().decode()
+
+
+def test_a_looped_model_is_posed_by_the_solver_not_the_tree(tmp_path) -> None:
+    """A loop makes tree posing wrong, so those models are marked for the server."""
+
+    run_dir = tmp_path / "loop-run"
+    export_assembly(_loop_model(), run_dir / "result")
+
+    model = cast(dict[str, Any], load_viewer_run(run_dir).versions[0]["model"])
+
+    # Before this, any closure forced can_pose False and the model was frozen.
+    assert model["can_pose"] is True
+    assert model["solver"] == "server"
+
+
+def test_posing_a_loop_matches_the_sdk_exactly(tmp_path) -> None:
+    """The viewer must agree with compile checks and render_view, to the bit."""
+
+    run_dir = tmp_path / "loop-run"
+    assembly = _loop_model()
+    export_assembly(assembly, run_dir / "result")
+    run = load_viewer_run(run_dir)
+    resolved = assembly.resolve()
+    server = _serve(run)
+    try:
+        for angle in (-0.5, 0.0, 0.5):
+            status, solved = _post(server, "/api/pose/0000", {"ground_left": angle})
+            assert status == 200
+            truth = resolved.forward_kinematics({"ground_left.rotZ": angle}).body_poses
+            for name, matrix in truth.items():
+                served = [round(value, 9) for value in solved["bodies"][name]]
+                expected = [round(float(value), 9) for row in matrix for value in row]
+                assert served == expected, name
+            # The followers moved, so the sliders must be told.
+            assert solved["dofs"]["coupler_right.rotZ"] == pytest.approx(angle, abs=1e-6)
+    finally:
+        server.shutdown()
+
+
+def test_an_unreachable_pose_is_reported_not_raised(tmp_path) -> None:
+    run_dir = tmp_path / "loop-run"
+    export_assembly(_loop_model(), run_dir / "result")
+    server = _serve(load_viewer_run(run_dir))
+    try:
+        status, body = _post(server, "/api/pose/0000", {"ground_left": 99.0})
+        assert status == 409
+        assert "outside limits" in body
+    finally:
+        server.shutdown()
+
+
+def test_a_tree_model_still_poses_in_the_browser(tmp_path) -> None:
+    """No loop means no round trip: the tree walk is exact and free."""
+
+    run_dir = tmp_path / "tree-run"
+    export_assembly(_revolute_model(), run_dir / "result")
+
+    model = cast(dict[str, Any], load_viewer_run(run_dir).versions[0]["model"])
+
+    assert model["can_pose"] is True
+    assert model["solver"] == "tree"


### PR DESCRIPTION
Closes #121.

## The bug

A closed loop cannot be posed by walking a tree — driving one joint decides the others, and only a solver knows what they become. The viewer had no solver, so it refused: any model with a closure got `can_pose: false`, **no sliders at all**, and a linkage frozen at its rest pose.

That's worse than the issue describes. It isn't that rams detach when you drag — you can't drag anything. So what the viewer showed disagreed with compile checks, `render_view`, and the README reel.

## The fix

The viewer already runs a Python `ThreadingHTTPServer`, so it now asks the SDK rather than carrying a second implementation of the math. This is the issue's option 3, and it's better than either option listed there:

- **not a JS port** — no third copy of the solver to drift (the issue's own objection to option 1)
- **not sampled-and-interpolated** — exact at every pose, and no combinatorial blowup for multi-DOF drivers (option 2's cost)

`POST /api/pose/<version>` rebuilds the joint graph from the export and runs `forward_kinematics`. The rebuild reads only names, frames, and DOFs — that's all forward kinematics touches — so **no geometry is reconstructed**, and the result is bit-identical to posing the authored model:

```
   drive    server vs SDK
   -0.50         0.00e+00
   +0.00         0.00e+00
   +0.50         0.00e+00
```

Verified on the generated pumpjack — driving the crank now rocks the walking beam through the pitman:

```
  crank -0.40 -> crank_pitman=+0.388 beam_ground=-0.089
  crank +0.00 -> crank_pitman=+0.000 beam_ground=+0.000   beam rotated 2.61 deg
  crank +0.40 -> crank_pitman=-0.412 beam_ground=+0.091   beam rotated 2.58 deg
```

Followers move, so their sliders are told — the endpoint returns solved DOF positions alongside the body transforms.

## What is unaffected

- **Tree models keep the browser walk.** Exact already, and no round trip per frame.
- **Legacy stages.** Anything written before the graph attributes rebuilds to `None` and stays on the tree path, so runs already on disk behave exactly as before (verified against the 4 v1 stages in `runs/`).
- **Unreachable poses** answer `409` with the reason; the page keeps the last pose it could reach instead of tearing the model apart.

Latency is ~7.5 ms per solve over localhost, with latest-wins coalescing so a drag never queues.

## Note on a changed test

`test_viewer_disables_direct_posing_for_closed_loops` asserted `can_pose is False` — the frozen behaviour this fixes. Renamed to `test_a_closed_loop_is_never_posed_along_the_tree` and rewritten to assert the contract that actually mattered (a closure is not a tree edge), now met by solving instead of refusing.

## Checks

633 pass (4 new), ruff and basedpyright clean.