### PR TITLE
Make articulation conditional

### DIFF
--- a/src/articraft/prompts/system.md
+++ b/src/articraft/prompts/system.md
@@ -1,10 +1,11 @@
 <role>
-You are articraft. Turn the user's request into a realistic articulated 3D
-object in the run workspace. `main.py` is the required entry point, but you may
+You are articraft. Turn the user's request into a realistic 3D object or
+assembly in the run workspace. `main.py` is the required entry point, but you may
 create other Python files when they make the model or its checks clearer.
 
-The object should read clearly from its shape, named geometry, construction, and
-motion. This is a visual modeling workflow. Do not claim structural safety,
+The object should read clearly from its shape, named geometry, and construction.
+Its motion should read clearly when motion is part of the design. This is a
+visual modeling workflow. Do not claim structural safety,
 manufacturing tolerances, compliance, print readiness, or real world fit unless
 the request asks for it and the checks prove it.
 </role>
@@ -26,16 +27,19 @@ Four requirements guide every design choice.
    rails, brackets, hinge barrels, shafts, controls, and other visible
    construction when the real object needs them. Tessellate curved surfaces
    finely enough to read smooth rather than faceted.
-2. PRIMARY MECHANISMS. Model the main motion a person expects from the object.
-   Use the matching joint freedoms and plausible motion limits. Add separate
-   moving controls when they are important to the object's identity or use. Do
-   not add decorative motion.
-3. NO FLOATING PARTS. Every rigid body and every separate piece of geometry must
-   physically connect to the object. Overlap within one rigid body is free and
+2. INTENTIONAL MOTION. Model independent motion when the request, a reference,
+   or the ordinary construction of the object clearly requires it. Use the
+   matching joint freedoms and plausible motion limits. A removable part may be
+   a separate seated body. Do not invent a hinge, slide, latch, or other retained
+   mechanism for a part that is normally lifted away.
+3. INTENTIONAL CONNECTIONS. Every separate piece of geometry within one rigid
+   body must connect to that body. Overlap within one rigid body is free and
    counts as connected, so attach a protrusion by extending its OWN end a few
-   millimeters into the surface it meets. Never add a separate piece whose only
-   job is to close a gap. Use an explicit test allowance only when separation is
-   a real part of the requested design.
+   millimeters into the surface it meets. A retained rigid body needs real
+   support or a real constraint. A deliberately removable rigid body may instead
+   rest against a mating surface in the authored pose. Never add a separate
+   piece whose only job is to close a gap. Use an explicit test allowance only
+   when separation is a real part of the requested design.
 4. NO UNINTENDED OVERLAPS. Keep distinct bodies separate when the design calls for
    separation. Small local overlap is acceptable for a captured pin, seated
    insert, nested part, or compressed interface. Give each intentional case a
@@ -48,12 +52,13 @@ geometry only to make a check pass.
 
 <workflow>
 Start with the SDK quickstart that is already in the conversation. Before the
-first edit, read the current `main.py` and survey the SDK references that could
-answer the design questions. Consider plausible build123d and mesh approaches
-before selecting a representation. Do not stop at the first workable API. Read
-enough to understand the relevant signatures, coordinate rules, limits, and
-nearby helpers. Use parallel `read` calls when comparing independent references.
-Keep the research relevant to the requested object.
+first edit, read the current `main.py` and the SDK references needed for the
+design. For a simple object, read only the closest geometry reference and
+example unless a specific question remains. Consider plausible build123d and
+mesh approaches when the representation is not clear. In that case, do not stop
+at the first workable API. Read enough to understand the relevant signatures,
+coordinate rules, and limits. Use parallel `read` calls when comparing
+independent references.
 
 <image_prompt>
 When a relevant SDK page names a reference figure, use `view_image` if the
@@ -62,20 +67,21 @@ load unrelated gallery images.
 </image_prompt>
 
 Make a compact internal brief before editing. Set the object scale, root part,
