### PR TITLE
Add hollow loft profiles

### DIFF
--- a/src/articraft/sdk/_mesh/core.py
+++ b/src/articraft/sdk/_mesh/core.py
@@ -1146,6 +1146,62 @@ def _add_rounded_loft_cap(
 
 
 class LoftGeometry(MeshGeometry):
+    @classmethod
+    def from_shell_profiles(
+        cls,
+        outer_profiles: Iterable[Iterable[Sequence[float]]],
+        inner_profiles: Iterable[Iterable[Sequence[float]]],
+        *,
+        interpolation: str = "linear",
+        samples_per_span: int = 1,
+        parameterization: str = "uniform",
+        tension: float = 0.0,
+    ) -> LoftGeometry:
+        """Build a hollow loft directly from corresponding outer and inner profiles."""
+        outer_rings = [_profile_3d(profile, minimum=3) for profile in outer_profiles]
+        inner_rings = [_profile_3d(profile, minimum=3) for profile in inner_profiles]
+        if len(outer_rings) != len(inner_rings):
+            raise ValueError("outer and inner loft profiles must have the same section count")
+        if len(outer_rings) < 2:
+            raise ValueError("a hollow loft requires at least two outer and inner profiles")
+        count = len(outer_rings[0])
+        if any(len(ring) != count for ring in (*outer_rings, *inner_rings)):
+            raise ValueError("outer and inner loft profiles must have the same point count")
+        if any(
+            _v_norm(_v_sub(outer, inner)) <= _EPS
+            for outer_ring, inner_ring in zip(outer_rings, inner_rings, strict=True)
+            for outer, inner in zip(outer_ring, inner_ring, strict=True)
+        ):
+            raise ValueError("outer and inner loft profiles must not touch")
+
+        options = {
+            "cap": False,
+            "closed": True,
+            "interpolation": interpolation,
+            "samples_per_span": samples_per_span,
+            "parameterization": parameterization,
+            "tension": tension,
+        }
+        outer_loft = cls(outer_rings, **options)
+        inner_loft = cls(inner_rings, **options)
+        if len(outer_loft.vertices) != len(inner_loft.vertices):
+            raise ValueError("outer and inner loft interpolation produced different ring counts")
+
+        inner_offset = len(outer_loft.vertices)
+        vertices = [*outer_loft.vertices, *inner_loft.vertices]
+        faces = [*outer_loft.faces]
+        faces.extend(
+            (inner_offset + c, inner_offset + b, inner_offset + a) for a, b, c in inner_loft.faces
+        )
+        outer_end = len(outer_loft.vertices) - count
+        inner_end = inner_offset + len(inner_loft.vertices) - count
+        _connect_loft_rings(faces, inner_offset, 0, count)
+        _connect_loft_rings(faces, outer_end, inner_end, count)
+
+        result = cls.__new__(cls)
+        MeshGeometry.__init__(result, vertices=vertices, faces=faces)
+        return result
+
     def __init__(
         self,
         profiles: Iterable[Iterable[Sequence[float]]],

--- a/src/articraft/sdk/docs/mesh/00_mesh_geometry.md
+++ b/src/articraft/sdk/docs/mesh/00_mesh_geometry.md
@@ -466,6 +466,34 @@ LoftGeometry(
 This is the direct mesh loft. Use `section_loft(...)` when sections have
 different point counts, need path offsets, need symmetry, or need repair.
 
+Use `from_shell_profiles(...)` for a hollow loft with open ends and a solid wall:
+
+```python
+LoftGeometry.from_shell_profiles(
+    outer_profiles: Iterable[Iterable[tuple[float, float, float]]],
+    inner_profiles: Iterable[Iterable[tuple[float, float, float]]],
+    *,
+    interpolation: str = "linear",
+    samples_per_span: int = 1,
+    parameterization: str = "uniform",
+    tension: float = 0.0,
+) -> LoftGeometry
+```
+
+The outer and inner inputs must have the same section count and point count. Corresponding
+points should describe the same position around each section. The helper builds both wall
+surfaces and joins them with an annular face at each end. It does not use a mesh boolean.
+
+```python
+spout = LoftGeometry.from_shell_profiles(
+    outer_profiles=[outer_root, outer_middle, outer_tip],
+    inner_profiles=[inner_root, inner_middle, inner_tip],
+    interpolation="catmull_rom",
+    samples_per_span=3,
+    parameterization="centripetal",
+)
+```
+
 At least two profiles are required. Every profile must have the same point
 count. With `closed=True`, each profile needs at least three distinct points
 and must enclose a nonzero planar area. Adjacent profile centers must be

--- a/src/articraft/sdk/docs/mesh/30_section_lofts.md
+++ b/src/articraft/sdk/docs/mesh/30_section_lofts.md
@@ -23,6 +23,10 @@ Use `LoftGeometry` instead when all profiles already have the same point count
 and need only a direct connection. Read [mesh geometry and solid
 builders](00_mesh_geometry.md) for that lower level builder.
 
+Use `LoftGeometry.from_shell_profiles(...)` when corresponding outer and inner sections
+should form one hollow wall. It builds the wall directly and joins the two end rings, so a
+boolean difference is not needed.
+
 ## LoftSection
 
 ```python

--- a/tests/test_mesh_sdk.py
+++ b/tests/test_mesh_sdk.py
@@ -215,6 +215,57 @@ def test_lathe_loft_and_extrusions_build_expected_solids() -> None:
     assert with_hole.to_trimesh().volume == pytest.approx((0.04 - 0.0036) * 0.02)
 
 
+def test_hollow_loft_builds_one_watertight_wall_without_booleans() -> None:
+    def ring(center: tuple[float, float, float], radius: float) -> list[tuple[float, float, float]]:
+        return [
+            (
+                center[0] + radius * math.cos(angle),
+                center[1] + radius * math.sin(angle),
+                center[2],
+            )
+            for angle in np.linspace(0.0, 2.0 * math.pi, 16, endpoint=False)
+        ]
+
+    centers = ((0.0, 0.0, 0.0), (0.015, 0.0, 0.08), (0.045, 0.0, 0.16))
+    shell = LoftGeometry.from_shell_profiles(
+        [ring(center, radius) for center, radius in zip(centers, (0.04, 0.035, 0.03), strict=True)],
+        [
+            ring(center, radius)
+            for center, radius in zip(centers, (0.032, 0.027, 0.022), strict=True)
+        ],
+        interpolation="catmull_rom",
+        samples_per_span=3,
+        parameterization="centripetal",
+    )
+
+    report = analyze_mesh_health(shell)
+    assert isinstance(shell, LoftGeometry)
+    assert shell.is_watertight
+    assert report.watertight
+    assert report.winding_consistent
+    assert report.component_count == 1
+    assert report.signed_volume > 0.0
+    assert not report.findings
+
+
+def test_hollow_loft_rejects_mismatched_or_touching_profiles() -> None:
+    square = [
+        (-0.1, -0.1, 0.0),
+        (0.1, -0.1, 0.0),
+        (0.1, 0.1, 0.0),
+        (-0.1, 0.1, 0.0),
+    ]
+    upper = [(x, y, 0.2) for x, y, _z in square]
+    inner = [[(x * 0.8, y * 0.8, z) for x, y, z in ring] for ring in (square, upper)]
+
+    with pytest.raises(ValueError, match="section count"):
+        LoftGeometry.from_shell_profiles((square, upper), (inner[0],))
+    with pytest.raises(ValueError, match="point count"):
+        LoftGeometry.from_shell_profiles((square, upper), (inner[0][:-1], inner[1][:-1]))
+    with pytest.raises(ValueError, match="must not touch"):
+        LoftGeometry.from_shell_profiles((square, upper), (square, upper))
+
+
 def test_sweep_pipe_wire_and_spline_builders() -> None:
     square = rounded_rect_profile(0.01, 0.006, 0.001)
     path = [(0.0, 0.0, 0.0), (0.04, 0.0, 0.04), (0.08, 0.0, 0.0)]


### PR DESCRIPTION
## What changed

`LoftGeometry.from_shell_profiles()` now builds a hollow loft from matching outer and inner sections. It creates the two wall surfaces and joins both ends with annular faces.

The helper supports the existing linear and Catmull Rom interpolation controls. It checks section counts, point counts, and touching profiles before it builds the mesh.

The mesh guides include the new signature and a hollow spout example.

## Why

Hollow curved forms such as teapot spouts previously needed a mesh boolean or custom face construction. Boolean subtraction can leave slivers or disconnected debris. This helper builds the intended wall topology directly.

## Checks

The mesh SDK file passed 45 tests. The new bent and tapered shell test verifies one watertight component, consistent winding, and positive volume. The repository suite passed 640 tests with 2 deselected when the paid live generation file was excluded. Ruff passed.
