### PR TITLE
Batch image inspection calls

### DIFF
--- a/src/articraft/agent/harness.py
+++ b/src/articraft/agent/harness.py
@@ -534,7 +534,9 @@ def _arguments(call: dict[str, Any]) -> dict[str, Any]:
 def _supports_parallel(call: dict[str, Any]) -> bool:
     try:
         name = str(call["name"])
-        return name == "read" and tools.get(name).supports_parallel
+        if name in {"write", "edit", "exec_command", "write_stdin", "compile"}:
+            return False
+        return tools.get(name).supports_parallel
     except (KeyError, ValueError):
         return False
 
@@ -684,7 +686,7 @@ def _read_sdk_quickstart(*, include_images: bool = True) -> str:
         "This SDK quickstart is preloaded for the run. Use it as the first "
         "reference. Before writing code, inspect the current script and survey "
         "the relevant SDK pages across plausible build123d and mesh approaches. "
-        "Use parallel reads when comparing independent references. Do not stop "
+        "Use parallel reads and image views when comparing independent references. Do not stop "
         "at the first workable API.\n\n"
         f"{quickstart.rstrip()}\n"
         "</sdk_quickstart>"

--- a/src/articraft/agent/tools/view_image.py
+++ b/src/articraft/agent/tools/view_image.py
@@ -58,4 +58,5 @@ TOOL = Tool(
         ["path"],
     ),
     run,
+    supports_parallel=True,
 )

--- a/src/articraft/prompts/system.md
+++ b/src/articraft/prompts/system.md
@@ -58,7 +58,7 @@ Keep the research relevant to the requested object.
 <image_prompt>
 When a relevant SDK page names a reference figure, use `view_image` if the
 figure can clarify the geometry, construction order, or visible result. Do not
-load unrelated gallery images.
+load unrelated gallery images. Inspect independent images in one parallel group.
 </image_prompt>
 
 Make a compact internal brief before editing. Set the object scale, root part,
@@ -235,8 +235,11 @@ commands can import the public SDK. Use `"$ARTICRAFT_PYTHON"` to run them
 with the same interpreter as articraft. Run `compile` after an actual file
 change and before the final response.
 
-Only `read` calls may run in parallel. Treat shell calls and all workspace
-changes as ordered actions.
+`read` calls may run in parallel. Treat shell calls and all workspace changes
+as ordered actions.
+<image_prompt>
+`view_image` calls may also run in parallel.
+</image_prompt>
 </tools>
 
 <final_response>

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -1130,6 +1130,68 @@ def test_agent_runs_parallel_safe_tools_concurrently(monkeypatch, tmp_path) -> N
     assert [event["call_id"] for event in outputs[:2]] == ["call_1", "call_2"]
 
 
+def test_agent_batches_parallel_image_inspection(monkeypatch, tmp_path) -> None:
+    active = 0
+    max_active = 0
+
+    async def run_view_image(context, args):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return ToolResult(
+            {"path": args["path"]},
+            [
+                {
+                    "type": "input_image",
+                    "image_url": f"data:image/png;base64,{args['path']}",
+                    "detail": "high",
+                }
+            ],
+        )
+
+    def inspect_images(query: ModelQuery) -> Response:
+        outputs = [
+            message for message in query.messages if message.get("type") == "function_call_output"
+        ]
+        assert [output["call_id"] for output in outputs] == ["call_1", "call_2"]
+        assert [output["output"][1]["image_url"] for output in outputs] == [
+            "data:image/png;base64,a.png",
+            "data:image/png;base64,b.png",
+        ]
+        return calls(tool_call("compile", {}, call_id="call_3"))
+
+    monkeypatch.setattr(
+        agent_tools,
+        "TOOLS",
+        {
+            "view_image": Tool(
+                "view_image",
+                stub_schema("view_image"),
+                run_view_image,
+                supports_parallel=True,
+            ),
+            "compile": compile_success_tool(),
+        },
+    )
+    model = ScriptedModel(
+        [
+            calls(
+                tool_call("view_image", {"path": "a.png"}, call_id="call_1"),
+                tool_call("view_image", {"path": "b.png"}, call_id="call_2"),
+            ),
+            inspect_images,
+            text("done"),
+        ]
+    )
+
+    result = run(Agent(model, LocalWorkspace(output_dir=tmp_path), max_turns=3).run("a box"))
+
+    assert result["status"] == "success"
+    assert max_active == 2
+
+
 def test_agent_serializes_non_parallel_tools(monkeypatch, tmp_path) -> None:
     active = 0
     max_active = 0
@@ -1175,7 +1237,7 @@ def test_sdk_quickstart_user_message_is_preloaded() -> None:
     assert content.startswith("<sdk_quickstart>")
     assert "This SDK quickstart is preloaded for the run." in content
     assert "plausible build123d and mesh approaches" in content
-    assert "parallel reads" in content
+    assert "parallel reads and image views" in content
     assert "Do not stop at the first workable API" in content
     assert "# SDK quickstart" in content
     assert "`docs/sdk/common/40_testing.md`" in content

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -54,7 +54,7 @@ def test_tool_schemas_include_prompting_guidance() -> None:
     )
     assert "appears exactly once" in edit_props["old_text"]["description"]
     assert get("read").supports_parallel is True
-    assert get("view_image").supports_parallel is False
+    assert get("view_image").supports_parallel is True
     assert get("exec_command").supports_parallel is False
 
 


### PR DESCRIPTION
## What changed

The image inspection tool is now safe to batch with other image inspections. The harness uses each tool's parallel flag for read only tools while it still forces writes, edits, shell commands, and compiles to run in order.

The image prompt asks the agent to inspect independent images in one group. Text only models do not receive that instruction.

## Why

The old prompt allowed only parallel text reads. Agents therefore tended to open one preview per model turn. A set of related previews can now reach the model together, which avoids repeated requests with the same growing context.

## Checks

The focused agent and tool files passed 73 tests. The new test runs two typed image results together and verifies their order in the next model request. The repository suite passed 639 tests with 2 deselected when the paid live generation file was excluded. Ruff passed.