-moving parts, visible construction, support paths, intended overlaps, and checks.
-Include the geometry strategy for each major visible form and why it fits. Use
-conservative real world dimensions when the request gives no size.
+part relationships, visible construction, intended overlaps, and checks. Include
+moving parts and support paths when the design has them. Include the geometry
+strategy for each major visible form and why it fits. Use conservative real
+world dimensions when the request gives no size.
 
 Add a validation brief before editing. Name the shape measurements that should
-hold, the mechanism poses that should work, and the contacts or clearances that
-should stay valid.
+hold and any contacts or clearances that should stay valid. Add mechanism poses
+only when the design has independent motion.
 <image_prompt>
 Choose the broad views and close views that will show the result clearly. Name
 any selected part, section, or motion view needed to judge
 internal construction or movement. Every validation brief must include at least
-one overall model view. An articulated object must also include a view that shows
-its important motion. Add a close view for every opening, rim, joint, or curved
-transition whose quality cannot be judged in the overall view.
+one overall model view. An object with independent motion must also include a
+view that shows its important motion. Add a close view only when an opening,
+rim, joint, or curved transition cannot be judged in the overall view.
 
 Build a complete first version, then write `previews.py`. Import `object_model`
 from `main` and use the public `render_view(...)` function. Render every view
@@ -185,11 +191,12 @@ inputs, prismatic travel, and test distances.
 
 <testing>
 Use `TestContext(object_model)` and return `ctx.report()`. Add a small set of
-prompt-specific checks for the important shape, mechanism, support relationship,
-pose, contact, clearance, or intended overlap. Record useful dimensions and mesh
-measurements as metrics. Sample important joints through their motion instead of
-checking only the rest pose. Track a point when its path makes the motion easier
-to verify.
+prompt-specific checks for the important shape, support relationship, contact,
+clearance, or intended overlap. Add mechanism and pose checks when independent
+motion is part of the design. Record useful dimensions and mesh measurements as
+metrics. Use a blocking threshold only for an explicit requirement or a clear
+defect. Sample important joints through their motion instead of checking only
+the rest pose. Track a point when its path makes the motion easier to verify.
 
 <image_prompt>
 Create visual files in `previews.py` with `render_view(...)`. Register the final
@@ -241,6 +248,6 @@ changes as ordered actions.
 
 <final_response>
 After the latest workspace compiles successfully, return a visible final response
-in one or two short sentences. State what you built and name the main motion. Do
-not include the full script.
+in one or two short sentences. State what you built. Name the main motion only
+when independent motion is part of the design. Do not include the full script.
 </final_response>

--- a/src/articraft/prompts/task.md
+++ b/src/articraft/prompts/task.md
@@ -4,8 +4,9 @@ User request:
 {{ prompt }}
 
 Edit `main.py` in the run workspace and build the requested object. Meet the four
-quality requirements from the system prompt. Use realistic geometry, model the
-primary mechanism, support every part, and avoid unintended overlap.
+quality requirements from the system prompt. Use realistic geometry, model only
+the motion the design requires, support retained parts, seat removable parts,
+and avoid unintended overlap.
 
 Start with the preloaded SDK quickstart. Before choosing a representation, use
 `read` to survey the relevant SDK references and compare plausible build123d and
@@ -21,5 +22,6 @@ After a successful compile, review the visual representation separately and
 improve any major form that uses a crude substitute when a public authoring
 method would fit it better.
 </image_prompt>
-Then return a short visible summary of the object and its main motion.
+Then return a short visible summary of the object. Include its main motion only
+when independent motion is part of the design.
 </task>

--- a/src/articraft/sdk/docs/common/00_quickstart.md
+++ b/src/articraft/sdk/docs/common/00_quickstart.md
@@ -36,7 +36,13 @@ top by a few millimeters.
 Use build123d for exact boundaries, wall thickness, openings, bores, rims, and local fillets.
 Use mesh helpers for freeform sections or paths.
 
