### PR TITLE
Add explicit DOF previews

### DIFF
--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -126,6 +126,27 @@ class Joint:
     def dof_id(self, dof: JointDOF) -> str:
         return f"{self.name}.{cast(JointAxis, dof.axis).value}"
 
+    def get_dof(self, dof: JointAxis | str) -> JointDOF:
+        """Return one authored degree of freedom by axis or qualified id."""
+        value = str(dof).strip()
+        if "." in value:
+            joint_name, value = value.rsplit(".", 1)
+            if joint_name != self.name:
+                raise ValidationError(
+                    f"DOF {dof!r} belongs to joint {joint_name!r}, not {self.name!r}"
+                )
+        try:
+            axis = JointAxis(value)
+        except ValueError as exc:
+            raise ValidationError(f"unknown joint axis: {value!r}") from exc
+        for authored in self.dofs:
+            if authored.axis == axis:
+                return authored
+        available = [cast(JointAxis, authored.axis).value for authored in self.dofs]
+        raise ValidationError(
+            f"joint {self.name!r} has no {axis.value!r} DOF; available axes are {available!r}"
+        )
+
 
 JointRef: TypeAlias = str | Joint
 ArticulationRootRef: TypeAlias = RigidBodyRef | Joint

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -317,6 +317,19 @@ poses = ctx.sample_joint("lid_hinge", samples=5)
 poses = ctx.sample_joint("lid_hinge", positions=(0.0, 0.4, 0.8))
 ```
 
+Use `sample_dof(...)` when a joint has several degrees of freedom. Pass an axis name or the
+qualified DOF identifier:
+
+```python
+lift_poses = ctx.sample_dof(
+    "removable_lid",
+    "removable_lid.transZ",
+    positions=(0.0, 0.04, 0.10),
+)
+```
+
+The other degrees of freedom keep their current values during the sweep.
+
 Use these records with:
 
 ```python

