### PR TITLE
Ask whether a hole actually fits, not whether its average point does

### DIFF
--- a/src/articraft/sdk/_mesh/core.py
+++ b/src/articraft/sdk/_mesh/core.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import math
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
-from itertools import pairwise
+from itertools import combinations, pairwise
 from numbers import Integral
 from typing import TYPE_CHECKING, Any, ClassVar, SupportsIndex, TypeAlias, cast
 
+import manifold3d
 import numpy as np
 import trimesh
 from scipy.interpolate import CubicHermiteSpline  # pyright: ignore[reportMissingTypeStubs]
@@ -281,23 +282,43 @@ def _ensure_ccw(points: list[Vec2]) -> list[Vec2]:
     return points if area > 0.0 else list(reversed(points))
 
 
-def _point_in_polygon(point: Vec2, polygon: Sequence[Vec2]) -> bool:
-    inside = False
-    for start, end in pairwise([*polygon, polygon[0]]):
-        cross = (end[0] - start[0]) * (point[1] - start[1]) - (end[1] - start[1]) * (
-            point[0] - start[0]
-        )
-        if (
-            abs(cross) <= 1e-9
-            and min(start[0], end[0]) - 1e-9 <= point[0] <= max(start[0], end[0]) + 1e-9
-            and min(start[1], end[1]) - 1e-9 <= point[1] <= max(start[1], end[1]) + 1e-9
-        ):
-            return True
-        if (start[1] > point[1]) != (end[1] > point[1]):
-            crossing = start[0] + (point[1] - start[1]) * (end[0] - start[0]) / (end[1] - start[1])
-            if crossing >= point[0]:
-                inside = not inside
-    return inside
+def _check_holes_fit(outer: list[Vec2], holes: list[list[Vec2]]) -> None:
+    """Reject holes that leave the outer profile or overlap each other.
+
+    Asked as an area question rather than by testing one averaged point. A hole
+    that straddles the boundary can have its mean comfortably inside, and the
+    cap is then triangulated against a hole the walls do not enclose: the mesh
+    that comes back is watertight, so mesh health passes it, while actually
+    being two components with the wrong volume.
+    """
+
+    if not holes:
+        return
+
+    def section(ring: list[Vec2]) -> manifold3d.CrossSection:
+        return manifold3d.CrossSection([np.asarray(ring, dtype=np.float64)])
+
+    outline = section(outer)
+    # Scale the tolerance to the profile, so the same check reads a millimetre
+    # bracket and a two metre panel.
+    slack = max(outline.area(), _EPS) * 1e-9
+    cuts = [section(hole) for hole in holes]
+    for index, cut in enumerate(cuts):
+        # `-` is difference: whatever of the hole is not covered by the outline.
+        escaped = (cut - outline).area()
+        if escaped > slack:
+            raise ValueError(
+                f"hole profile {index} must lie inside the outer profile; "
+                f"{escaped:.6g} of its area falls outside"
+            )
+    for first, second in combinations(range(len(cuts)), 2):
+        # `^` is intersection: two holes sharing area cut the same material twice.
+        shared = (cuts[first] ^ cuts[second]).area()
+        if shared > slack:
+            raise ValueError(
+                f"hole profiles {first} and {second} must not overlap; "
+                f"they share {shared:.6g} of area"
+            )
 
 
 def _triangulate_simple(points: list[Vec2]) -> list[Face]:
@@ -309,18 +330,10 @@ def _triangulate_with_holes(
 ) -> tuple[list[Vec2], list[Face]]:
     outer = _ensure_ccw(outer)
     holes = [_ensure_ccw(hole) for hole in holes]
-    for hole in holes:
-        center = (
-            sum(point[0] for point in hole) / len(hole),
-            sum(point[1] for point in hole) / len(hole),
-        )
-        if not _point_in_polygon(center, outer):
-            raise ValueError("hole profile must lie inside the outer profile")
+    _check_holes_fit(outer, holes)
     rings = [outer, *(list(reversed(hole)) for hole in holes)]
     flat = [point for ring in rings for point in ring]
     try:
-        import manifold3d
-
         polygons = cast(
             "list[DoubleNx2[int]]",
             [np.asarray(ring, dtype=np.float64) for ring in rings],

--- a/tests/test_mesh_sdk.py
+++ b/tests/test_mesh_sdk.py
@@ -801,3 +801,37 @@ def test_shell_partition_and_face_opening_helpers() -> None:
 def test_wire_polyline_rejects_invalid_options(kwargs: dict[str, Any]) -> None:
     with pytest.raises(ValueError):
         WirePolylineGeometry([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)], **kwargs)
