### PR TITLE
Add atomic batch edits

### DIFF
--- a/src/articraft/agent/compaction.py
+++ b/src/articraft/agent/compaction.py
@@ -195,6 +195,7 @@ def _tool_call(call: dict[str, Any]) -> str:
     elif name == "edit":
         arguments.pop("old_text", None)
         arguments.pop("new_text", None)
+        arguments.pop("edits", None)
         arguments["text"] = "[edit text omitted]"
     return f"{name}({_truncate(json.dumps(arguments, sort_keys=True))})"
 

--- a/src/articraft/agent/tools/edit.py
+++ b/src/articraft/agent/tools/edit.py
@@ -1,42 +1,93 @@
 from __future__ import annotations
 
+from itertools import pairwise
 from typing import Any
 
 from articraft.agent.tools._core import Tool, ToolContext, display_path, schema, workspace_path
 
 
+def _replacement_args(args: dict[str, Any]) -> list[tuple[str, str]]:
+    raw = args.get("edits")
+    if (
+        raw is None
+        and isinstance(args.get("old_text"), str)
+        and isinstance(args.get("new_text"), str)
+    ):
+        raw = [{"old_text": args["old_text"], "new_text": args["new_text"]}]
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("edits must contain at least one replacement")
+    replacements: list[tuple[str, str]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"edits[{index}] must be an object")
+        old_text = item.get("old_text")
+        new_text = item.get("new_text")
+        if not isinstance(old_text, str) or not isinstance(new_text, str):
+            raise ValueError(f"edits[{index}] must contain string old_text and new_text values")
+        if not old_text:
+            raise ValueError(f"edits[{index}].old_text must not be empty")
+        if old_text == new_text:
+            raise ValueError(f"edits[{index}] would not change the file")
+        replacements.append((old_text, new_text))
+    return replacements
+
+
 async def run(context: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     path = workspace_path(context.workspace, str(args["path"]))
-    old_text = str(args["old_text"])
-    new_text = str(args["new_text"])
     text = path.read_text(encoding="utf-8")
-    count = text.count(old_text)
-    if count != 1:
-        raise ValueError(f"old_text matched {count} times")
-    path.write_text(text.replace(old_text, new_text, 1), encoding="utf-8")
-    return {"path": display_path(context.workspace, path), "replaced": 1}
+    matches: list[tuple[int, int, int, str]] = []
+    replacements = _replacement_args(args)
+    for index, (old_text, new_text) in enumerate(replacements):
+        count = text.count(old_text)
+        if count != 1:
+            raise ValueError(f"edits[{index}].old_text matched {count} times")
+        start = text.index(old_text)
+        matches.append((start, start + len(old_text), index, new_text))
+    matches.sort()
+    for previous, current in pairwise(matches):
+        if previous[1] > current[0]:
+            raise ValueError(
+                f"edits[{previous[2]}] and edits[{current[2]}] overlap; merge them into one edit"
+            )
+    updated = text
+    for start, end, _index, new_text in reversed(matches):
+        updated = updated[:start] + new_text + updated[end:]
+    path.write_text(updated, encoding="utf-8")
+    return {"path": display_path(context.workspace, path), "replaced": len(replacements)}
 
 
 TOOL = Tool(
     "edit",
     schema(
         "edit",
-        "Edit one workspace file by replacing an exact text block. The old text must appear exactly once; use read first if you need current context.",
+        "Edit one workspace file with one or more exact replacements. Every old text must appear exactly once in the original file. The whole call fails without writing if any replacement is invalid.",
         {
             "path": {
                 "type": "string",
                 "description": "Path to the file inside the run workspace. Relative paths are resolved against the workspace.",
             },
-            "old_text": {
-                "type": "string",
-                "description": "Exact text to replace. The call fails unless this text appears exactly once.",
-            },
-            "new_text": {
-                "type": "string",
-                "description": "Replacement text to write in place of old_text.",
+            "edits": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Targeted replacements matched against the original file. Use one call for disjoint changes. Merge nearby or overlapping changes into one replacement.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "old_text": {
+                            "type": "string",
+                            "description": "Exact text to replace. It must appear exactly once in the original file.",
+                        },
+                        "new_text": {
+                            "type": "string",
+                            "description": "Replacement text to write in place of old_text.",
+                        },
+                    },
+                    "required": ["old_text", "new_text"],
+                    "additionalProperties": False,
+                },
             },
         },
-        ["path", "old_text", "new_text"],
+        ["path", "edits"],
     ),
     run,
 )