-## Add motion
+## Decide whether the object moves
+
+Many objects have no independent motion. A loose teapot or saucepan lid is a separate seated
+part, not a reason to invent a hinge. Add a retained mechanism only when the request,
+reference, or ordinary construction calls for one.
+
+## Add retained motion
 
 First, use `model.joint(...)` to connect two bodies. Then use `model.articulation(...)` to
 select the solver tree.
@@ -44,18 +50,19 @@ select the solver tree.
 ```python
 from articraft.sdk import JointAxis, JointDOF
 
-lid = model.rigid_body("lid")
-lid.add(Box(0.8, 0.5, 0.02), name="panel")
+moving_model = RigidBodyAssembly("wall_cabinet")
+frame = moving_model.rigid_body("cabinet_frame")
+frame.add(Box(0.8, 0.08, 0.6), name="frame")
+door = moving_model.rigid_body("cabinet_door")
+door.add(Box(0.8, 0.02, 0.6), name="panel")
 
-# The edge direction becomes the local Z axis of the frame.
-hinge = top.edges().filter_by(Axis.X).sort_by(Axis.Z)[-1]
-model.joint(
-    "lid_hinge",
-    body.at(hinge),
-    lid.at(hinge),
-    dofs=(JointDOF(JointAxis.ROT_Z, limits=(-1.9, 0.0)),),
+moving_model.joint(
+    "door_hinge",
+    frame.at((-0.4, 0.0, 0.0)),
+    door.at((-0.4, 0.0, 0.0)),
+    dofs=(JointDOF(JointAxis.ROT_Z, limits=(0.0, 1.9)),),
 )
-model.articulation("main", root=body, joints=["lid_hinge"])
+moving_model.articulation("main", root=frame, joints=["door_hinge"])
 ```
 
 Use `body.at(...)` to bind a point or build123d feature to its body. Pass the same feature to

--- a/src/articraft/sdk/docs/common/30_assembly.md
+++ b/src/articraft/sdk/docs/common/30_assembly.md
@@ -124,7 +124,7 @@ from build123d import Axis
 
 top = housing_shape.faces().sort_by(Axis.Z)[-1]
 top_frame = housing_body.at(top)
-hinge_axis = lid_body.at(lid_shape.edges().filter_by(Axis.X)[0])
+hinge_axis = door_body.at(door_shape.edges().filter_by(Axis.X)[0])
 ```
 
 Use `WORLD.at(...)` to create a world endpoint. Use a raw `JointFrame` when exact numbers are

--- a/src/articraft/sdk/docs/common/35_joints.md
+++ b/src/articraft/sdk/docs/common/35_joints.md
@@ -78,13 +78,32 @@ A joint cannot connect `WORLD` to itself.
 | Another combination | Generic D6 |
 
 ```python
-lid_hinge = model.joint(
-    "lid_hinge",
+door_hinge = model.joint(
+    "door_hinge",
     base.at((0.0, -0.04, 0.02)),
-    lid.at((0.0, -0.04, 0.0)),
+    door.at((0.0, -0.04, 0.0)),
     dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.57)),),
 )
 ```
+
+## Removable bodies
+
+A separate body does not always need retained hardware. A teapot lid can sit on its mating
+rim and lift away freely. Use a generic D6 relation with all six axes free when the body must
+remain in the assembly graph:
+
+```python
+free_motion = tuple(JointDOF(axis) for axis in JointAxis)
+removable_lid = model.joint(
+    "removable_lid",
+    pot.at((0.0, 0.0, 0.12)),
+    lid.at((0.0, 0.0, 0.0)),
+    dofs=free_motion,
+)
+```
+
+This relation describes the possible poses. It does not imply a physical hinge, latch, or
+other retention hardware. Model the seated rim and clearance in the geometry.
 
 ## `model.articulation(...)`
 

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -313,8 +313,8 @@ The default sweep spans the authored limits. A closed loop can have a smaller re
 so sweep checks record unreachable samples as failures.
 
 ```python
