### PR TITLE
Validate rounded lathe caps

### DIFF
--- a/src/articraft/sdk/_mesh/core.py
+++ b/src/articraft/sdk/_mesh/core.py
@@ -876,6 +876,15 @@ class LatheGeometry(MeshGeometry):
     ) -> LatheGeometry:
         outer = _profile_2d(outer_profile, minimum=2)
         inner = _profile_2d(inner_profile, minimum=2)
+        for name, first, second, mode in (
+            ("start_cap", inner[0], outer[0], start_cap),
+            ("end_cap", outer[-1], inner[-1], end_cap),
+        ):
+            if mode == "round" and abs(first[0]) <= _EPS and abs(second[0]) <= _EPS:
+                raise ValueError(
+                    f"lathe shell {name}='round' cannot connect two points on the rotation "
+                    "axis; use a flat cap or give one endpoint a positive radius"
+                )
         axis_direction = 1.0 if outer[-1][1] + inner[-1][1] >= outer[0][1] + inner[0][1] else -1.0
         end = _cap_connector(outer[-1], inner[-1], end_cap, lip_samples, outward_z=axis_direction)
         start = _cap_connector(

--- a/src/articraft/sdk/docs/mesh/00_mesh_geometry.md
+++ b/src/articraft/sdk/docs/mesh/00_mesh_geometry.md
@@ -435,6 +435,10 @@ order defines the start and end. Cap modes are `"flat"` and `"round"`.
 `lip_samples` controls the curved connector used by a round cap and is clamped
 to at least 2.
 
+A round cap needs at least one endpoint with a positive radius. It cannot connect two points
+on the rotation axis because that would create a ring of collapsed faces. Use a flat cap when
+both endpoints lie on the axis.
+
 ```python
 cup = LatheGeometry.from_shell_profiles(
     outer_profile=[(0.045, 0.0), (0.050, 0.09)],

--- a/tests/test_mesh_sdk.py
+++ b/tests/test_mesh_sdk.py
@@ -189,6 +189,17 @@ def test_profile_and_spline_helpers_are_deterministic() -> None:
     assert arc[-1] == pytest.approx((0.0, 1.0, 0.0), abs=1e-8)
 
 
+def test_lathe_shell_rejects_round_cap_between_axis_points() -> None:
+    outer = [(0.0, -0.12), (0.08, -0.08), (0.09, 0.1)]
+    inner = [(0.0, -0.09), (0.06, -0.06), (0.07, 0.08)]
+
+    flat = LatheGeometry.from_shell_profiles(outer, inner, start_cap="flat")
+
+    assert flat.is_watertight
+    with pytest.raises(ValueError, match="cannot connect two points on the rotation axis"):
+        LatheGeometry.from_shell_profiles(outer, inner, start_cap="round")
+
+
 def test_lathe_loft_and_extrusions_build_expected_solids() -> None:
     lathe = LatheGeometry([(0.0, -0.1), (0.08, -0.1), (0.08, 0.1), (0.0, 0.1)])
     shell = LatheGeometry.from_shell_profiles(


### PR DESCRIPTION
## What changed

`LatheGeometry.from_shell_profiles()` now rejects a rounded cap when both endpoints lie on the rotation axis. The error tells the caller to use a flat cap or give one endpoint a positive radius.

The mesh guide explains the invalid case. The regression test also verifies that the same profiles produce a watertight shell with a flat cap.

## Why

A rounded connector between two axis points creates collapsed rings and boundary edges. The previous helper returned that broken mesh, so the agent found the problem only during compile and had to repair the model in another turn.

## Checks

The focused lathe tests passed. The repository suite passed 639 tests with 2 deselected when the paid live generation file was excluded. Ruff passed.