--- a/src/articraft/sdk/docs/common/45_visual_evidence.md
+++ b/src/articraft/sdk/docs/common/45_visual_evidence.md
@@ -206,6 +206,18 @@ MotionStripView(
 )
 ```
 
+Set `dof` when the joint has several degrees of freedom. It accepts an axis name or the
+qualified DOF identifier:
+
+```python
+MotionStripView(
+    articulation="removable_lid",
+    dof="removable_lid.transZ",
+    positions=(0.0, 0.04, 0.10),
+    view=ModelView.side(width=320, height=280),
+)
+```
+
 Omit `positions` to sample the authored motion limits. A continuous joint uses a half turn.
 
 ## Render directly

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -570,18 +570,55 @@ class TestContext:
         self._reject_unposable(joint.name)
         if len(joint.dofs) != 1:
             raise ValidationError("sample_joint requires a joint with exactly one DOF")
+        return self._sample_dof_values(
+            joint,
+            joint.dofs[0],
+            positions,
+            samples=samples,
+            label=joint.name,
+        )
+
+    def sample_dof(
+        self,
+        articulation: str | Joint,
+        dof: JointAxis | str,
+        positions: Sequence[float] | None = None,
+        *,
+        samples: int = 5,
+    ) -> tuple[PoseSample, ...]:
+        """Sample one explicit degree of freedom on a joint."""
+        joint = self.model.get_joint(articulation)
+        self._reject_unposable(joint.name)
+        selected = joint.get_dof(dof)
+        return self._sample_dof_values(
+            joint,
+            selected,
+            positions,
+            samples=samples,
+            label=joint.dof_id(selected),
+        )
+
+    def _sample_dof_values(
+        self,
+        joint: Joint,
+        dof: JointDOF,
+        positions: Sequence[float] | None,
+        *,
+        samples: int,
+        label: str,
+    ) -> tuple[PoseSample, ...]:
         values = (
-            _articulation_sweep_values(joint, max(2, int(samples)))
+            _articulation_sweep_values(joint, max(2, int(samples)), dof)
             if positions is None
             else [_finite(value, "joint sample") for value in positions]
         )
         if not values:
             raise ValidationError("positions must contain at least one joint value")
-        dof_id = joint.dof_id(joint.dofs[0])
+        dof_id = joint.dof_id(dof)
         return tuple(
             PoseSample(
                 positions=tuple(sorted({**self._pose, dof_id: value}.items())),
-                label=f"{joint.name}={value:.6g}",
+                label=f"{label}={value:.6g}",
             )
             for value in values
         )

--- a/src/articraft/sdk/visual.py
+++ b/src/articraft/sdk/visual.py
@@ -152,6 +152,7 @@ class MeridionalSectionView:
 class MotionStripView:
     articulation: str | Joint
     positions: tuple[float, ...] = ()
+    dof: JointAxis | str | None = None
     samples: int = 5
     view: ModelView = field(
         default_factory=lambda: ModelView.three_quarter(width=320, height=280, show_joints=True)
@@ -400,8 +401,11 @@ def _render_motion_strip(
         raise ValidationError(
             f"motion strip joint {joint.name!r} is fixed; it has no motion to sweep"
         )
-    rotational = [dof for dof in joint.dofs if cast(JointAxis, dof.axis).is_rotational]
-    swept = rotational[0] if rotational else joint.dofs[0]
+    if view.dof is not None:
+        swept = joint.get_dof(view.dof)
+    else:
+        rotational = [dof for dof in joint.dofs if cast(JointAxis, dof.axis).is_rotational]
+        swept = rotational[0] if rotational else joint.dofs[0]
     # Pose by the swept DOF's qualified id: a bare joint name resolves only
     # for single-DOF joints, and this one may carry several.
     dof_id = joint.dof_id(swept)

--- a/tests/test_evidence_sdk.py
+++ b/tests/test_evidence_sdk.py
@@ -215,6 +215,38 @@ def test_model_section_meridional_and_motion_views_render(monkeypatch, tmp_path:
     assert Path(artifact.path).is_file()
 
 
+def test_motion_strip_uses_an_explicit_dof_on_a_multi_dof_joint(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    model = RigidBodyAssembly("free_part")
+    base = model.rigid_body("base")
+    base.add(BoxGeometry((0.4, 0.4, 0.2)), name="base")
+    moving = model.rigid_body("moving")
+    moving.add(BoxGeometry((0.2, 0.2, 0.1)), name="body")
+    model.joint(
+        "free",
+        base.at(),
+        moving.at(),
+        dofs=(JointDOF(JointAxis.TRANS_Z), JointDOF(JointAxis.ROT_Z)),
+    )
+    model.articulation("main", root=base, joints=("free",))
+
+    output = render_view(
+        model,
+        MotionStripView(
+            "free",
+            positions=(0.0, 0.1),
+            dof="free.transZ",
+            view=ModelView.side(width=160, height=140),
+        ),
+        "explicit_dof.png",
+    )
+
+    assert output == Path("explicit_dof.png")
+    assert Image.open(output).width == 160 * 2 + 12
+
+
 def test_reference_reticles_use_normalized_coordinates(tmp_path: Path) -> None:
     source = tmp_path / "reference.webp"
     Image.new("RGB", (200, 100), (240, 240, 240)).save(source)

--- a/tests/test_testing_sdk.py
+++ b/tests/test_testing_sdk.py
@@ -572,6 +572,39 @@ def test_pose_sweeps_record_unreachable_loop_poses() -> None:
     assert failures and "unreachable" in failures[0].details
 
 
+def test_sample_dof_selects_one_axis_on_multi_dof_joint() -> None:
+    model = RigidBodyAssembly("removable_lid")
+    pot = model.rigid_body("pot")
+    add_box(pot, "body")
+    lid = model.rigid_body("lid")
+    add_box(lid, "body")
+    model.joint(
+        "lid_free",
+        pot.at(),
+        lid.at(),
+        dofs=tuple(JointDOF(axis) for axis in JointAxis),
+    )
+    model.articulation("main", root=pot, joints=("lid_free",))
+    context = TestContext(model)
+
+    poses = context.sample_dof(
+        "lid_free",
+        "lid_free.transZ",
+        positions=(0.0, 0.04, 0.1),
+    )
+
+    assert [pose.as_dict() for pose in poses] == [
+        {"lid_free.transZ": 0.0},
+        {"lid_free.transZ": 0.04},
+        {"lid_free.transZ": 0.1},
+    ]
+    assert poses[-1].label == "lid_free.transZ=0.1"
+    with pytest.raises(ValidationError, match="belongs to joint"):
+        context.sample_dof("lid_free", "other.transZ", positions=(0.0,))
+    with pytest.raises(ValidationError, match="unknown joint axis"):
+        context.sample_dof("lid_free", "scaleX", positions=(0.0,))
+
+
 def test_separation_check_handles_multi_dof_joints() -> None:
     model = RigidBodyAssembly("multi_dof_baseline")
     base = model.rigid_body("base")


### PR DESCRIPTION
## What changed

`TestContext.sample_dof()` can now sample one named degree of freedom on a joint that has several. The caller may pass an axis name or a qualified identifier such as `lid_free.transZ`.

`MotionStripView` now accepts `dof=`. Existing callers keep the old automatic selection, while removable parts and other joints with several freedoms can choose the intended lift, slide, or rotation.

The SDK guides include examples for sampling and rendering an explicit degree of freedom.

## Why

`sample_joint()` requires exactly one degree of freedom. `MotionStripView` used to choose a rotational axis first. Together, those rules made a free removable lid harder to test and preview than a hinge.

## Checks

The focused SDK tests passed with 56 tests. The repository suite passed 640 tests with 2 deselected when the paid live generation file was excluded. Ruff passed.