-poses = ctx.sample_joint("lid_hinge", samples=5)
-poses = ctx.sample_joint("lid_hinge", positions=(0.0, 0.4, 0.8))
+poses = ctx.sample_joint("door_hinge", samples=5)
+poses = ctx.sample_joint("door_hinge", positions=(0.0, 0.4, 0.8))
 ```
 
 Use these records with:

--- a/src/articraft/sdk/docs/common/45_visual_evidence.md
+++ b/src/articraft/sdk/docs/common/45_visual_evidence.md
@@ -200,7 +200,7 @@ The axis and radial direction must be perpendicular.
 
 ```python
 MotionStripView(
-    articulation="lid_hinge",
+    articulation="door_hinge",
     positions=(0.0, 0.6, 1.2),
     view=ModelView.side(width=320, height=280, show_joints=True),
 )
@@ -217,7 +217,7 @@ render_view(
     object_model,
     ModelView.three_quarter(),
     "qa/three_quarter.png",
-    pose={"lid_hinge": 0.8},
+    pose={"door_hinge": 0.8},
 )
 ```
 

--- a/tests/test_sdk_docs.py
+++ b/tests/test_sdk_docs.py
@@ -376,8 +376,8 @@ def test_prompt_and_docs_state_the_new_authoring_contract() -> None:
         "JointFrame",
         "JointDOF",
         "realistic geometry",
-        "primary mechanisms",
-        "floating parts",
+        "intentional motion",
+        "removable part",
         "unintended overlaps",
     ]:
         assert required.lower() in text.lower()
@@ -410,8 +410,39 @@ def test_prompts_encourage_research_and_mesh_without_a_usage_quota() -> None:
         "jet engine",
         "stand mixer",
         "desk lamp",
+        "realistic articulated 3d object",
+        "model the primary mechanism",
+        "lid_hinge",
     ]:
         assert forbidden.lower() not in normalized
+
+
+def test_prompts_do_not_force_articulation_or_invent_retention() -> None:
+    system = (package_dir / "prompts" / "system.md").read_text(encoding="utf-8")
+    task = (package_dir / "prompts" / "task.md").read_text(encoding="utf-8")
+    quickstart = (package_dir / "sdk" / "docs" / "common" / "00_quickstart.md").read_text(
+        encoding="utf-8"
+    )
+    text = " ".join(f"{system}\n{task}\n{quickstart}".split()).lower()
+
+    for required in [
+        "3d object or assembly",
+        "model only the motion the design requires",
+        "a removable part may be a separate seated body",
+        "do not invent a hinge",
+        "a loose teapot or saucepan lid is a separate seated part",
+        "name the main motion only when independent motion is part of the design",
+        "blocking threshold only for an explicit requirement or a clear defect",
+    ]:
+        assert required in text
+
+    for forbidden in [
+        "turn the user's request into a realistic articulated 3d object",
+        "model the primary mechanism",
+        "state what you built and name the main motion",
+        "lid_hinge",
+    ]:
+        assert forbidden not in text
 
 
 def test_prompt_requires_agent_driven_visual_review() -> None:


### PR DESCRIPTION
## What changed

The agent now models motion only when the request, a reference, or the ordinary construction requires it. A removable part may be a separate seated body, so the agent no longer needs to invent a hinge or latch.

The prompt now gives simple objects a smaller research and preview scope. It also reserves blocking checks for explicit requirements and clear defects.

The common SDK examples now use a cabinet door for retained hinge motion. The joint guide includes a separate teapot lid with six free axes.

## Why

The old prompt required an articulated object, a primary mechanism, and a main motion for every request. That made a hinge the easiest way to represent a teapot lid and increased the number of research, preview, and repair turns.

## Checks

The focused prompt and documentation tests passed with 19 tests. The repository suite passed 639 tests with 2 deselected when the paid live generation file was excluded. Ruff passed. The live generation file requires an OpenAI API key and had no replay tape in this checkout.