+
+
+def test_extrude_rejects_a_hole_that_leaves_the_outer_profile() -> None:
+    """A hole straddling the boundary used to pass and build a broken solid.
+
+    The old check tested the hole's averaged point, which sits inside the
+    square here even though a third of the hole hangs off the right edge. The
+    mesh that came back was watertight -- so mesh health passed it -- but was
+    two components with the wrong volume.
+    """
+
+    outer = [(0.0, 0.0), (0.04, 0.0), (0.04, 0.04), (0.0, 0.04)]
+    escaping = [(0.025, 0.01), (0.054, 0.01), (0.054, 0.03), (0.025, 0.03)]
+    assert np.allclose(np.mean(escaping, axis=0), (0.0395, 0.02))  # inside the square
+    with pytest.raises(ValueError, match="must lie inside the outer profile"):
+        ExtrudeWithHolesGeometry(outer, [escaping], 0.01)
+
+
+def test_extrude_rejects_overlapping_holes() -> None:
+    outer = [(0.0, 0.0), (0.06, 0.0), (0.06, 0.06), (0.0, 0.06)]
+    first = [(0.01, 0.01), (0.03, 0.01), (0.03, 0.03), (0.01, 0.03)]
+    second = [(0.02, 0.02), (0.04, 0.02), (0.04, 0.04), (0.02, 0.04)]
+    with pytest.raises(ValueError, match="must not overlap"):
+        ExtrudeWithHolesGeometry(outer, [first, second], 0.01)
+
+
+def test_extrude_still_accepts_holes_that_fit() -> None:
+    outer = [(0.0, 0.0), (0.06, 0.0), (0.06, 0.06), (0.0, 0.06)]
+    first = [(0.01, 0.01), (0.02, 0.01), (0.02, 0.02), (0.01, 0.02)]
+    second = [(0.04, 0.04), (0.05, 0.04), (0.05, 0.05), (0.04, 0.05)]
+    solid = ExtrudeWithHolesGeometry(outer, [first, second], 0.01).to_trimesh()
+    assert solid.is_watertight
+    assert solid.euler_number == -2  # one solid, genus two: 2 - 2 * holes
+    assert solid.volume == pytest.approx((0.0036 - 2 * 0.0001) * 0.01)


### PR DESCRIPTION
## What changed

`_triangulate_with_holes` checked hole containment by averaging the hole's vertices and ray casting that one point against the outer profile. It now asks `manifold3d` how much of the hole's area falls outside the outline, and rejects the profile when any does.

The same pass rejects holes that overlap each other, which nothing checked before. The hand written `_point_in_polygon` ray cast is retired; the containment test was its only caller.

`manifold3d` moves to a module level import, matching `_collision.py`, `weld.py`, and `boolean.py`. It was already imported inside two functions here, one of them within a `try` that would have reported an import failure as a malformed profile.

## Why

The averaged point is right at both extremes and wrong in the band between them. A hole far outside the profile is rejected correctly, because its mean is outside. A hole well inside is accepted correctly. A hole that **hangs over the edge** is accepted, because most of it is still on the part:

```python
outer = [(0, 0), (0.04, 0), (0.04, 0.04), (0, 0.04)]        # 40mm square
hole  = [(0.025, 0.01), (0.054, 0.01), (0.054, 0.03), (0.025, 0.03)]
# mean (0.0395, 0.02) is inside; the hole runs 14mm past the edge
```

That is the failure worth closing, because it is the plausible authoring mistake. A hole is rarely nowhere near the part; it is a couple of millimetres too wide, or nudged toward the rim, which is what an agent iterating on dimensions produces.

`ExtrudeWithHolesGeometry` accepts that profile today and builds wall loops around the full hole perimeter, including the part with no material behind it. The result is not a plate with a badly cut hole but two components: the uncut plate, plus an inward wound prism hanging off the edge whose negative volume cancels part of it. The solid reports `is_watertight == True` and a volume roughly a fifth short of correct.

`analyze_mesh_health` does catch this, as `inward_orientation` — so the claim is not that it goes undetected. It is that detection is late and opt in: nothing during construction runs it, and it only surfaces if the model calls `fail_if_mesh_unhealthy`. Rejecting at the helper that made the shape is the same move as #141 rejecting an invalid lathe cap instead of returning a broken mesh for compile to find.

Overlapping holes had no coverage anywhere, before or after health analysis.

## Checks

`tests/test_mesh_sdk.py` passes with 49 tests, including three new ones: the escaping hole is rejected, overlapping holes are rejected, and two holes that do fit still produce one watertight genus two solid with the expected volume. The repository suite passes 652 tests with 3 deselected, excluding the paid live generation file. Ruff and basedpyright pass.