--- a/src/articraft/prompts/system.md
+++ b/src/articraft/prompts/system.md
@@ -227,8 +227,10 @@ and failure cases. Do not spend shell calls guessing the API.
 The `view_image` tool is also available for relevant workspace images and SDK
 reference figures.
 </image_prompt>
-Use `edit` for one exact replacement and `write` for an intentional whole file
-replacement. Use them for `main.py` and for local helper modules. Use
+Use `edit` for one or more exact replacements in one file and `write` for an
+intentional whole file replacement. Put disjoint replacements for the same file
+in one `edit` call. The tool matches every replacement against the original
+file. Use these tools for `main.py` and for local helper modules. Use
 `exec_command` and `write_stdin` for local inspection scripts, short geometry
 inspections, and debugging tasks that `read` and `compile` do not cover. Python
 commands can import the public SDK. Use `"$ARTICRAFT_PYTHON"` to run them

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -478,14 +478,20 @@ def test_agent_keeps_compile_fresh_after_inspection_and_noop_edits(
             calls(
                 tool_call(
                     "edit",
-                    {"path": "main.py", "old_text": "x", "new_text": "x"},
+                    {
+                        "path": "main.py",
+                        "edits": [{"old_text": "x", "new_text": "x"}],
+                    },
                     call_id="call_3",
                 )
             ),
             calls(
                 tool_call(
                     "edit",
-                    {"path": "main.py", "old_text": "missing", "new_text": "y"},
+                    {
+                        "path": "main.py",
+                        "edits": [{"old_text": "missing", "new_text": "y"}],
+                    },
                     call_id="call_4",
                 )
             ),

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -52,7 +52,12 @@ def test_tool_schemas_include_prompting_guidance() -> None:
         stdin_props["chars"]["description"]
         == "Bytes to write to stdin. Defaults to empty, which polls without writing."
     )
-    assert "appears exactly once" in edit_props["old_text"]["description"]
+    assert "old_text" not in edit_props
+    assert edit_props["edits"]["minItems"] == 1
+    assert (
+        "appear exactly once"
+        in edit_props["edits"]["items"]["properties"]["old_text"]["description"]
+    )
     assert get("read").supports_parallel is True
     assert get("view_image").supports_parallel is False
     assert get("exec_command").supports_parallel is False
@@ -88,7 +93,10 @@ def test_workspace_tools_handle_default_relative_run_dir(monkeypatch, tmp_path) 
     write_result = run(get("write").run(ctx, {"path": "main.py", "content": "old\n"}))
     read_result = run(get("read").run(ctx, {"path": "main.py"}))
     edit_result = run(
-        get("edit").run(ctx, {"path": "main.py", "old_text": "old", "new_text": "new"})
+        get("edit").run(
+            ctx,
+            {"path": "main.py", "edits": [{"old_text": "old", "new_text": "new"}]},
+        )
     )
 
     assert write_result == {"path": "main.py", "bytes": 4}
@@ -249,7 +257,12 @@ def test_edit_replaces_unique_text(tmp_path) -> None:
     path = ctx.workspace / "main.py"
     path.write_text("old\n", encoding="utf-8")
 
-    result = run(get("edit").run(ctx, {"path": "main.py", "old_text": "old", "new_text": "new"}))
+    result = run(
+        get("edit").run(
+            ctx,
+            {"path": "main.py", "edits": [{"old_text": "old", "new_text": "new"}]},
+        )
+    )
 
     assert result == {"path": "main.py", "replaced": 1}
     assert path.read_text(encoding="utf-8") == "new\n"
