### PR TITLE
Catch a closed loop that contradicts its own joint limits

### DIFF
--- a/src/articraft/compiler/feedback.py
+++ b/src/articraft/compiler/feedback.py
@@ -362,6 +362,11 @@ _FAILURE_SPECS: dict[FailureKind, _FailureSpec] = {
         "ARTICULATION_SEPARATION",
         "A hinge or pivot pulls its child away from its parent during motion.",
     ),
+    FailureKind.LOOP_LIMITS: _FailureSpec(
+        "loop_limits",
+        "LOOP_LIMITS",
+        "A closed loop contradicts its own joint limits.",
+    ),
     FailureKind.AUTHORED: _FailureSpec(
         "test_failure",
         "FAILURE",

--- a/src/articraft/compiler/worker.py
+++ b/src/articraft/compiler/worker.py
@@ -324,6 +324,8 @@ def _run_baseline_tests(
         ctx.fail_if_parts_overlap_in_current_pose()
     with tracker.phase("checking articulation motion"):
         ctx.fail_if_articulation_separates_child()
+    with tracker.phase("checking loop joint limits"):
+        ctx.fail_if_loop_limits_contradict()
     report = _without_allowance_notes(ctx.report())
     # Most baseline checks report as diagnostics so a run still produces a model.
     # Missing mass is different: with the physics lane on, a part without mass has

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -374,6 +374,7 @@ class ResolvedRigidBodyAssembly:
         dof_positions: Mapping[str, float] | None = None,
         *,
         relax_limits: bool = False,
+        loop_start: Mapping[str, float] | None = None,
     ) -> tuple[dict[str, float], dict[str, Mat4]]:
         """Solve the tree and its loops, before the state is validated.
 
@@ -425,6 +426,7 @@ class ResolvedRigidBodyAssembly:
                 self.articulations,
                 positions,
                 relax_limits=relax_limits,
+                start=loop_start,
             )
         try:
             transforms = _propagate_transforms(
@@ -851,6 +853,7 @@ def _solve_closed_loops(
     positions: dict[str, float],
     *,
     relax_limits: bool = False,
+    start: Mapping[str, float] | None = None,
 ) -> dict[str, float]:
     """Solve unspecified tree DOFs so every excluded constraint stays closed.
 
@@ -956,12 +959,23 @@ def _solve_closed_loops(
         )
         return project(solution.x)
 
-    values = np.zeros(len(candidates), dtype=np.float64)
-    # With no unknowns left -- every ring coordinate supplied by the caller --
-    # there is nothing to solve, but the closure residual still decides
-    # whether the supplied pose keeps the loop assembled.
-    for step in range(1, (_LOOP_STEPS if candidates else 0) + 1):
-        values = solve_toward(step / _LOOP_STEPS, values)
+    if start is not None and candidates:
+        # A warm start is already on the branch the caller is walking, so the
+        # homotopy from rest is not needed: one full-scale solve tracks it.
+        values = project(
+            np.asarray(
+                [start.get(joint.dof_id(dof), 0.0) for joint, dof in candidates],
+                dtype=np.float64,
+            )
+        )
+        values = solve_toward(1.0, values)
+    else:
+        values = np.zeros(len(candidates), dtype=np.float64)
+        # With no unknowns left -- every ring coordinate supplied by the caller --
+        # there is nothing to solve, but the closure residual still decides
+        # whether the supplied pose keeps the loop assembled.
+        for step in range(1, (_LOOP_STEPS if candidates else 0) + 1):
+            values = solve_toward(step / _LOOP_STEPS, values)
 
     # One gate, equal to validate_state's per-axis tolerance: anything
     # accepted here passes validation, anything rejected names the loop.

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -366,6 +366,24 @@ class ResolvedRigidBodyAssembly:
     def forward_kinematics(self, dof_positions: Mapping[str, float] | None = None) -> PhysicsState:
         """Pose the articulation tree and solve unspecified coordinates that close loops."""
 
+        positions, transforms = self._kinematics(dof_positions)
+        return self.validate_state(PhysicsState(transforms, dof_positions=positions))
+
+    def _kinematics(
+        self,
+        dof_positions: Mapping[str, float] | None = None,
+        *,
+        relax_limits: bool = False,
+    ) -> tuple[dict[str, float], dict[str, Mat4]]:
+        """Solve the tree and its loops, before the state is validated.
+
+        With ``relax_limits`` the solver ignores the limits on the coordinates
+        it derives, so a caller can ask where the mechanism reaches instead of
+        where the authored limits let it reach. Those coordinates can then land
+        outside their own limits, which is why this stays private:
+        ``forward_kinematics`` validates everything it hands out.
+        """
+
         positions = {
             _as_name(name, field_name="joint position"): _finite(
                 value, field_name=f"joint position {name!r}"
@@ -406,6 +424,7 @@ class ResolvedRigidBodyAssembly:
                 closures,
                 self.articulations,
                 positions,
+                relax_limits=relax_limits,
             )
         try:
             transforms = _propagate_transforms(
@@ -419,7 +438,7 @@ class ResolvedRigidBodyAssembly:
                 "forward kinematics requires one spanning articulation tree; "
                 "provide a complete PhysicsState for this assembly"
             ) from exc
-        return self.validate_state(PhysicsState(transforms, dof_positions=positions))
+        return positions, transforms
 
 
 @dataclass
@@ -830,6 +849,8 @@ def _solve_closed_loops(
     closures: tuple[Joint, ...],
     articulations: tuple[ResolvedArticulation, ...],
     positions: dict[str, float],
+    *,
+    relax_limits: bool = False,
 ) -> dict[str, float]:
     """Solve unspecified tree DOFs so every excluded constraint stays closed.
 
@@ -864,12 +885,13 @@ def _solve_closed_loops(
     if not any(locked.values()):
         return positions
 
-    limits = tuple(dof.limits for _, dof in candidates)
+    # Relaxing takes the walls away from the coordinates the solver derives,
+    # so the ring reports where the mechanism reaches instead of where the
+    # authored limits allow it to reach. Supplied coordinates keep their own
+    # limits either way -- the caller is driving those.
+    limits = tuple(None if relax_limits else dof.limits for _, dof in candidates)
     periodic = tuple(
-        dof.limits is not None
-        and cast(JointAxis, dof.axis).is_rotational
-        and dof.limits[1] - dof.limits[0] >= 2.0 * math.pi - 1e-9
-        for _, dof in candidates
+        _is_periodic(dof, bound) for (_, dof), bound in zip(candidates, limits, strict=True)
     )
 
     def assemble(scale: float, values: np.ndarray) -> dict[str, float]:
@@ -970,6 +992,19 @@ def _solve_closed_loops(
             "the mechanism cannot reach this pose"
         )
     return assemble(1.0, values)
+
+
+def _is_periodic(dof: JointDOF, limits: tuple[float, float] | None) -> bool:
+    """True when the coordinate turns full circle, so its limits are not a wall.
+
+    A hinge authored -pi..pi says "unconstrained", not "must reach every angle":
+    there is no seam at the ends, and no range claim for a mechanism to
+    contradict.
+    """
+
+    if limits is None or not cast(JointAxis, dof.axis).is_rotational:
+        return False
+    return limits[1] - limits[0] >= 2.0 * math.pi - 1e-9
 
 
 def _joint_path(

--- a/src/articraft/sdk/assembly.py
+++ b/src/articraft/sdk/assembly.py
@@ -382,7 +382,10 @@ class ResolvedRigidBodyAssembly:
         it derives, so a caller can ask where the mechanism reaches instead of
         where the authored limits let it reach. Those coordinates can then land
         outside their own limits, which is why this stays private:
-        ``forward_kinematics`` validates everything it hands out.
+        ``forward_kinematics`` validates everything it hands out. ``loop_start``
+        seeds the loop solver with a neighbouring solution, so a sweep can
+        continue along one assembly branch instead of solving every pose from
+        rest.
         """
 
         positions = {
@@ -861,6 +864,11 @@ def _solve_closed_loops(
     Walking from the zero configuration to the requested pose keeps linkages on
     the assembly branch they were authored in instead of snapping through a
     singular pose.
+
+    ``start`` maps dof ids to a warm start. Coordinates it names begin there,
+    projected into their bounds, missing ones begin at zero, and the homotopy
+    from rest is skipped: a caller walking a sweep hands in the neighbouring
+    solution and stays on the branch it was already on.
     """
 
     active_closures: list[Joint] = []

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -559,7 +559,7 @@ Nested closed solids with positive volume intersection count as connected geomet
 
 ### Loop limits
 
-`fail_if_loop_limits_contradict(*, samples=17, tolerance=1e-6, overrun_fraction=0.25,
+`fail_if_loop_limits_contradict(*, samples=9, tolerance=1e-6, overrun_fraction=0.25,
 max_solves=1000, name=None)` sweeps every bounded coordinate on a closed loop. Each sample is
 solved twice. One solve stays inside the authored limits. The other leaves the coordinates the
 solver derives unbounded, so it reports where the linkage reaches. The difference between the two
@@ -576,7 +576,7 @@ A full-circle coordinate is never reported. A hinge authored `(-pi, pi)` says un
 does not claim that every angle is reachable. A revolute coordinate also satisfies its limits when
 any whole turn of the required pose fits inside them.
 
-The sweep costs two loop solves per sample per coordinate. `max_solves` bounds that budget. When a
+The sweep costs one loop solve per sample per coordinate, plus a second solve for the poses a limit turns out to exclude. A coordinate on two rings is driven once. `max_solves` bounds that budget. When a
 ring has more bounded coordinates than fit, the check warns and names the ones it did not drive.
 
 ### Scale warnings

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -569,7 +569,7 @@ where a follower moves fastest. The check names two defects.
 
 A follower whose limits exclude motion the linkage requires. Where the walk leaves a follower's
 authored limits, the solve that respects those limits is asked for the same pose. Only its
-failure, pinned at the limits, makes a case. When it solves every accused pose instead, the
+failure to close the ring within them makes a case. When it solves every accused pose instead, the
 limits blocked nothing. The disagreement then indicts the unbounded walk, which has no assembly
 branch guarantee near a singular fold. The report gives the declared range, the range the
 mechanism needs, and the driver poses where the two disagree. The needed range is rounded
@@ -580,8 +580,9 @@ than `overrun_fraction` of the declared travel lies past where the ring stops cl
 fraction measures travel rather than samples, so slack smaller than that stays quiet at every
 sweep density.
 
-A full-circle coordinate is never reported. A hinge authored `(-pi, pi)` says unconstrained. It
-does not claim that every angle is reachable.
+A full-circle coordinate is never reported as a defect. A hinge authored `(-pi, pi)` says
+unconstrained. It does not claim that every angle is reachable. When such a ring closes over less
+than a hundredth of its declared range, the check warns that the loop barely moves.
 
 The walk costs about one loop solve per sample per coordinate. Each unreachable edge adds its
 bisection, and each pose a limit excludes adds one bounded solve. A coordinate on two rings is

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -511,6 +511,7 @@ health allowances into a new context and runs these baseline checks before expor
 6. `warn_if_absurd_dimensions()`
 7. `fail_if_parts_overlap_in_current_pose()`
 8. `fail_if_articulation_separates_child()`
+9. `fail_if_loop_limits_contradict()` (only reaches a closed loop the articulation tree spans)
 
 If model validity fails, the worker stops the rest of the baseline pass. When the object is valid
 enough to inspect, model validity, mesh health, missing mass properties, and USDZ validation can
@@ -555,6 +556,28 @@ ctx.fail_if_part_contains_disconnected_geometry_islands(contact_tol=1e-6)
 ```
 
 Nested closed solids with positive volume intersection count as connected geometry.
+
+### Loop limits
+
+`fail_if_loop_limits_contradict(*, samples=17, tolerance=1e-6, overrun_fraction=0.25,
+max_solves=1000, name=None)` sweeps every bounded coordinate on a closed loop. Each sample is
+solved twice. One solve stays inside the authored limits. The other leaves the coordinates the
+solver derives unbounded, so it reports where the linkage reaches. The difference between the two
+names two defects.
+
+A follower whose limits exclude motion the linkage requires. The check reports the range it
+declares, the range the mechanism needs, and the part of the driver travel where they disagree.
+
+A driver whose range is wider than the linkage can follow. This is reported once more than
+`overrun_fraction` of its sampled poses are out of reach. Less slack than that is normal
+authoring.
+
+A full-circle coordinate is never reported. A hinge authored `(-pi, pi)` says unconstrained. It
+does not claim that every angle is reachable. A revolute coordinate also satisfies its limits when
+any whole turn of the required pose fits inside them.
+
+The sweep costs two loop solves per sample per coordinate. `max_solves` bounds that budget. When a
+ring has more bounded coordinates than fit, the check warns and names the ones it did not drive.
 
 ### Scale warnings
 

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -572,6 +572,11 @@ A driver whose range is wider than the linkage can follow. This is reported once
 `overrun_fraction` of its sampled poses are out of reach. Less slack than that is normal
 authoring.
 
+A linkage can have assembly modes that no motion connects. A four bar sits elbow up or elbow
+down, with a span of driver values in between that has no solution at all. The check keeps the
+unbroken run of solutions nearest the rest pose. Anything past a gap describes a machine that would
+have to be taken apart and rebuilt. It counts as out of reach, not as required motion.
+
 A full-circle coordinate is never reported. A hinge authored `(-pi, pi)` says unconstrained. It
 does not claim that every angle is reachable. A revolute coordinate also satisfies its limits when
 any whole turn of the required pose fits inside them.

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -579,7 +579,7 @@ have to be taken apart and rebuilt. It counts as out of reach, not as required m
 
 A full-circle coordinate is never reported. A hinge authored `(-pi, pi)` says unconstrained. It
 does not claim that every angle is reachable. A revolute coordinate also satisfies its limits when
-any whole turn of the required pose fits inside them.
+the required pose, or one whole turn of it, fits inside them.
 
 The sweep costs one loop solve per sample per coordinate, plus a second solve for the poses a limit turns out to exclude. A coordinate on two rings is driven once. `max_solves` bounds that budget. When a
 ring has more bounded coordinates than fit, the check warns and names the ones it did not drive.

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -560,29 +560,33 @@ Nested closed solids with positive volume intersection count as connected geomet
 ### Loop limits
 
 `fail_if_loop_limits_contradict(*, samples=9, tolerance=1e-6, overrun_fraction=0.25,
-max_solves=1000, name=None)` sweeps every bounded coordinate on a closed loop. Each sample is
-solved twice. One solve stays inside the authored limits. The other leaves the coordinates the
-solver derives unbounded, so it reports where the linkage reaches. The difference between the two
-names two defects.
+max_solves=1000, name=None)` sweeps every bounded coordinate on a closed loop. The sweep walks
+outward from the rest pose. Each sample continues from its neighbour's solution, with the
+coordinates the solver derives unbounded, so the walk follows the motion the linkage asks for.
+Each side of the sweep ends at the first pose where the ring will not close. A bisection toward
+that edge measures the travel the mechanism covers. It also probes the motion close to the edge,
+where a follower moves fastest. The check names two defects.
 
-A follower whose limits exclude motion the linkage requires. The check reports the range it
-declares, the range the mechanism needs, and the part of the driver travel where they disagree.
+A follower whose limits exclude motion the linkage requires. Where the walk leaves a follower's
+authored limits, the solve that respects those limits is asked for the same pose. Only its
+failure, pinned at the limits, makes a case. When it solves every accused pose instead, the
+limits blocked nothing. The disagreement then indicts the unbounded walk, which has no assembly
+branch guarantee near a singular fold. The report gives the declared range, the range the
+mechanism needs, and the driver poses where the two disagree. The needed range is rounded
+outward, so its numbers can be copied back as the new limits.
 
-A driver whose range is wider than the linkage can follow. This is reported once more than
-`overrun_fraction` of its sampled poses are out of reach. Less slack than that is normal
-authoring.
-
-A linkage can have assembly modes that no motion connects. A four bar sits elbow up or elbow
-down, with a span of driver values in between that has no solution at all. The check keeps the
-unbroken run of solutions nearest the rest pose. Anything past a gap describes a machine that would
-have to be taken apart and rebuilt. It counts as out of reach, not as required motion.
+A driver whose declared range is wider than the linkage can follow. This is reported once more
+than `overrun_fraction` of the declared travel lies past where the ring stops closing. The
+fraction measures travel rather than samples, so slack smaller than that stays quiet at every
+sweep density.
 
 A full-circle coordinate is never reported. A hinge authored `(-pi, pi)` says unconstrained. It
-does not claim that every angle is reachable. A revolute coordinate also satisfies its limits when
-the required pose, or one whole turn of it, fits inside them.
+does not claim that every angle is reachable.
 
-The sweep costs one loop solve per sample per coordinate, plus a second solve for the poses a limit turns out to exclude. A coordinate on two rings is driven once. `max_solves` bounds that budget. When a
-ring has more bounded coordinates than fit, the check warns and names the ones it did not drive.
+The walk costs about one loop solve per sample per coordinate. Each unreachable edge adds its
+bisection, and each pose a limit excludes adds one bounded solve. A coordinate on two rings is
+driven once. `max_solves` bounds that budget. When a ring has more bounded coordinates than fit,
+the check warns and names the ones it did not drive.
 
 ### Scale warnings
 

--- a/src/articraft/sdk/docs/common/40_testing.md
+++ b/src/articraft/sdk/docs/common/40_testing.md
@@ -569,7 +569,10 @@ where a follower moves fastest. The check names two defects.
 
 A follower whose limits exclude motion the linkage requires. Where the walk leaves a follower's
 authored limits, the solve that respects those limits is asked for the same pose. Only its
-failure to close the ring within them makes a case. When it solves every accused pose instead, the
+failure to close the ring within them makes a case. When the driver is a full-circle coordinate,
+the case must also start at the first step away from rest. A stop that leaves the mechanism its
+motion around rest is authoring, not a contradiction. A full-circle driver claims no range that a
+stop could contradict. When it solves every accused pose instead, the
 limits blocked nothing. The disagreement then indicts the unbounded walk, which has no assembly
 branch guarantee near a singular fold. The report gives the declared range, the range the
 mechanism needs, and the driver poses where the two disagree. The needed range is rounded
@@ -586,8 +589,9 @@ than a hundredth of its declared range, the check warns that the loop barely mov
 
 The walk costs about one loop solve per sample per coordinate. Each unreachable edge adds its
 bisection, and each pose a limit excludes adds one bounded solve. A coordinate on two rings is
-driven once. `max_solves` bounds that budget. When a ring has more bounded coordinates than fit,
-the check warns and names the ones it did not drive.
+driven once. `max_solves` sizes the sweep: coordinates that do not fit are not driven, and a
+warning names them. The first coordinate is always driven, and fewer than five samples are raised
+to five, since a coarser grid cannot see the travel it walks.
 
 ### Scale warnings
 

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -32,8 +32,11 @@ from articraft.sdk.assembly import (
     JointAxis,
     JointDOF,
     PhysicsState,
+    ResolvedRigidBodyAssembly,
     RigidBodyAssembly,
     _frame_matrix,
+    _is_periodic,
+    _joint_path,
 )
 from articraft.sdk.bodies import RigidBody, RigidBodyRef
 from articraft.sdk.errors import LoopClosureError, ValidationError
@@ -63,6 +66,7 @@ class FailureKind(StrEnum):
     OVERLAP = "overlap"
     CONTACT = "contact"
     ARTICULATION_SEPARATION = "articulation_separation"
+    LOOP_LIMITS = "loop_limits"
     MISSING_MASS = "missing_mass"
     AUTHORED = "authored"
 
@@ -1405,6 +1409,153 @@ class TestContext:
         )
         return self._record(check_name, False, details, kind=FailureKind.ARTICULATION_SEPARATION)
 
+    def fail_if_loop_limits_contradict(
+        self,
+        *,
+        samples: int = 17,
+        tolerance: float = 1e-6,
+        overrun_fraction: float = 0.25,
+        max_solves: int = 1000,
+        name: str | None = None,
+    ) -> bool:
+        """Report joint limits that a closed loop's own motion contradicts.
+
+        `validate()` reads one joint at a time, so a limit pointing the wrong
+        way is legal on its own -- the ring is what makes it a lie, and the ring
+        is never sampled as a mechanism. Each sweep sample is solved twice, once
+        inside the authored limits and once with the derived coordinates
+        unbounded, which separates the two ways a ring is mis-authored: a
+        follower whose limits exclude the motion the linkage requires, and a
+        driver whose range is wider than the linkage can follow. A full-circle
+        coordinate is neither -- it declares no wall, so it makes no claim a
+        mechanism can contradict.
+        """
+        samples = max(2, int(samples))
+        tolerance = _non_negative(tolerance, "tolerance")
+        check_name = name or f"fail_if_loop_limits_contradict(samples={samples})"
+        resolved = self.model.resolve()
+        tree = tuple(item.joint for item in resolved.joints if not item.exclude_from_articulation)
+        closures = tuple(item.joint for item in resolved.joints if item.exclude_from_articulation)
+        rings = [
+            (closure, path)
+            for closure in closures
+            if (path := _joint_path(tree, closure.body0, closure.body1)) is not None
+        ]
+        if not rings:
+            # Either no ring the tree spans, or a maximal-coordinate assembly
+            # posed from supplied body poses: there is no driver to sweep.
+            return self._record(check_name, True)
+
+        planned = [
+            (closure, path, joint, dof)
+            for closure, path in rings
+            for joint in path
+            for dof in joint.dofs
+            if dof.limits is not None
+        ]
+        budget = max(1, int(max_solves) // (2 * samples))
+        if len(planned) > budget:
+            skipped = [joint.dof_id(dof) for _, _, joint, dof in planned[budget:]]
+            self.warn(
+                f"loop limit sweep covered {budget} of {len(planned)} ring coordinates at "
+                f"samples={samples}; these were not swept as drivers: {skipped!r}"
+            )
+            planned = planned[:budget]
+
+        # One line per defect, not per (driver, defect) pair: every coordinate on
+        # the ring drives the same mechanism, so the same bad limit is found
+        # again from each of them. Keep the sweep that shows the widest motion.
+        overrun: dict[str, str] = {}
+        contradicted: dict[str, tuple[float, str]] = {}
+        for closure, path, drive_joint, drive_dof in planned:
+            bounds = drive_dof.limits
+            if bounds is None:
+                continue
+            driver_id = drive_joint.dof_id(drive_dof)
+            declared = f"({bounds[0]:.4g}, {bounds[1]:.4g})"
+            solved = [
+                (
+                    value,
+                    _ring_solution(resolved, driver_id, value, relax=False),
+                    _ring_solution(resolved, driver_id, value, relax=True),
+                )
+                for value in _articulation_sweep_values(drive_joint, samples, drive_dof)
+            ]
+            reached = [(value, held, free) for value, held, free in solved if free is not None]
+            unreachable = [value for value, _, free in solved if free is None]
+            # Slack is how ring coordinates are normally authored: a slider given
+            # a little more travel than the linkage uses is not a defect. Only a
+            # range the mechanism misses by a wide margin is a claim it cannot keep.
+            if (
+                len(unreachable) > overrun_fraction * len(solved)
+                and not _is_periodic(drive_dof, bounds)
+            ):
+                overrun[driver_id] = (
+                    f"loop={closure.name!r} driver={driver_id!r} declared={declared}: "
+                    f"{len(unreachable)} of {len(solved)} sampled poses are beyond the linkage "
+                    f"itself (first at {unreachable[0]:.4g}) -- this range is wider than the "
+                    "mechanism, whatever the follower limits say"
+                )
+            for joint in path:
+                for dof in joint.dofs:
+                    follower_id = joint.dof_id(dof)
+                    limits = dof.limits
+                    if limits is None or follower_id == driver_id:
+                        continue
+                    if _is_periodic(dof, limits):
+                        continue
+                    lower, upper = limits
+                    solutions = [
+                        (value, held, free, free[follower_id])
+                        for value, held, free in reached
+                        if free is not None and follower_id in free
+                    ]
+                    rotational = cast(JointAxis, dof.axis).is_rotational
+                    outside = [
+                        (value, held, free)
+                        for value, held, free, position in solutions
+                        if not _within_limits(
+                            position, (lower, upper), rotational=rotational, tolerance=tolerance
+                        )
+                    ]
+                    if not outside:
+                        continue
+                    needs = [position for *_, position in solutions]
+                    blocked = sum(1 for _, held, _ in outside if held is None)
+                    elsewhere = [
+                        _branch_gap(held, free) for _, held, free in outside if held is not None
+                    ]
+                    line = (
+                        f"loop={closure.name!r} driver={driver_id!r} follower={follower_id!r} "
+                        f"declared=({lower:.4g}, {upper:.4g}) needs at least ({min(needs):.4g}, "
+                        f"{max(needs):.4g}) over driver {outside[0][0]:.4g}..{outside[-1][0]:.4g}; "
+                        f"the authored limits leave {blocked} of those {len(outside)} poses "
+                        "unsolvable"
+                        + (
+                            f" and answer {len(elsewhere)} from up to {max(elsewhere):.4g} away "
+                            "in joint coordinates -- a different assembly branch"
+                            if elsewhere
+                            else ""
+                        )
+                    )
+                    span = max(needs) - min(needs)
+                    if follower_id not in contradicted or span > contradicted[follower_id][0]:
+                        contradicted[follower_id] = (span, line)
+
+        findings = [overrun[key] for key in sorted(overrun)] + [
+            contradicted[key][1] for key in sorted(contradicted)
+        ]
+        if not findings:
+            return self._record(check_name, True)
+        details = (
+            "A closed loop contradicts its own joint limits. Each joint's limits are legal on "
+            "their own, but sweeping the ring as a mechanism shows it needs motion those limits "
+            "forbid -- so the linkage jams, or quietly assembles the other way round. Widen the "
+            "limits named below, or narrow the driver's range to what the linkage can follow:\n"
+            + "\n".join(findings)
+        )
+        return self._record(check_name, False, details, kind=FailureKind.LOOP_LIMITS)
+
     def warn_if_absurd_dimensions(
         self,
         *,
@@ -1741,6 +1892,46 @@ def _pose_dicts(
         )
         result.append(dict(values))
     return result
+
+
+def _ring_solution(
+    resolved: ResolvedRigidBodyAssembly, driver_id: str, value: float, *, relax: bool
+) -> dict[str, float] | None:
+    """Ring coordinates for one driver pose, or None when the loop will not close."""
+
+    try:
+        positions, _ = resolved._kinematics({driver_id: float(value)}, relax_limits=relax)
+    except LoopClosureError:
+        return None
+    return positions
+
+
+def _within_limits(
+    position: float, limits: tuple[float, float], *, rotational: bool, tolerance: float
+) -> bool:
+    """True when the pose fits the limits, for a hinge by any whole turn of it.
+
+    A revolute coordinate of 4.05 and one of -2.23 are the same pose. The
+    relaxed solve walks continuously and can report either, so a limit is only
+    contradicted when no turn of the required pose fits inside it.
+    """
+
+    lower, upper = limits
+    turns = (0.0,) if not rotational else (0.0, 2.0 * math.pi, -2.0 * math.pi)
+    return any(lower - tolerance <= position + turn <= upper + tolerance for turn in turns)
+
+
+def _branch_gap(held: Mapping[str, float], free: Mapping[str, float]) -> float:
+    """How far two solves of the same pose sit apart, in joint coordinates.
+
+    Two solves of a pose no limit binds agree to solver precision. A gap the
+    size of a joint angle means the limits routed the mechanism somewhere else.
+    """
+
+    return max(
+        (abs(held[key] - value) for key, value in free.items() if key in held),
+        default=0.0,
+    )
 
 
 def _articulation_sweep_values(

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1482,20 +1482,19 @@ class TestContext:
                 (value, _ring_solution(resolved, driver_id, value, relax=True))
                 for value in _articulation_sweep_values(drive_joint, samples, drive_dof)
             ]
-            reached = [(value, free) for value, free in solved if free is not None]
-            unreachable = [value for value, free in solved if free is None]
+            reached, out_of_reach = _reachable_from_rest(solved)
             held_cache: dict[float, dict[str, float] | None] = {}
             # Slack is how ring coordinates are normally authored: a slider given
             # a little more travel than the linkage uses is not a defect. Only a
             # range the mechanism misses by a wide margin is a claim it cannot keep.
-            if len(unreachable) > overrun_fraction * len(solved) and not _is_periodic(
+            if out_of_reach > overrun_fraction * len(solved) and not _is_periodic(
                 drive_dof, bounds
             ):
                 overrun[driver_id] = (
                     f"loop={closure.name!r} driver={driver_id!r} declared={declared}: "
-                    f"{len(unreachable)} of {len(solved)} sampled poses are beyond the linkage "
-                    f"itself (first at {unreachable[0]:.4g}) -- this range is wider than the "
-                    "mechanism, whatever the follower limits say"
+                    f"{out_of_reach} of {len(solved)} sampled poses cannot be reached from the "
+                    "rest pose -- this range is wider than the mechanism, whatever the follower "
+                    "limits say"
                 )
             for joint in path:
                 for dof in joint.dofs:
@@ -1926,6 +1925,34 @@ def _within_limits(
     lower, upper = limits
     turns = (0.0,) if not rotational else (0.0, 2.0 * math.pi, -2.0 * math.pi)
     return any(lower - tolerance <= position + turn <= upper + tolerance for turn in turns)
+
+
+def _reachable_from_rest(
+    solved: list[tuple[float, dict[str, float] | None]],
+) -> tuple[list[tuple[float, dict[str, float]]], int]:
+    """The poses the mechanism can move into, and how many it cannot.
+
+    A linkage can have assembly modes that no motion connects: a four bar sits
+    elbow up or elbow down, and between them is a span of driver values with no
+    solution at all. Coordinates solved on the far side of such a gap describe a
+    machine that would have to be taken apart and rebuilt, so they say nothing
+    about the limits of the one that was authored. Keep the unbroken run of
+    solutions nearest the rest pose and count everything else out of reach.
+    """
+
+    runs: list[list[tuple[float, dict[str, float]]]] = []
+    for value, free in solved:
+        if free is None:
+            runs.append([])
+            continue
+        if not runs:
+            runs.append([])
+        runs[-1].append((value, free))
+    runs = [run for run in runs if run]
+    if not runs:
+        return [], len(solved)
+    family = min(runs, key=lambda run: min(abs(value) for value, _ in run))
+    return family, len(solved) - len(family)
 
 
 def _held_solution(

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1426,7 +1426,7 @@ class TestContext:
         from the rest pose with the derived coordinates unbounded, which shows
         the motion the linkage itself asks for. Where that motion leaves a
         follower's limits, the solve that respects them is the judge, and only
-        its failure, pinned at those limits, makes a case: when it solves every
+        its failure to close the ring within them makes a case: when it solves every
         accused pose instead, the limits blocked nothing, however far the
         unbounded walk wandered to say otherwise. A driver
         whose declared travel reaches past where the ring stops closing is
@@ -1477,6 +1477,7 @@ class TestContext:
         # again from each of them. Keep the sweep that shows the widest motion.
         overrun: dict[str, str] = {}
         contradicted: dict[str, tuple[float, str]] = {}
+        barely_moving: set[str] = set()
         for closure, path, drive_joint, drive_dof in planned:
             bounds = drive_dof.limits
             if bounds is None:
@@ -1502,6 +1503,17 @@ class TestContext:
             # tip the verdict by itself.
             declared_span = bounds[1] - bounds[0]
             missing = declared_span - span_reached
+            if (
+                _is_periodic(drive_dof, bounds)
+                and span_reached < _BARELY_MOVES_FRACTION * declared_span
+                and closure.name not in barely_moving
+            ):
+                barely_moving.add(closure.name)
+                self.warn(
+                    f"loop={closure.name!r} driver={driver_id!r} is authored full circle but "
+                    f"the ring closes over only {span_reached:.4g} of it -- the loop barely "
+                    "moves"
+                )
             if missing > overrun_fraction * declared_span and not _is_periodic(drive_dof, bounds):
                 overrun[driver_id] = (
                     f"loop={closure.name!r} driver={driver_id!r} declared={declared}: the "
@@ -1931,6 +1943,11 @@ _BOUNDARY_BISECTIONS = 8
 # ~1e-1 apart. The gate lives in the decade between, and deliberately not at
 # `tolerance`, which measures limit compliance, not distance between solves.
 _BRANCH_TOLERANCE = 1e-3
+# Below this fraction of its declared range, a full-circle ring coordinate is
+# not articulating anything: the ring closes only in a sliver around rest, and
+# a structure that barely moves deserves a word even though unconstrained
+# coordinates make no range claim to contradict.
+_BARELY_MOVES_FRACTION = 0.01
 
 
 def _ring_solution(
@@ -1964,7 +1981,8 @@ def _continued_solution(
 
     A solve from rest is free to land on whichever assembly branch it finds,
     and near a limiting position it does. Continuing from the neighbour keeps
-    the walk on the branch the mechanism actually moves along. One warm solve
+    the walk close to the branch it started on -- close, not provably on it,
+    which is why no case is ever filed on the walk's word alone. One warm solve
     covers an ordinary step, judged by ``_stayed_local``: when the local
     branch has no solution at the target, the solver converges somewhere far
     instead of failing, and a whole-turn hop must not pass for continuation.

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1919,7 +1919,9 @@ def _within_limits(
 
     A revolute coordinate of 4.05 and one of -2.23 are the same pose. The
     relaxed solve walks continuously and can report either, so a limit is only
-    contradicted when no turn of the required pose fits inside it.
+    contradicted when neither the required pose nor one whole turn of it fits
+    inside it. One turn each way is exhaustive here: a coordinate with a wall
+    spans less than a turn, so no second one can fit.
     """
 
     lower, upper = limits

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1422,16 +1422,21 @@ class TestContext:
 
         `validate()` reads one joint at a time, so a limit pointing the wrong
         way is legal on its own -- the ring is what makes it a lie, and the ring
-        is never sampled as a mechanism. Each sweep sample is solved twice, once
-        inside the authored limits and once with the derived coordinates
-        unbounded, which separates the two ways a ring is mis-authored: a
-        follower whose limits exclude the motion the linkage requires, and a
-        driver whose range is wider than the linkage can follow. A full-circle
-        coordinate is neither -- it declares no wall, so it makes no claim a
-        mechanism can contradict.
+        is never sampled as a mechanism. The sweep walks each driver outward
+        from the rest pose with the derived coordinates unbounded, which shows
+        the motion the linkage itself asks for. Where that motion leaves a
+        follower's limits, the solve that respects them is the judge, and only
+        its failure, pinned at those limits, makes a case: when it solves every
+        accused pose instead, the limits blocked nothing, however far the
+        unbounded walk wandered to say otherwise. A driver
+        whose declared travel reaches past where the ring stops closing is
+        reported on its own. A full-circle coordinate makes no such claims --
+        it declares no wall for a mechanism to contradict.
         """
         samples = max(2, int(samples))
         tolerance = _non_negative(tolerance, "tolerance")
+        overrun_fraction = _non_negative(overrun_fraction, "overrun_fraction")
+        max_solves = max(1, int(_non_negative(max_solves, "max_solves")))
         check_name = name or f"fail_if_loop_limits_contradict(samples={samples})"
         resolved = self.model.resolve()
         tree = tuple(item.joint for item in resolved.joints if not item.exclude_from_articulation)
@@ -1458,7 +1463,7 @@ class TestContext:
                         continue
                     seen.add(dof_id)
                     planned.append((closure, path, joint, dof))
-        budget = max(1, int(max_solves) // (2 * samples))
+        budget = max(1, max_solves // (3 * samples + 2 * _BOUNDARY_BISECTIONS))
         if len(planned) > budget:
             skipped = [joint.dof_id(dof) for _, _, joint, dof in planned[budget:]]
             self.warn(
@@ -1478,23 +1483,34 @@ class TestContext:
                 continue
             driver_id = drive_joint.dof_id(drive_dof)
             declared = f"({bounds[0]:.4g}, {bounds[1]:.4g})"
-            solved = [
-                (value, _ring_solution(resolved, driver_id, value, relax=True))
-                for value in _articulation_sweep_values(drive_joint, samples, drive_dof)
-            ]
-            reached, out_of_reach = _reachable_from_rest(solved)
+            sweep = _articulation_sweep_values(drive_joint, samples, drive_dof)
+            rotational_ids = frozenset(
+                joint.dof_id(dof)
+                for joint in path
+                for dof in joint.dofs
+                if cast(JointAxis, dof.axis).is_rotational
+            )
+            reached, probes, span_reached, out_of_reach = _swept_from_rest(
+                resolved, driver_id, sweep, rotational_ids
+            )
+            judged = sorted(reached + probes, key=lambda item: item[0])
             held_cache: dict[float, dict[str, float] | None] = {}
-            # Slack is how ring coordinates are normally authored: a slider given
-            # a little more travel than the linkage uses is not a defect. Only a
-            # range the mechanism misses by a wide margin is a claim it cannot keep.
-            if out_of_reach > overrun_fraction * len(solved) and not _is_periodic(
+            # Slack is how ring coordinates are normally authored: a range a
+            # little wider than the mechanism's travel is not a defect. The
+            # overrun is measured as travel, not as a count of samples, so a
+            # sample grid whose end points sit on the declared walls cannot
+            # tip the verdict by itself.
+            declared_span = bounds[1] - bounds[0]
+            missing = declared_span - span_reached
+            if missing > overrun_fraction * declared_span and not _is_periodic(
                 drive_dof, bounds
             ):
                 overrun[driver_id] = (
-                    f"loop={closure.name!r} driver={driver_id!r} declared={declared}: "
-                    f"{out_of_reach} of {len(solved)} sampled poses cannot be reached from the "
-                    "rest pose -- this range is wider than the mechanism, whatever the follower "
-                    "limits say"
+                    f"loop={closure.name!r} driver={driver_id!r} declared={declared}: the "
+                    f"mechanism's travel covers {span_reached:.4g} of the declared "
+                    f"{declared_span:.4g}, leaving {out_of_reach} of {len(sweep)} sampled "
+                    "poses out of reach -- this range is wider than the mechanism, whatever "
+                    "the follower limits say"
                 )
             for joint in path:
                 for dof in joint.dofs:
@@ -1507,40 +1523,51 @@ class TestContext:
                     lower, upper = limits
                     solutions = [
                         (value, free, free[follower_id])
-                        for value, free in reached
+                        for value, free in judged
                         if follower_id in free
                     ]
-                    rotational = cast(JointAxis, dof.axis).is_rotational
                     outside = [
-                        (value, free)
+                        (value, free, position)
                         for value, free, position in solutions
-                        if not _within_limits(
-                            position, (lower, upper), rotational=rotational, tolerance=tolerance
-                        )
+                        if not lower - tolerance <= position <= upper + tolerance
                     ]
                     if not outside:
                         continue
+                    # The solve that respects the limits judges every excursion,
+                    # and only its failure makes a case. Succeeding at every
+                    # accused pose means the limits blocked nothing: the
+                    # unbounded walk has no branch guarantee near a singular
+                    # fold, so a disagreement on its own indicts the walk, not
+                    # the limits. Where the bounded solve does fail pinned, a
+                    # disagreement at the other accused poses is reported with
+                    # it: the limits are answering from another assembly branch.
+                    blocked: list[float] = []
+                    rerouted: list[tuple[float, float]] = []
+                    for value, free, position in outside:
+                        held = _held_solution(resolved, driver_id, value, held_cache)
+                        if held is None:
+                            blocked.append(value)
+                            continue
+                        gap = _branch_gap(held, free, rotational_ids)
+                        if gap > _BRANCH_TOLERANCE:
+                            rerouted.append((value, gap))
+                    if not blocked:
+                        continue
                     needs = [position for *_, position in solutions]
-                    held_states = [
-                        _held_solution(resolved, driver_id, value, held_cache)
-                        for value, _ in outside
-                    ]
-                    blocked = sum(1 for state in held_states if state is None)
-                    elsewhere = [
-                        _branch_gap(state, free)
-                        for (_, free), state in zip(outside, held_states, strict=True)
-                        if state is not None
-                    ]
+                    named = sorted(blocked + [value for value, _ in rerouted])
+                    accused = len(blocked) + len(rerouted)
                     line = (
                         f"loop={closure.name!r} driver={driver_id!r} follower={follower_id!r} "
-                        f"declared=({lower:.4g}, {upper:.4g}) needs at least ({min(needs):.4g}, "
-                        f"{max(needs):.4g}) over driver {outside[0][0]:.4g}..{outside[-1][0]:.4g}; "
-                        f"the authored limits leave {blocked} of those {len(outside)} poses "
-                        "unsolvable"
+                        f"declared=({lower:.4g}, {upper:.4g}) needs at least "
+                        f"({_round_out(min(needs), up=False):.4g}, "
+                        f"{_round_out(max(needs), up=True):.4g}) over driver "
+                        f"{named[0]:.4g}..{named[-1]:.4g}; the authored limits leave "
+                        f"{len(blocked)} of those {accused} poses unsolvable"
                         + (
-                            f" and answer {len(elsewhere)} from up to {max(elsewhere):.4g} away "
-                            "in joint coordinates -- a different assembly branch"
-                            if elsewhere
+                            f" and answer {len(rerouted)} from up to "
+                            f"{max(gap for _, gap in rerouted):.4g} away in joint "
+                            "coordinates -- a different assembly branch"
+                            if rerouted
                             else ""
                         )
                     )
@@ -1900,61 +1927,179 @@ def _pose_dicts(
     return result
 
 
+_SWEEP_SUBSTEPS = 3
+_BOUNDARY_BISECTIONS = 8
+# Solver noise at a singular fold reaches ~1e-4; real assembly branches sit
+# ~1e-1 apart. The gate lives in the decade between, and deliberately not at
+# `tolerance`, which measures limit compliance, not distance between solves.
+_BRANCH_TOLERANCE = 1e-3
+
+
 def _ring_solution(
-    resolved: ResolvedRigidBodyAssembly, driver_id: str, value: float, *, relax: bool
+    resolved: ResolvedRigidBodyAssembly,
+    driver_id: str,
+    value: float,
+    *,
+    relax: bool,
+    start: Mapping[str, float] | None = None,
 ) -> dict[str, float] | None:
     """Ring coordinates for one driver pose, or None when the loop will not close."""
 
     try:
-        positions, _ = resolved._kinematics({driver_id: float(value)}, relax_limits=relax)
+        positions, _ = resolved._kinematics(
+            {driver_id: float(value)}, relax_limits=relax, loop_start=start
+        )
     except LoopClosureError:
         return None
     return positions
 
 
-def _within_limits(
-    position: float, limits: tuple[float, float], *, rotational: bool, tolerance: float
+def _continued_solution(
+    resolved: ResolvedRigidBodyAssembly,
+    driver_id: str,
+    prev_value: float,
+    prev_free: dict[str, float],
+    value: float,
+    rotational: frozenset[str],
+) -> dict[str, float] | None:
+    """Relaxed solve at ``value``, continued from a neighbouring solution.
+
+    A solve from rest is free to land on whichever assembly branch it finds,
+    and near a limiting position it does. Continuing from the neighbour keeps
+    the walk on the branch the mechanism actually moves along. One warm solve
+    covers an ordinary step, judged by ``_stayed_local``: when the local
+    branch has no solution at the target, the solver converges somewhere far
+    instead of failing, and a whole-turn hop must not pass for continuation.
+    A rejected or failed step is retried in thirds before the pose is called
+    unreachable, so a hard solve is not mistaken for a wall.
+    """
+
+    free = _ring_solution(resolved, driver_id, value, relax=True, start=prev_free)
+    if free is not None and _stayed_local(prev_free, free, rotational):
+        return free
+    stepped = prev_free
+    for step in range(1, _SWEEP_SUBSTEPS + 1):
+        target = prev_value + (value - prev_value) * step / _SWEEP_SUBSTEPS
+        moved = _ring_solution(resolved, driver_id, target, relax=True, start=stepped)
+        if moved is None or not _stayed_local(stepped, moved, rotational):
+            return None
+        stepped = moved
+    return stepped
+
+
+def _stayed_local(
+    before: Mapping[str, float], after: Mapping[str, float], rotational: frozenset[str]
 ) -> bool:
-    """True when the pose fits the limits, for a hinge by any whole turn of it.
+    """True when a continuation step stayed on its own side of a half turn.
 
-    A revolute coordinate of 4.05 and one of -2.23 are the same pose. The
-    relaxed solve walks continuously and can report either, so a limit is only
-    contradicted when neither the required pose nor one whole turn of it fits
-    inside it. One turn each way is exhaustive here: a coordinate with a wall
-    spans less than a turn, so no second one can fit.
+    A hinge that hops more than a half turn in one step has not moved there:
+    it names a solution on the far side of the seam, and treating it as
+    continuation is how a lifted copy of the mechanism sneaks into the sweep.
     """
 
-    lower, upper = limits
-    turns = (0.0,) if not rotational else (0.0, 2.0 * math.pi, -2.0 * math.pi)
-    return any(lower - tolerance <= position + turn <= upper + tolerance for turn in turns)
+    return all(
+        abs(after[key] - value) <= math.pi
+        for key, value in before.items()
+        if key in after and key in rotational
+    )
 
 
-def _reachable_from_rest(
-    solved: list[tuple[float, dict[str, float] | None]],
-) -> tuple[list[tuple[float, dict[str, float]]], int]:
-    """The poses the mechanism can move into, and how many it cannot.
+def _swept_from_rest(
+    resolved: ResolvedRigidBodyAssembly,
+    driver_id: str,
+    sweep: list[float],
+    rotational: frozenset[str],
+) -> tuple[
+    list[tuple[float, dict[str, float]]],
+    list[tuple[float, dict[str, float]]],
+    float,
+    int,
+]:
+    """Walk the sweep outward from the rest pose, and measure how far it gets.
 
-    A linkage can have assembly modes that no motion connects: a four bar sits
-    elbow up or elbow down, and between them is a span of driver values with no
-    solution at all. Coordinates solved on the far side of such a gap describe a
-    machine that would have to be taken apart and rebuilt, so they say nothing
-    about the limits of the one that was authored. Keep the unbroken run of
-    solutions nearest the rest pose and count everything else out of reach.
+    The mechanism cannot pass through a pose where its ring will not close, so
+    each side of the sweep ends at the first value that fails, and everything
+    beyond it is counted out of reach without being solved. A bisection toward
+    each such edge then measures the reachable travel and probes the motion
+    close to it, where a follower moves fastest and a fixed grid is blindest.
+
+    Returns the reached samples, the boundary probes, the reachable travel,
+    and the number of sampled poses out of reach.
     """
 
-    runs: list[list[tuple[float, dict[str, float]]]] = []
-    for value, free in solved:
+    solved: dict[int, dict[str, float] | None] = {}
+    edges: list[float] = [0.0]
+    probes: list[tuple[float, dict[str, float]]] = []
+    for negative in (False, True):
+        side = sorted(
+            (index for index, value in enumerate(sweep) if (value < 0.0) == negative),
+            key=lambda index: abs(sweep[index]),
+        )
+        prev_value, prev_free = 0.0, None
+        alive = True
+        for index in side:
+            value = sweep[index]
+            if not alive:
+                solved[index] = None
+                continue
+            if prev_free is None:
+                free = _ring_solution(resolved, driver_id, value, relax=True)
+            else:
+                free = _continued_solution(
+                    resolved, driver_id, prev_value, prev_free, value, rotational
+                )
+            solved[index] = free
+            if free is not None:
+                prev_value, prev_free = value, free
+                continue
+            alive = False
+            if prev_free is None:
+                prev_free = _ring_solution(resolved, driver_id, prev_value, relax=True)
+            if prev_free is None:
+                edges.append(prev_value)
+            else:
+                found, edge = _reach_boundary(
+                    resolved, driver_id, prev_value, prev_free, value, rotational
+                )
+                probes.extend(found)
+                edges.append(edge)
+        if alive and side:
+            edges.append(sweep[side[-1]])
+    reached = [
+        (sweep[index], positions)
+        for index, positions in sorted(solved.items())
+        if positions is not None
+    ]
+    out_of_reach = sum(1 for positions in solved.values() if positions is None)
+    return reached, probes, max(edges) - min(edges), out_of_reach
+
+
+def _reach_boundary(
+    resolved: ResolvedRigidBodyAssembly,
+    driver_id: str,
+    good_value: float,
+    good_free: dict[str, float],
+    bad_value: float,
+    rotational: frozenset[str],
+) -> tuple[list[tuple[float, dict[str, float]]], float]:
+    """Bisect between a reachable driver value and an unreachable one.
+
+    The demand on a follower grows fastest against this edge, so the solutions
+    found on the way carry the part of the motion the sample grid steps over.
+    """
+
+    probes: list[tuple[float, dict[str, float]]] = []
+    for _ in range(_BOUNDARY_BISECTIONS):
+        middle = 0.5 * (good_value + bad_value)
+        free = _continued_solution(
+            resolved, driver_id, good_value, good_free, middle, rotational
+        )
         if free is None:
-            runs.append([])
-            continue
-        if not runs:
-            runs.append([])
-        runs[-1].append((value, free))
-    runs = [run for run in runs if run]
-    if not runs:
-        return [], len(solved)
-    family = min(runs, key=lambda run: min(abs(value) for value, _ in run))
-    return family, len(solved) - len(family)
+            bad_value = middle
+        else:
+            probes.append((middle, free))
+            good_value, good_free = middle, free
+    return probes, good_value
 
 
 def _held_solution(
@@ -1965,8 +2110,8 @@ def _held_solution(
 ) -> dict[str, float] | None:
     """The solve that respects the authored limits, computed once per pose.
 
-    Only the poses a limit turns out to exclude need it, and on a ring that
-    agrees with its limits that is none of them.
+    Only the poses the relaxed walk carries outside a limit need it, and on a
+    ring that agrees with its limits that is none of them.
     """
 
     if value not in cache:
@@ -1974,17 +2119,42 @@ def _held_solution(
     return cache[value]
 
 
-def _branch_gap(held: Mapping[str, float], free: Mapping[str, float]) -> float:
+def _branch_gap(
+    held: Mapping[str, float], free: Mapping[str, float], rotational: frozenset[str]
+) -> float:
     """How far two solves of the same pose sit apart, in joint coordinates.
 
-    Two solves of a pose no limit binds agree to solver precision. A gap the
-    size of a joint angle means the limits routed the mechanism somewhere else.
+    Whole turns of a hinge name the same pose, so they are removed before the
+    distance is read. What remains is real: two solves that agree land within
+    solver precision of each other, and a gap the size of a joint angle means
+    the limits routed the mechanism onto a different assembly branch.
     """
 
-    return max(
-        (abs(held[key] - value) for key, value in free.items() if key in held),
-        default=0.0,
-    )
+    gap = 0.0
+    for key, value in free.items():
+        if key not in held:
+            continue
+        difference = held[key] - value
+        if key in rotational:
+            difference -= 2.0 * math.pi * round(difference / (2.0 * math.pi))
+        gap = max(gap, abs(difference))
+    return gap
+
+
+def _round_out(value: float, *, up: bool) -> float:
+    """Round to four shown digits, away from the measured range.
+
+    The printed range is the one an author will copy back. Rounding toward the
+    range would hand out limits a hair narrower than the motion they came
+    from, which then fail again while printing the same numbers.
+    """
+
+    if value == 0.0 or not math.isfinite(value):
+        return value
+    quantum = 10.0 ** (math.floor(math.log10(abs(value))) - 3)
+    scaled = value / quantum
+    rounded = math.ceil(scaled) if up else math.floor(scaled)
+    return rounded * quantum
 
 
 def _articulation_sweep_values(

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1412,7 +1412,7 @@ class TestContext:
     def fail_if_loop_limits_contradict(
         self,
         *,
-        samples: int = 17,
+        samples: int = 9,
         tolerance: float = 1e-6,
         overrun_fraction: float = 0.25,
         max_solves: int = 1000,
@@ -1446,13 +1446,18 @@ class TestContext:
             # posed from supplied body poses: there is no driver to sweep.
             return self._record(check_name, True)
 
-        planned = [
-            (closure, path, joint, dof)
-            for closure, path in rings
-            for joint in path
-            for dof in joint.dofs
-            if dof.limits is not None
-        ]
+        # One coordinate can sit on two rings. Driving it twice sweeps the same
+        # mechanism twice, so keep the first ring that reaches it.
+        planned: list[tuple[Joint, tuple[Joint, ...], Joint, JointDOF]] = []
+        seen: set[str] = set()
+        for closure, path in rings:
+            for joint in path:
+                for dof in joint.dofs:
+                    dof_id = joint.dof_id(dof)
+                    if dof.limits is None or dof_id in seen:
+                        continue
+                    seen.add(dof_id)
+                    planned.append((closure, path, joint, dof))
         budget = max(1, int(max_solves) // (2 * samples))
         if len(planned) > budget:
             skipped = [joint.dof_id(dof) for _, _, joint, dof in planned[budget:]]
@@ -1474,21 +1479,17 @@ class TestContext:
             driver_id = drive_joint.dof_id(drive_dof)
             declared = f"({bounds[0]:.4g}, {bounds[1]:.4g})"
             solved = [
-                (
-                    value,
-                    _ring_solution(resolved, driver_id, value, relax=False),
-                    _ring_solution(resolved, driver_id, value, relax=True),
-                )
+                (value, _ring_solution(resolved, driver_id, value, relax=True))
                 for value in _articulation_sweep_values(drive_joint, samples, drive_dof)
             ]
-            reached = [(value, held, free) for value, held, free in solved if free is not None]
-            unreachable = [value for value, _, free in solved if free is None]
+            reached = [(value, free) for value, free in solved if free is not None]
+            unreachable = [value for value, free in solved if free is None]
+            held_cache: dict[float, dict[str, float] | None] = {}
             # Slack is how ring coordinates are normally authored: a slider given
             # a little more travel than the linkage uses is not a defect. Only a
             # range the mechanism misses by a wide margin is a claim it cannot keep.
-            if (
-                len(unreachable) > overrun_fraction * len(solved)
-                and not _is_periodic(drive_dof, bounds)
+            if len(unreachable) > overrun_fraction * len(solved) and not _is_periodic(
+                drive_dof, bounds
             ):
                 overrun[driver_id] = (
                     f"loop={closure.name!r} driver={driver_id!r} declared={declared}: "
@@ -1506,14 +1507,14 @@ class TestContext:
                         continue
                     lower, upper = limits
                     solutions = [
-                        (value, held, free, free[follower_id])
-                        for value, held, free in reached
-                        if free is not None and follower_id in free
+                        (value, free, free[follower_id])
+                        for value, free in reached
+                        if follower_id in free
                     ]
                     rotational = cast(JointAxis, dof.axis).is_rotational
                     outside = [
-                        (value, held, free)
-                        for value, held, free, position in solutions
+                        (value, free)
+                        for value, free, position in solutions
                         if not _within_limits(
                             position, (lower, upper), rotational=rotational, tolerance=tolerance
                         )
@@ -1521,9 +1522,15 @@ class TestContext:
                     if not outside:
                         continue
                     needs = [position for *_, position in solutions]
-                    blocked = sum(1 for _, held, _ in outside if held is None)
+                    held_states = [
+                        _held_solution(resolved, driver_id, value, held_cache)
+                        for value, _ in outside
+                    ]
+                    blocked = sum(1 for state in held_states if state is None)
                     elsewhere = [
-                        _branch_gap(held, free) for _, held, free in outside if held is not None
+                        _branch_gap(state, free)
+                        for (_, free), state in zip(outside, held_states, strict=True)
+                        if state is not None
                     ]
                     line = (
                         f"loop={closure.name!r} driver={driver_id!r} follower={follower_id!r} "
@@ -1919,6 +1926,23 @@ def _within_limits(
     lower, upper = limits
     turns = (0.0,) if not rotational else (0.0, 2.0 * math.pi, -2.0 * math.pi)
     return any(lower - tolerance <= position + turn <= upper + tolerance for turn in turns)
+
+
+def _held_solution(
+    resolved: ResolvedRigidBodyAssembly,
+    driver_id: str,
+    value: float,
+    cache: dict[float, dict[str, float] | None],
+) -> dict[str, float] | None:
+    """The solve that respects the authored limits, computed once per pose.
+
+    Only the poses a limit turns out to exclude need it, and on a ring that
+    agrees with its limits that is none of them.
+    """
+
+    if value not in cache:
+        cache[value] = _ring_solution(resolved, driver_id, value, relax=False)
+    return cache[value]
 
 
 def _branch_gap(held: Mapping[str, float], free: Mapping[str, float]) -> float:

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1502,9 +1502,7 @@ class TestContext:
             # tip the verdict by itself.
             declared_span = bounds[1] - bounds[0]
             missing = declared_span - span_reached
-            if missing > overrun_fraction * declared_span and not _is_periodic(
-                drive_dof, bounds
-            ):
+            if missing > overrun_fraction * declared_span and not _is_periodic(drive_dof, bounds):
                 overrun[driver_id] = (
                     f"loop={closure.name!r} driver={driver_id!r} declared={declared}: the "
                     f"mechanism's travel covers {span_reached:.4g} of the declared "
@@ -1543,7 +1541,7 @@ class TestContext:
                     # it: the limits are answering from another assembly branch.
                     blocked: list[float] = []
                     rerouted: list[tuple[float, float]] = []
-                    for value, free, position in outside:
+                    for value, free, _ in outside:
                         held = _held_solution(resolved, driver_id, value, held_cache)
                         if held is None:
                             blocked.append(value)
@@ -2091,9 +2089,7 @@ def _reach_boundary(
     probes: list[tuple[float, dict[str, float]]] = []
     for _ in range(_BOUNDARY_BISECTIONS):
         middle = 0.5 * (good_value + bad_value)
-        free = _continued_solution(
-            resolved, driver_id, good_value, good_free, middle, rotational
-        )
+        free = _continued_solution(resolved, driver_id, good_value, good_free, middle, rotational)
         if free is None:
             bad_value = middle
         else:
@@ -2162,7 +2158,7 @@ def _articulation_sweep_values(
 ) -> list[float]:
     """Joint values to sample across an articulation's motion range.
 
-    The first value is the rest pose. A bounded joint sweeps lower..upper; a
+    A bounded joint sweeps lower..upper with both ends included; a
     continuous or unbounded joint samples a half turn (0..pi), which is enough to
     reveal a child that separates as it rotates.
     """

--- a/src/articraft/sdk/testing.py
+++ b/src/articraft/sdk/testing.py
@@ -1433,7 +1433,7 @@ class TestContext:
         reported on its own. A full-circle coordinate makes no such claims --
         it declares no wall for a mechanism to contradict.
         """
-        samples = max(2, int(samples))
+        samples = max(5, int(samples))
         tolerance = _non_negative(tolerance, "tolerance")
         overrun_fraction = _non_negative(overrun_fraction, "overrun_fraction")
         max_solves = max(1, int(_non_negative(max_solves, "max_solves")))
@@ -1494,6 +1494,14 @@ class TestContext:
             reached, probes, span_reached, out_of_reach = _swept_from_rest(
                 resolved, driver_id, sweep, rotational_ids
             )
+            doorstep = {
+                value
+                for value in (
+                    min((v for v in sweep if v > 0.0), default=None),
+                    max((v for v in sweep if v < 0.0), default=None),
+                )
+                if value is not None
+            }
             judged = sorted(reached + probes, key=lambda item: item[0])
             held_cache: dict[float, dict[str, float] | None] = {}
             # Slack is how ring coordinates are normally authored: a range a
@@ -1561,9 +1569,27 @@ class TestContext:
                         gap = _branch_gap(held, free, rotational_ids)
                         if gap > _BRANCH_TOLERANCE:
                             rerouted.append((value, gap))
+                    # A full-circle driver makes no range claim, so poses it
+                    # reaches only through a neighbour's stop are not motion
+                    # the linkage requires: a stop that leaves the mechanism
+                    # its motion around rest is authoring, not a contradiction.
+                    # A limit authored against the motion's own direction is
+                    # different -- limits must contain the zero configuration,
+                    # so such a limit jams the very first step away from rest,
+                    # and that is the signature this keeps.
+                    if (
+                        blocked
+                        and _is_periodic(drive_dof, bounds)
+                        and not any(any(abs(b - d) <= 1e-12 for d in doorstep) for b in blocked)
+                    ):
+                        blocked = []
                     if not blocked:
                         continue
-                    needs = [position for *_, position in solutions]
+                    # "At least" must not read narrower than the declaration on
+                    # either side: the walk can die early on one side and the
+                    # sampled range under-span there, and a fix has to keep what
+                    # the author already declared as wanted travel.
+                    needs = [position for *_, position in solutions] + [lower, upper]
                     named = sorted(blocked + [value for value, _ in rerouted])
                     accused = len(blocked) + len(rerouted)
                     line = (
@@ -1994,8 +2020,16 @@ def _continued_solution(
     if free is not None and _stayed_local(prev_free, free, rotational):
         return free
     stepped = prev_free
+    low, high = min(prev_value, value), max(prev_value, value)
     for step in range(1, _SWEEP_SUBSTEPS + 1):
-        target = prev_value + (value - prev_value) * step / _SWEEP_SUBSTEPS
+        if step == _SWEEP_SUBSTEPS:
+            # `prev + (value - prev)` is not `value` in floating point, and a
+            # sweep endpoint sits exactly on a driver's limit: recomputing it
+            # can land one ulp outside and trip the strict limit guard.
+            target = value
+        else:
+            target = prev_value + (value - prev_value) * (step / _SWEEP_SUBSTEPS)
+            target = min(max(target, low), high)
         moved = _ring_solution(resolved, driver_id, target, relax=True, start=stepped)
         if moved is None or not _stayed_local(stepped, moved, rotational):
             return None
@@ -2166,9 +2200,12 @@ def _round_out(value: float, *, up: bool) -> float:
     if value == 0.0 or not math.isfinite(value):
         return value
     quantum = 10.0 ** (math.floor(math.log10(abs(value))) - 3)
+    if quantum == 0.0 or not math.isfinite(quantum):
+        return value
     scaled = value / quantum
     rounded = math.ceil(scaled) if up else math.floor(scaled)
-    return rounded * quantum
+    result = rounded * quantum
+    return result if math.isfinite(result) else value
 
 
 def _articulation_sweep_values(

--- a/tests/test_compiler_feedback.py
+++ b/tests/test_compiler_feedback.py
@@ -372,6 +372,7 @@ def test_every_failure_kind_maps_to_a_specific_signal() -> None:
         FailureKind.OVERLAP: "real_overlap",
         FailureKind.CONTACT: "exact_contact_gap",
         FailureKind.ARTICULATION_SEPARATION: "articulation_separation",
+        FailureKind.LOOP_LIMITS: "loop_limits",
         FailureKind.MISSING_MASS: "missing_mass",
         FailureKind.AUTHORED: "test_failure",
     }

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -11,6 +11,7 @@ from articraft.sdk.errors import LoopClosureError
 from articraft.sdk.testing import (
     TestContext,
     _articulation_sweep_values,
+    _round_out,
     _swept_from_rest,
 )
 
@@ -335,3 +336,26 @@ def test_a_closure_the_tree_does_not_span_is_passed_over() -> None:
     context = TestContext(assembly)
 
     assert context.fail_if_loop_limits_contradict() is True
+
+
+def test_a_branch_answer_is_reported_next_to_the_jam() -> None:
+    # Poses the limits leave unsolvable make the case. Where the bounded solve
+    # answers from a different assembly branch instead, that is reported with
+    # them, whole turns removed before the distance is read.
+    details = failure_details(four_bar(coupler_limits=(0.0, 1.75)))
+
+    assert "poses unsolvable" in details
+    assert "away in joint coordinates -- a different assembly branch" in details
+
+
+@pytest.mark.parametrize(
+    "value",
+    [3.3457, -1.8694, 0.9999999999, 1.0000000001, -0.1, 1e-5, 12345.678, -3.0],
+)
+def test_needs_bounds_round_outward(value: float) -> None:
+    # The printed range must survive being copied back: parsing the four shown
+    # digits has to give an interval that still contains the measured value.
+    lower = float(f"{_round_out(value, up=False):.4g}")
+    upper = float(f"{_round_out(value, up=True):.4g}")
+
+    assert lower <= value <= upper

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -359,3 +359,58 @@ def test_needs_bounds_round_outward(value: float) -> None:
     upper = float(f"{_round_out(value, up=True):.4g}")
 
     assert lower <= value <= upper
+
+
+def locked_four_bar() -> RigidBodyAssembly:
+    """A four-bar that closes only at rest: crank plus coupler exactly reach
+    the rocker circle when stretched, so the ring is a structure, not a
+    mechanism."""
+
+    assembly = RigidBodyAssembly("locked_four_bar")
+    ground = assembly.rigid_body("ground")
+    crank = assembly.rigid_body("crank")
+    coupler = assembly.rigid_body("coupler")
+    rocker = assembly.rigid_body("rocker")
+    for body, length in ((ground, 0.5), (crank, 0.2), (coupler, 0.2), (rocker, 0.1)):
+        body.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+    crank_pin = assembly.joint(
+        "crank_pin",
+        ground.at(JointFrame(xyz=(-0.25, 0.0, 0.0))),
+        crank.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    coupler_pin = assembly.joint(
+        "coupler_pin",
+        crank.at(JointFrame(xyz=(0.2, 0.0, 0.0))),
+        coupler.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    rocker_pin = assembly.joint(
+        "rocker_pin",
+        ground.at(JointFrame(xyz=(0.25, 0.0, 0.0), rpy=(0.0, math.pi, 0.0))),
+        rocker.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    assembly.joint(
+        "closing_pin",
+        coupler.at(JointFrame(xyz=(0.2, 0.0, 0.0))),
+        rocker.at(JointFrame(xyz=(0.1, 0.0, 0.0))),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    assembly.articulation("main", root=ground, joints=(crank_pin, coupler_pin, rocker_pin))
+    return assembly
+
+
+def test_a_ring_that_barely_moves_warns_instead_of_failing() -> None:
+    # Full-circle coordinates make no range claim, so a structure that closes
+    # only in a sliver around rest must not fail -- but silence would read as
+    # a working mechanism, so it gets a warning.
+    context = TestContext(locked_four_bar())
+
+    assert context.fail_if_loop_limits_contradict() is True
+    warnings = context.report().warnings
+    assert any("barely moves" in warning for warning in warnings)
+
+    healthy = TestContext(four_bar())
+    healthy.fail_if_loop_limits_contradict()
+    assert not any("barely moves" in warning for warning in healthy.report().warnings)

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+from build123d import Box
+
+from articraft.sdk.assembly import JointAxis, JointDOF, JointFrame, RigidBodyAssembly
+from articraft.sdk.errors import LoopClosureError
+from articraft.sdk.testing import TestContext
+
+FULL = (-math.pi, math.pi)
+GROUND_A = (-0.2, 0.0, 0.1)
+GROUND_D = (0.25, 0.0, 0.1)
+CRANK = 0.2
+ROCKER = 0.25
+POINT_B = (GROUND_A[0] + CRANK, 0.0, GROUND_A[2])
+POINT_C = (GROUND_D[0], 0.0, GROUND_D[2] + ROCKER)
+COUPLER = math.dist(POINT_B, POINT_C)
+COUPLER_TILT = -math.atan2(POINT_C[2] - POINT_B[2], POINT_C[0] - POINT_B[0])
+LINK = 0.2
+SLIDE = (-0.4, 0.0)
+
+
+def four_bar(*, coupler_limits=FULL, crank_limits=FULL) -> RigidBodyAssembly:
+    assembly = RigidBodyAssembly("four_bar")
+    ground = assembly.rigid_body("ground")
+    crank = assembly.rigid_body("crank")
+    coupler = assembly.rigid_body("coupler")
+    rocker = assembly.rigid_body("rocker")
+    for body, length in ((ground, 0.5), (crank, CRANK), (coupler, COUPLER), (rocker, ROCKER)):
+        body.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+    crank_pin = assembly.joint(
+        "crank_pin",
+        ground.at(JointFrame(xyz=GROUND_A)),
+        crank.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=crank_limits),),
+    )
+    coupler_pin = assembly.joint(
+        "coupler_pin",
+        crank.at(JointFrame(xyz=(CRANK, 0.0, 0.0), rpy=(0.0, COUPLER_TILT, 0.0))),
+        coupler.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=coupler_limits),),
+    )
+    rocker_pin = assembly.joint(
+        "rocker_pin",
+        ground.at(JointFrame(xyz=GROUND_D, rpy=(0.0, -math.pi / 2.0, 0.0))),
+        rocker.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    assembly.joint(
+        "closing_pin",
+        coupler.at(JointFrame(xyz=(COUPLER, 0.0, 0.0))),
+        rocker.at(JointFrame(xyz=(ROCKER, 0.0, 0.0))),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    assembly.articulation("main", root=ground, joints=(crank_pin, coupler_pin, rocker_pin))
+    return assembly
+
+
+def slider_crank(*, slide_limits=SLIDE) -> RigidBodyAssembly:
+    """A crank driving a slider through a link, closed back onto the slider."""
+
+    assembly = RigidBodyAssembly("slider_crank")
+    ground = assembly.rigid_body("ground")
+    crank = assembly.rigid_body("crank")
+    link = assembly.rigid_body("link")
+    slider = assembly.rigid_body("slider")
+    for body, length in ((ground, 0.6), (crank, CRANK), (link, LINK), (slider, 0.08)):
+        body.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+    crank_pin = assembly.joint(
+        "crank_pin",
+        ground.at(JointFrame(xyz=(-0.25, 0.0, 0.0))),
+        crank.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    link_pin = assembly.joint(
+        "link_pin",
+        crank.at(JointFrame(xyz=(CRANK, 0.0, 0.0))),
+        link.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    guide = assembly.joint(
+        "guide",
+        ground.at(JointFrame(xyz=(0.15, 0.0, 0.0))),
+        slider.at(),
+        dofs=(JointDOF(JointAxis.TRANS_X, limits=slide_limits),),
+    )
+    assembly.joint(
+        "closing_pin",
+        link.at(JointFrame(xyz=(LINK, 0.0, 0.0))),
+        slider.at(),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+    )
+    assembly.articulation("main", root=ground, joints=(crank_pin, link_pin, guide))
+    return assembly
+
+
+def hinge_only() -> RigidBodyAssembly:
+    assembly = RigidBodyAssembly("lid")
+    box = assembly.rigid_body("box")
+    lid = assembly.rigid_body("lid")
+    box.add(Box(0.2, 0.2, 0.1), name="shell")
+    lid.add(Box(0.2, 0.2, 0.01), name="panel")
+    hinge = assembly.joint(
+        "hinge",
+        box.at(JointFrame(xyz=(0.0, 0.1, 0.05))),
+        lid.at(),
+        dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.9)),),
+    )
+    assembly.articulation("main", root=box, joints=(hinge,))
+    return assembly
+
+
+def failure_details(model: RigidBodyAssembly, **kwargs: object) -> str:
+    context = TestContext(model)
+    passed = context.fail_if_loop_limits_contradict(**kwargs)  # type: ignore[arg-type]
+    report = context.report()
+    if passed:
+        return ""
+    return "\n".join(failure.details for failure in report.failures)
+
+
+def test_a_ring_that_agrees_with_its_limits_reports_nothing() -> None:
+    assert failure_details(four_bar()) == ""
+
+
+def test_a_follower_limit_pointing_the_wrong_way_is_named() -> None:
+    details = failure_details(four_bar(coupler_limits=(0.0, 1.75)))
+
+    assert "follower='coupler_pin.rotY'" in details
+    assert "declared=(0, 1.75)" in details
+    assert "needs at least (-1.8" in details
+
+
+def test_a_follower_limit_narrower_than_the_ring_is_named() -> None:
+    details = failure_details(four_bar(coupler_limits=(-1.0, 1.0)))
+
+    assert "follower='coupler_pin.rotY'" in details
+    assert "declared=(-1, 1)" in details
+
+
+@pytest.mark.parametrize("samples", [5, 9, 17, 33])
+def test_the_defect_is_found_at_every_sweep_density(samples: int) -> None:
+    details = failure_details(four_bar(coupler_limits=(0.0, 1.75)), samples=samples)
+
+    assert "follower='coupler_pin.rotY'" in details
+
+
+def test_a_driver_range_wider_than_the_linkage_is_named() -> None:
+    details = failure_details(slider_crank(slide_limits=(-0.05, 0.05)))
+
+    assert "driver='guide.transX'" in details
+    assert "wider than the mechanism" in details
+
+
+@pytest.mark.parametrize("slack", [0.0, 0.02, 0.05])
+def test_slack_on_a_bounded_coordinate_is_not_a_defect(slack: float) -> None:
+    assert failure_details(slider_crank(slide_limits=(SLIDE[0] - slack, SLIDE[1] + slack))) == ""
+
+
+def test_a_full_circle_hinge_makes_no_claim() -> None:
+    # The four-bar cannot turn any of its pins the whole way round, and its
+    # pins are all authored -pi..pi. That is not a range claim, so nothing is
+    # reported -- but the linkage really does refuse those poses.
+    resolved = four_bar().resolve()
+    with pytest.raises(LoopClosureError):
+        resolved.forward_kinematics({"crank_pin.rotY": math.pi})
+
+    assert failure_details(four_bar()) == ""
+
+
+def test_a_hinge_that_needs_the_other_turn_is_not_a_contradiction() -> None:
+    # Driving from the far side of the ring solves the crank to +4.05 rad, the
+    # same pose as -2.23 and inside its limits. One turn away is not outside.
+    assert failure_details(four_bar(crank_limits=(-2.5, 2.5))) == ""
+
+
+def test_an_assembly_without_a_loop_is_skipped() -> None:
+    context = TestContext(hinge_only())
+
+    assert context.fail_if_loop_limits_contradict() is True
+    assert context.report().checks_run == 1
+
+
+def test_the_sweep_warns_about_coordinates_it_could_not_drive() -> None:
+    context = TestContext(slider_crank(slide_limits=(-0.05, 0.05)))
+    context.fail_if_loop_limits_contradict(samples=9, max_solves=18)
+    warnings = context.report().warnings
+
+    assert any("not swept as drivers" in warning for warning in warnings)
+
+
+def test_forward_kinematics_still_validates_what_the_solver_returns() -> None:
+    # The relaxed solve is private for this reason: it can answer with a
+    # coordinate outside its own limits, and the public path must not.
+    resolved = four_bar(coupler_limits=(0.0, 1.75)).resolve()
+    positions, _ = resolved._kinematics({"crank_pin.rotY": 0.25}, relax_limits=True)
+
+    assert positions["coupler_pin.rotY"] < 0.0
+    with pytest.raises(LoopClosureError):
+        resolved.forward_kinematics({"crank_pin.rotY": 0.25})

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -11,8 +11,7 @@ from articraft.sdk.errors import LoopClosureError
 from articraft.sdk.testing import (
     TestContext,
     _articulation_sweep_values,
-    _reachable_from_rest,
-    _ring_solution,
+    _swept_from_rest,
 )
 
 FULL = (-math.pi, math.pi)
@@ -179,10 +178,14 @@ def test_a_full_circle_hinge_makes_no_claim() -> None:
     assert failure_details(four_bar()) == ""
 
 
-def test_a_hinge_that_needs_the_other_turn_is_not_a_contradiction() -> None:
-    # Driving from the far side of the ring solves the crank to +4.05 rad, the
-    # same pose as -2.23 and inside its limits. One turn away is not outside.
-    assert failure_details(four_bar(crank_limits=(-2.5, 2.5))) == ""
+@pytest.mark.parametrize("samples", [5, 7, 9, 13])
+def test_a_hinge_with_slack_past_its_own_travel_is_not_a_contradiction(samples: int) -> None:
+    # Walked from the rest pose, the far side of the ring arrives with the
+    # crank at -2.23 rad, inside its limits -- not at the +4.05 a solve from
+    # rest used to report for the same pose. The slack past the crank's own
+    # travel stays quiet at every density: the overrun is a fraction of the
+    # declared travel, not of however many samples landed on the walls.
+    assert failure_details(four_bar(crank_limits=(-2.5, 2.5)), samples=samples) == ""
 
 
 def test_an_assembly_without_a_loop_is_skipped() -> None:
@@ -211,20 +214,24 @@ def test_forward_kinematics_still_validates_what_the_solver_returns() -> None:
         resolved.forward_kinematics({"crank_pin.rotY": 0.25})
 
 
-def test_a_disconnected_assembly_mode_is_not_the_mechanism_that_was_authored() -> None:
-    # Driving the coupler pin, the four-bar runs out of solutions partway and
-    # picks up again on the other assembly mode, with the crank a whole turn
-    # away. No motion connects the two, so the far side says nothing about the
-    # crank's limits and must not be read as motion the linkage requires.
+def test_the_sweep_stops_where_the_ring_stops_closing() -> None:
+    # Driving the coupler pin, the four-bar's ring stops closing partway round
+    # on one side. The walk from the rest pose ends there: the mechanism cannot
+    # pass through a pose with no solution, so everything past it is counted
+    # out of reach instead of being solved into a lifted copy of the linkage
+    # with the crank a whole turn away.
     resolved = four_bar().resolve()
     joint = resolved.get_joint("coupler_pin").joint
     dof = joint.dofs[0]
-    solved = [
-        (value, _ring_solution(resolved, "coupler_pin.rotY", value, relax=True))
-        for value in _articulation_sweep_values(joint, 33, dof)
-    ]
-    family, out_of_reach = _reachable_from_rest(solved)
+    sweep = _articulation_sweep_values(joint, 33, dof)
+    reached, _, span_reached, out_of_reach = _swept_from_rest(
+        resolved, "coupler_pin.rotY", sweep, frozenset({"crank_pin.rotY", "rocker_pin.rotY"})
+    )
 
     assert out_of_reach > 0
-    assert len(family) < sum(1 for _, free in solved if free is not None)
-    assert all(abs(free["crank_pin.rotY"]) < 2.5 for _, free in family)
+    assert span_reached < sweep[-1] - sweep[0]
+    assert all(abs(free["crank_pin.rotY"]) < 2.5 for _, free in reached)
+    # The kept poses are one unbroken stretch of driver travel around rest.
+    index_of = {value: index for index, value in enumerate(sweep)}
+    kept = sorted(index_of[value] for value, _ in reached)
+    assert kept == list(range(kept[0], kept[-1] + 1))

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -147,11 +147,38 @@ def test_a_follower_limit_pointing_the_wrong_way_is_named() -> None:
     assert float(needed.group(1)) < 0.0
 
 
-def test_a_follower_limit_narrower_than_the_ring_is_named() -> None:
-    details = failure_details(four_bar(coupler_limits=(-1.0, 1.0)))
+def test_a_follower_limit_narrower_than_a_bounded_drive_is_named() -> None:
+    # The crank's own range is a claim: the follower must span what honouring
+    # that claim requires.
+    details = failure_details(four_bar(coupler_limits=(-1.0, 1.0), crank_limits=(-2.5, 2.5)))
 
     assert "follower='coupler_pin.rotY'" in details
     assert "declared=(-1, 1)" in details
+
+
+def test_a_stop_narrower_than_the_free_motion_is_not_a_contradiction() -> None:
+    # With every other coordinate authored full circle, nothing claims the
+    # motion the stop forbids. The mechanism keeps its travel around rest and
+    # simply stops earlier than an unconstrained linkage would.
+    assert failure_details(four_bar(coupler_limits=(-1.75, 2.60))) == ""
+
+
+def test_a_wall_crossed_inside_a_bounded_drive_is_reported() -> None:
+    # The crank's declared range is a claim. Honouring it walks the coupler
+    # through its wall, and the bounded solve fails pinned there, so the
+    # excursion is reported even though the wrapped pose would fit.
+    details = failure_details(four_bar(coupler_limits=(-3.0, 3.0), crank_limits=(-2.31, 2.31)))
+
+    assert "follower='coupler_pin.rotY'" in details
+
+
+def test_a_sweep_endpoint_on_a_limit_does_not_raise() -> None:
+    # Substep arithmetic must land exactly on the endpoint: recomputing it in
+    # floating point can overshoot the driver's own limit by one ulp and trip
+    # the strict limit guard as a ValidationError instead of a finding.
+    context = TestContext(four_bar(rocker_limits=(-1.4, 0.2)))
+
+    assert isinstance(context.fail_if_loop_limits_contradict(), bool)
 
 
 @pytest.mark.parametrize("samples", [5, 9, 17, 33])
@@ -342,7 +369,7 @@ def test_a_branch_answer_is_reported_next_to_the_jam() -> None:
     # Poses the limits leave unsolvable make the case. Where the bounded solve
     # answers from a different assembly branch instead, that is reported with
     # them, whole turns removed before the distance is read.
-    details = failure_details(four_bar(coupler_limits=(0.0, 1.75)))
+    details = failure_details(four_bar(coupler_limits=(0.0, 1.75), crank_limits=(-2.5, 2.5)))
 
     assert "poses unsolvable" in details
     assert "away in joint coordinates -- a different assembly branch" in details
@@ -350,7 +377,7 @@ def test_a_branch_answer_is_reported_next_to_the_jam() -> None:
 
 @pytest.mark.parametrize(
     "value",
-    [3.3457, -1.8694, 0.9999999999, 1.0000000001, -0.1, 1e-5, 12345.678, -3.0],
+    [3.3457, -1.8694, 0.9999999999, 1.0000000001, -0.1, 1e-5, 12345.678, -3.0, 1e-319, -1.6e308],
 )
 def test_needs_bounds_round_outward(value: float) -> None:
     # The printed range must survive being copied back: parsing the four shown

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 
 import pytest
 from build123d import Box
@@ -130,7 +131,10 @@ def test_a_follower_limit_pointing_the_wrong_way_is_named() -> None:
 
     assert "follower='coupler_pin.rotY'" in details
     assert "declared=(0, 1.75)" in details
-    assert "needs at least (-1.8" in details
+    needed = re.search(r"needs at least \((-?[\d.]+), (-?[\d.]+)\)", details)
+    assert needed is not None
+    # The knee folds the way the limits forbid, whatever the sweep density is.
+    assert float(needed.group(1)) < 0.0
 
 
 def test_a_follower_limit_narrower_than_the_ring_is_named() -> None:

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -8,7 +8,12 @@ from build123d import Box
 
 from articraft.sdk.assembly import JointAxis, JointDOF, JointFrame, RigidBodyAssembly
 from articraft.sdk.errors import LoopClosureError
-from articraft.sdk.testing import TestContext
+from articraft.sdk.testing import (
+    TestContext,
+    _articulation_sweep_values,
+    _reachable_from_rest,
+    _ring_solution,
+)
 
 FULL = (-math.pi, math.pi)
 GROUND_A = (-0.2, 0.0, 0.1)
@@ -204,3 +209,22 @@ def test_forward_kinematics_still_validates_what_the_solver_returns() -> None:
     assert positions["coupler_pin.rotY"] < 0.0
     with pytest.raises(LoopClosureError):
         resolved.forward_kinematics({"crank_pin.rotY": 0.25})
+
+
+def test_a_disconnected_assembly_mode_is_not_the_mechanism_that_was_authored() -> None:
+    # Driving the coupler pin, the four-bar runs out of solutions partway and
+    # picks up again on the other assembly mode, with the crank a whole turn
+    # away. No motion connects the two, so the far side says nothing about the
+    # crank's limits and must not be read as motion the linkage requires.
+    resolved = four_bar().resolve()
+    joint = resolved.get_joint("coupler_pin").joint
+    dof = joint.dofs[0]
+    solved = [
+        (value, _ring_solution(resolved, "coupler_pin.rotY", value, relax=True))
+        for value in _articulation_sweep_values(joint, 33, dof)
+    ]
+    family, out_of_reach = _reachable_from_rest(solved)
+
+    assert out_of_reach > 0
+    assert len(family) < sum(1 for _, free in solved if free is not None)
+    assert all(abs(free["crank_pin.rotY"]) < 2.5 for _, free in family)

--- a/tests/test_loop_limit_check.py
+++ b/tests/test_loop_limit_check.py
@@ -23,11 +23,11 @@ POINT_B = (GROUND_A[0] + CRANK, 0.0, GROUND_A[2])
 POINT_C = (GROUND_D[0], 0.0, GROUND_D[2] + ROCKER)
 COUPLER = math.dist(POINT_B, POINT_C)
 COUPLER_TILT = -math.atan2(POINT_C[2] - POINT_B[2], POINT_C[0] - POINT_B[0])
-LINK = 0.2
+LINK = 0.32
 SLIDE = (-0.4, 0.0)
 
 
-def four_bar(*, coupler_limits=FULL, crank_limits=FULL) -> RigidBodyAssembly:
+def four_bar(*, coupler_limits=FULL, crank_limits=FULL, rocker_limits=FULL) -> RigidBodyAssembly:
     assembly = RigidBodyAssembly("four_bar")
     ground = assembly.rigid_body("ground")
     crank = assembly.rigid_body("crank")
@@ -51,7 +51,7 @@ def four_bar(*, coupler_limits=FULL, crank_limits=FULL) -> RigidBodyAssembly:
         "rocker_pin",
         ground.at(JointFrame(xyz=GROUND_D, rpy=(0.0, -math.pi / 2.0, 0.0))),
         rocker.at(),
-        dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+        dofs=(JointDOF(JointAxis.ROT_Y, limits=rocker_limits),),
     )
     assembly.joint(
         "closing_pin",
@@ -64,7 +64,12 @@ def four_bar(*, coupler_limits=FULL, crank_limits=FULL) -> RigidBodyAssembly:
 
 
 def slider_crank(*, slide_limits=SLIDE) -> RigidBodyAssembly:
-    """A crank driving a slider through a link, closed back onto the slider."""
+    """A crank driving a slider through a link, closed back onto the slider.
+
+    The link is longer than the crank, so neither end of the stroke folds the
+    pair onto a singular one-parameter family. The stroke stays (l + a) minus
+    (l - a) = 2a = 0.4, matching SLIDE.
+    """
 
     assembly = RigidBodyAssembly("slider_crank")
     ground = assembly.rigid_body("ground")
@@ -87,7 +92,7 @@ def slider_crank(*, slide_limits=SLIDE) -> RigidBodyAssembly:
     )
     guide = assembly.joint(
         "guide",
-        ground.at(JointFrame(xyz=(0.15, 0.0, 0.0))),
+        ground.at(JointFrame(xyz=(-0.25 + CRANK + LINK, 0.0, 0.0))),
         slider.at(),
         dofs=(JointDOF(JointAxis.TRANS_X, limits=slide_limits),),
     )
@@ -235,3 +240,98 @@ def test_the_sweep_stops_where_the_ring_stops_closing() -> None:
     index_of = {value: index for index, value in enumerate(sweep)}
     kept = sorted(index_of[value] for value, _ in reached)
     assert kept == list(range(kept[0], kept[-1] + 1))
+
+
+def double_four_bar(*, second_coupler_limits=FULL) -> RigidBodyAssembly:
+    """Two identical four-bar rings driven by one shared crank."""
+
+    assembly = RigidBodyAssembly("double_four_bar")
+    ground = assembly.rigid_body("ground")
+    crank = assembly.rigid_body("crank")
+    for body, length in ((ground, 0.5), (crank, CRANK)):
+        body.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+    joints = [
+        assembly.joint(
+            "crank_pin",
+            ground.at(JointFrame(xyz=GROUND_A)),
+            crank.at(),
+            dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+        )
+    ]
+    for tag, coupler_limits in (("a", FULL), ("b", second_coupler_limits)):
+        coupler = assembly.rigid_body(f"coupler_{tag}")
+        rocker = assembly.rigid_body(f"rocker_{tag}")
+        for body, length in ((coupler, COUPLER), (rocker, ROCKER)):
+            body.add(Box(max(length, 0.05), 0.04, 0.04), name="bar")
+        joints.append(
+            assembly.joint(
+                f"coupler_pin_{tag}",
+                crank.at(JointFrame(xyz=(CRANK, 0.0, 0.0), rpy=(0.0, COUPLER_TILT, 0.0))),
+                coupler.at(),
+                dofs=(JointDOF(JointAxis.ROT_Y, limits=coupler_limits),),
+            )
+        )
+        joints.append(
+            assembly.joint(
+                f"rocker_pin_{tag}",
+                ground.at(JointFrame(xyz=GROUND_D, rpy=(0.0, -math.pi / 2.0, 0.0))),
+                rocker.at(),
+                dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+            )
+        )
+        assembly.joint(
+            f"closing_pin_{tag}",
+            coupler.at(JointFrame(xyz=(COUPLER, 0.0, 0.0))),
+            rocker.at(JointFrame(xyz=(ROCKER, 0.0, 0.0))),
+            dofs=(JointDOF(JointAxis.ROT_Y, limits=FULL),),
+        )
+    assembly.articulation("main", root=ground, joints=tuple(joints))
+    return assembly
+
+
+def test_two_rings_sharing_a_driver_stay_silent_together() -> None:
+    # The shared crank sits on both rings' paths, so it is planned once and
+    # an honest pair of rings reports nothing.
+    assert failure_details(double_four_bar()) == ""
+
+
+def test_a_defect_on_the_second_ring_is_still_found() -> None:
+    details = failure_details(double_four_bar(second_coupler_limits=(0.0, 1.75)))
+
+    assert "follower='coupler_pin_b.rotY'" in details
+
+
+def test_findings_come_out_in_a_stable_order() -> None:
+    details = failure_details(four_bar(coupler_limits=(0.0, 1.75), rocker_limits=(-0.5, 0.5)))
+
+    coupler = details.index("follower='coupler_pin.rotY'")
+    rocker = details.index("follower='rocker_pin.rotY'")
+    assert coupler < rocker
+
+
+def test_a_closure_the_tree_does_not_span_is_passed_over() -> None:
+    # A closure to a body outside the articulation tree has no driver the
+    # sweep could turn, so the check records a pass instead of guessing.
+    assembly = RigidBodyAssembly("lidded")
+    box = assembly.rigid_body("box")
+    lid = assembly.rigid_body("lid")
+    latch = assembly.rigid_body("latch")
+    box.add(Box(0.2, 0.2, 0.1), name="shell")
+    lid.add(Box(0.2, 0.2, 0.01), name="panel")
+    latch.add(Box(0.04, 0.04, 0.04), name="block")
+    hinge = assembly.joint(
+        "hinge",
+        box.at(JointFrame(xyz=(0.0, 0.1, 0.05))),
+        lid.at(),
+        dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 1.9)),),
+    )
+    assembly.joint(
+        "latch_pin",
+        lid.at(JointFrame(xyz=(0.1, 0.0, 0.0))),
+        latch.at(),
+        dofs=(JointDOF(JointAxis.ROT_X, limits=(0.0, 0.5)),),
+    )
+    assembly.articulation("main", root=box, joints=(hinge,))
+    context = TestContext(assembly)
+
+    assert context.fail_if_loop_limits_contradict() is True


### PR DESCRIPTION
Draft for #122.

#124 landed the day after this issue and taught the solver to respect limits while solving, projecting its iterates into their bounds, and #134 kept that when it moved to a bounded trust-region solve. So the reading the issue proposes -- a follower whose solved value leaves its own limits -- can no longer happen. The coordinate pins, the loop reports as open, or the mechanism assembles the other way round and says nothing.

The defect still has to be found, so the check walks each ring driver outward from the rest pose with the derived coordinates unbounded, each sample continued from its neighbour's solution. The walk shows the motion the linkage itself asks for. Where that motion leaves a follower's authored limits, the solve that respects them is asked for the same pose, and only its failure to close the ring within them makes a case. Reading the `LoopClosureError` the solver already raises would not find any of this, since it fires only at poses someone asks for, and the landing gear's knee was wrong across a whole retraction with nothing asking.

## What changed

`fail_if_loop_limits_contradict()` joins the compiler's baseline checks as a diagnostic, next to `fail_if_articulation_separates_child()`. It reports:

- a follower whose limits exclude motion the linkage requires, naming the declared range, the range the mechanism needs, and the driver poses where they disagree. The needed range unions the declaration and rounds outward, so copying its numbers back as the new limits passes on the next run.
- a driver whose declared travel is wider than the mechanism's, once more than a quarter of it lies past where the ring stops closing. Travel, not samples: each side of the walk ends at the first pose with no solution, and a bisection toward that edge measures how far the mechanism actually reaches -- and probes the motion beside the edge, where a follower moves fastest and a fixed grid is blindest.

The landing gear knee from the issue is the first shape. A full-circle ring that closes over less than a hundredth of its declared range additionally warns that the loop barely moves: unconstrained coordinates contradict nothing, but silence would read as a working mechanism.

The relaxed walk is the computation the ring already runs, with `limits` read as `None` for the coordinates it derives and a warm start to continue from -- two keywords on `_solve_closed_loops`. It is reached through `ResolvedRigidBodyAssembly._kinematics()`, which stays private because it can answer with a coordinate outside its own limits, and `forward_kinematics()` must never hand one out.

## What it does not report

Each of these was a measured false positive in an earlier cut:

- A stop narrower than the free motion. A full-circle driver claims no range, so a follower that stops the mechanism short of the circle is authoring, not contradiction -- unless the jam starts at the first step away from rest, which is where a limit authored against the motion's own direction always bites, since limits must contain the zero configuration. A bounded driver's range stays a hard claim on its followers.
- Slack. A range a little wider than the travel is how ring coordinates are normally authored. Under a quarter of the declared travel it stays quiet at every sweep density, because travel is measured by bisection toward the reachable edge rather than counted in grid samples -- a grid pins two samples on the declared walls and would call any slack two-of-N unreachable.
- A disagreement the bounded solve does not confirm. Near a singular fold the unbounded walk has no assembly-branch guarantee: on a parallelogram whose limits are consistent by construction, it hops to the antiparallelogram branch and swears the limits are wrong, while the bounded solve closes the loop inside those limits at every accused pose. So the bounded solve is the judge, and its success ends the case.

## What it costs

About a millisecond when there is no ring, which is what almost every compile pays: of 151 generated `main.py` files from a hinged-box campaign, 146 rebuild, and none of them authors a closed loop -- median 1 ms, max 5 ms across those 146. Two models on loop-requiring prompts did author rings; the check costs 0.5 s and 4.8 s on them, the worst cases measured, and the second is the barely-moving ring above. Warm continuation keeps density cheap: on the honest four-bar fixture, 33 samples cost 1.0 s where 9 cost 0.8 s. `max_solves` sizes the sweep and a warning names any coordinate it did not drive.

It reports as a diagnostic rather than blocking the compile, like articulation separation. The limits are metadata, the object still exports, and the model can act on the finding on its next turn.

## Checks

690 pass with 3 deselected (39 new). `test_warm_environment_enforces_the_timeout_contract` fails on this machine before the change as well. Ruff and basedpyright are clean.

<details>
<summary>Measurements behind the defaults</summary>

Sweep density against a reversed follower limit on a four-bar: every density catches it (requests below five samples are raised to five, since a coarser grid can step over whole infeasible gaps). Cost runs 1.4 s to 3.1 s across three to thirty-three samples on the defective fixture.

Defect severity against a crank claiming `(-2.5, 2.5)`: the follower's requirement over that claim measures about `-1.87..3.35`, the exact edge moving in the second decimal with density. Limits covering 102% of it report nothing, because the bounded solve clears every accused pose. From 99% down, including the reversed case, every one is reported.

`overrun_fraction` against a slider whose travel is `-0.4..0.0`, at the default nine samples: slack worth 20% of the declared travel passes at the default 0.25 and is caught at 0.1, a range sitting right on the 25% boundary fires, and a declared `(-0.05, 0.05)` against that travel is caught at both.

Two solves of a pose no limit binds agree to 1e-15. The branch gate sits at 1e-3: above the solve-to-solve noise measured at a singular fold (2e-5), below real assembly branches (a few hundredths of a radian and up).

</details>

## Still weak

- The reachable edge is found by bisecting from the sample grid, so a feasible arc hiding entirely between two samples is still measured only as well as the grid allows -- and below five samples the walk was measured stepping over a whole infeasible gap, which is why five is now the floor.
- A closure the articulation tree does not span has no driver to sweep, and passes silently. A test locks that in.
- A coordinate on two rings is driven once, on the first ring that reaches it. A defect visible only from the losing ring's side of that shared sweep can go unnamed while another finding stands.
- Limits that exclude the natural assembly but admit a mirror one at every sampled pose are not reported: the bounded solve then succeeds everywhere, and a disagreement alone equally fingerprints an unbounded walk that wandered at a fold. The parallelogram decided which of the two to believe.