@@ -260,7 +273,100 @@ def test_edit_fails_when_text_is_not_unique(tmp_path) -> None:
     ctx.workspace.joinpath("main.py").write_text("x\nx\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="2 times"):
-        run(get("edit").run(ctx, {"path": "main.py", "old_text": "x", "new_text": "y"}))
+        run(
+            get("edit").run(
+                ctx,
+                {"path": "main.py", "edits": [{"old_text": "x", "new_text": "y"}]},
+            )
+        )
+
+
+def test_edit_applies_disjoint_replacements_atomically(tmp_path) -> None:
+    ctx = context(tmp_path)
+    path = ctx.workspace / "main.py"
+    path.write_text("alpha\nmiddle\nomega\n", encoding="utf-8")
+
+    result = run(
+        get("edit").run(
+            ctx,
+            {
+                "path": "main.py",
+                "edits": [
+                    {"old_text": "alpha", "new_text": "first"},
+                    {"old_text": "omega", "new_text": "last"},
+                ],
+            },
+        )
+    )
+
+    assert result == {"path": "main.py", "replaced": 2}
+    assert path.read_text(encoding="utf-8") == "first\nmiddle\nlast\n"
+
+
+def test_edit_does_not_write_when_one_replacement_fails(tmp_path) -> None:
+    ctx = context(tmp_path)
+    path = ctx.workspace / "main.py"
+    original = "alpha\nomega\n"
+    path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"edits\[1\].*matched 0 times"):
+        run(
+            get("edit").run(
+                ctx,
+                {
+                    "path": "main.py",
+                    "edits": [
+                        {"old_text": "alpha", "new_text": "first"},
+                        {"old_text": "missing", "new_text": "last"},
+                    ],
+                },
+            )
+        )
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_edit_rejects_overlapping_and_noop_replacements(tmp_path) -> None:
+    ctx = context(tmp_path)
+    path = ctx.workspace / "main.py"
+    path.write_text("alpha beta\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="overlap"):
+        run(
+            get("edit").run(
+                ctx,
+                {
+                    "path": "main.py",
+                    "edits": [
+                        {"old_text": "alpha beta", "new_text": "whole"},
+                        {"old_text": "beta", "new_text": "tail"},
+                    ],
+                },
+            )
+        )
+    with pytest.raises(ValueError, match="would not change"):
+        run(
+            get("edit").run(
+                ctx,
+                {
+                    "path": "main.py",
+                    "edits": [{"old_text": "alpha", "new_text": "alpha"}],
+                },
+            )
+        )
+
+    assert path.read_text(encoding="utf-8") == "alpha beta\n"
+
+
+def test_edit_accepts_the_legacy_single_replacement_shape(tmp_path) -> None:
+    ctx = context(tmp_path)
+    path = ctx.workspace / "main.py"
+    path.write_text("old\n", encoding="utf-8")
+
+    result = run(get("edit").run(ctx, {"path": "main.py", "old_text": "old", "new_text": "new"}))
+
+    assert result == {"path": "main.py", "replaced": 1}
+    assert path.read_text(encoding="utf-8") == "new\n"
 
 
 def test_edit_rejects_symlinked_sdk_docs(tmp_path) -> None:
@@ -272,8 +378,7 @@ def test_edit_rejects_symlinked_sdk_docs(tmp_path) -> None:
                 ctx,
                 {
                     "path": "docs/sdk/common/20_core_types.md",
-                    "old_text": "Core Types",
-                    "new_text": "Core Values",
+                    "edits": [{"old_text": "Core Types", "new_text": "Core Values"}],
                 },
             )
         )

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -65,6 +65,22 @@ def test_summary_input_omits_large_payloads() -> None:
     messages[3]["tool_calls"][0]["arguments"] = json.dumps(
         {"path": "main.py", "content": "SECRET_FILE_BODY" * 200}
     )
+    messages[3]["tool_calls"].append(
+        {
+            "name": "edit",
+            "arguments": json.dumps(
+                {
+                    "path": "main.py",
+                    "edits": [
+                        {
+                            "old_text": "SECRET_OLD_TEXT" * 200,
+                            "new_text": "SECRET_NEW_TEXT" * 200,
+                        }
+                    ],
+                }
+            ),
+        }
+    )
     messages[4]["output"] = [
         {"type": "input_text", "text": "x" * 3_000},
         {
@@ -77,8 +93,11 @@ def test_summary_input_omits_large_payloads() -> None:
     assert plan is not None
     summary_input = plan.summary_messages[1]["content"]
     assert "SECRET_FILE_BODY" not in summary_input
+    assert "SECRET_OLD_TEXT" not in summary_input
+    assert "SECRET_NEW_TEXT" not in summary_input
     assert "SECRET_IMAGE_DATA" not in summary_input
     assert "[file content omitted]" in summary_input
+    assert "[edit text omitted]" in summary_input
     assert "more characters omitted" in summary_input
     assert "image payload omitted" in summary_input
 


### PR DESCRIPTION
## What changed

The edit tool now exposes one `edits[]` input for both single and multiple replacements. It checks every exact match against the original file, rejects repeated or overlapping targets, and writes only after the whole batch is valid.

The old single replacement shape remains as an internal compatibility path for saved runs, but it is no longer part of the model facing schema.

The prompt asks the agent to group disjoint changes to one file in one call. Compaction removes all replacement text from old tool history.

## Why

The old tool could change only one text block per call. A model that needed several independent changes had to take several turns and resend its growing context. Pi's current editor avoids that cost with one array based schema and atomic matching against the original file.

## Checks

The focused agent, tool, and compaction files passed 79 tests. The repository suite passed 642 tests with 2 deselected when the paid live generation file was excluded. Ruff passed.
